### PR TITLE
fix(html): align circled bullet points in Safari

### DIFF
--- a/ebook/en/export/101-linux-commands.html
+++ b/ebook/en/export/101-linux-commands.html
@@ -370,7 +370,7 @@
 
         .content-wrapper li {
             margin-bottom: 0.75rem;
-            padding-left: 2rem;
+            padding-left: 2.5rem;
             position: relative;
             color: var(--reading-text-light);
             line-height: 1.7;
@@ -396,7 +396,9 @@
         .content-wrapper ol li::before {
             content: counter(list-counter);
             position: absolute;
-            left: 0;
+            left: 0.5rem;
+            top: 50%;
+            transform: translateY(-50%);
             background: var(--accent-color);
             color: white;
             width: 1.4rem;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Chapter
- [x] 🐛 Bug Fix/Typo
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Fix misalignment of numbered list circles in Safari by updating CSS for ordered lists. Ensures consistent appearance across browsers.

<img width="2032" height="1056" alt="image" src="https://github.com/user-attachments/assets/2c4a62b9-3b88-4873-8a08-608bd5da5f23" />

## Related Tickets & Documents

**ref: #377**

## Added to documentation?

- [ ] 📜 readme
- [x] 🙅 no documentation needed