### PR TITLE
Fixed counting error with show * by filetype and concatenate

### DIFF
--- a/ebook/en/content/003-the-cat-tac-command.md
+++ b/ebook/en/content/003-the-cat-tac-command.md
@@ -27,6 +27,12 @@ cat file1 file2 ...
 cat > filename
 ```
 
+4. To display all files in current directory with the same filetype:
+
+```
+cat *.txt
+```
+
 5. To display the content of all the files in current directory:
 
 ```
@@ -45,13 +51,19 @@ cat filename | more
 cat filename | less
 ```
 
-8. Append the contents of file1.txt to file2.txt
+8. Append the contents of file1.txt to file2.txt:
 
 ```
 cat file1.txt >> file2.txt
 ```
 
-9. Some implementations of cat, with option -n, it's possible to show line numbers
+9. To concatenate two files together in a new file:
+
+```
+cat file1.txt file2.txt merge.txt
+```
+
+10. Some implementations of cat, with option -n, it's possible to show line numbers:
 
 ```
 cat -n file1.txt file2.txt > newnumberedfile.txt


### PR DESCRIPTION
Fixed the counting error from 3. to 5. by adding cat *.txt as fourth command which is a good transition to cat *. Also added the concatenate with cat file1.txt file2.txt merge.txt as 9th command.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/101-linux-commands-ebook/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Chapter
- [ ] 🐛 Bug Fix/Typo
- [x] 👷 Optimization
- [x] 📝 Documentation Update
- [ ] 🚩 Other

## Description



## Related Tickets & Documents



## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?