### PR TITLE
fix typo in grep command syntax

### DIFF
--- a/ebook/en/content/107-the-grep-command.md
+++ b/ebook/en/content/107-the-grep-command.md
@@ -37,7 +37,7 @@ tail -f destination.txt | grep --line-buffered "key"
 
 ### Syntax:
 
-The general syntax for the cp command is as follows:
+The general syntax for the grep command is as follows:
 
 ```
 grep [options] pattern [files]


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Contributing Guide: https://github.com/bobbyiliev/101-linux-commands-ebook/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Chapter
- [x] 🐛 Bug Fix/Typo
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Fixed typo in grep syntax.(`cp` to `grep`)

## Related Tickets & Documents



## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?