### PR TITLE
docs: Rewrite and enhance 'cmp' command chapter with practical examples

### DIFF
--- a/ebook/en/content/134-the-cmp-command.md
+++ b/ebook/en/content/134-the-cmp-command.md
@@ -1,68 +1,84 @@
 # The `cmp` command
 
-The `cmp` command is used to compare the two files byte by byte.
+The `cmp` command is a simple utility used to compare two files byte by byte. 
 
-Example:
-```
-cmp file1.txt file2.txt
-```
+If the files are identical, `cmp` produces no output and returns a successful exit status. If the files differ, it reports the byte and line number where the first difference occurred.
 
-Syntax:
-```
-cmp [option] File1 File2
+## Syntax
+```bash
+$ cmp [OPTION]... FILE1 [FILE2]
 ```
 
-## Few Examples :
+## Examples :
 
-1. ### Comparison of two files:
+For the following examples, let's assume we have three files:
 
-Perform a simple comparison of the two files to check out if they differ from each other or not.
-
-Example:
-```
-cmp File1 File2
+file1.txt:
+```bash
+hello world
 ```
 
-2. ### Comparing Files after Skipping a Specified Number of Bytes:
-
-Compare two files after skipping a certain number of bytes
-
-Example:
-```
-cmp -i 2 list.txt list2.txt
+file2.txt:
+```bash
+hello world
 ```
 
-Here “INT” represents the number of bytes to be skipped
-
-3. ### Display the Differing Bytes of the Files in the Output:
-
-Example: 
-```
-cmp -b list.txt list1.txt
-```
-4. ### Display Byte Numbers and Differing Byte Values of the Files in the Output:
-
-Example: 
-```
-cmp -l list.txt list1.txt
+file3.txt:
+```bash
+hello World
 ```
 
-5. ### Comparing the First “n” Number of Bytes of the Files:
+### 1. Comparing two identical files
+When the files are the same, cmp will produce no output. This is the standard way to confirm that two files are identical.
 
-Example:
+```bash
+$ cmp file1.txt file2.txt
 ```
-cmp -n 10 list.txt list2.txt 
+(No output is shown)
+
+### 2. Comparing two different files
+When a difference is found, cmp reports the location of the first differing byte.
+
+```bash
+$ cmp file1.txt file3.txt
+file1.txt file3.txt differ: byte 7, line 1
 ```
-### Additional Flags and their Functionalities
 
-|**Short Flag**   |**Long Flag**   |**Description**   |
-|:---|:---|:---|
-|`-b`|`--print-bytes`|print differing bytes|
-|`-i`|`--ignore-initial=SKIP`|skip first SKIP bytes of both inputs|
-|`-i`|`--ignore-initial=SKIP1:SKIP2`|skip first SKIP1 bytes of FILE1 and first SKIP2 bytes of FILE2|
-|`-l`|`--verbose`|output byte numbers and differing byte values|
-|`-n`|`--bytes=LIMIT`|compare at most LIMIT bytes|
-|`-s`|`--quiet, --silent`|suppress all normal output|
-|`v`|`--version`|output version information and exit|
-||`--help`|Display this help and exit|
+### 3. Displaying all differing bytes (--verbose or -l)
+The -l (lowercase L) flag is very powerful. It prints the byte number (in decimal) and the value of the differing bytes (in octal) for every difference in the files.
 
+```bash
+$ cmp -l file1.txt file3.txt
+ 7 167 127
+```
+
+#### Explanation: 
+This output means that at byte position 7, file1.txt has the octal value 167 (the letter 'w'), while file3.txt has the octal value 127 (the letter 'W').
+
+### 4. Comparing only the first "n" bytes (--bytes or -n)
+You can limit the comparison to a certain number of bytes. Here, we only compare the first 5 bytes. Since "hello" is the same in both files, cmp finds no difference.
+
+```bash
+$ cmp -n 5 file1.txt file3.txt
+```
+(No output is shown)
+
+### 5. Ignoring the initial "n" bytes (--ignore-initial or -i)
+You can tell cmp to skip a certain number of bytes at the beginning of the files before starting its comparison. Here, we skip the first 6 bytes, so the comparison starts at the letter 'w'.
+
+```bash
+$ cmp -i 6 file1.txt file3.txt
+file1.txt file3.txt differ: byte 1, line 1
+```
+#### Explanation: 
+The output now says the difference is at "byte 1" because the comparison started after the initial 6 bytes were ignored.
+
+### Common Options
+
+| Short Flag | Long Flag                  | Description                                             |
+|------------|----------------------------|---------------------------------------------------------|
+| -b         | --print-bytes              | Print the differing bytes.                             |
+| -i SKIP    | --ignore-initial=SKIP      | Skip the first SKIP bytes of both files.               |
+| -l         | --verbose                  | Output the byte number and the values of all differing bytes. |
+| -n LIMIT   | --bytes=LIMIT              | Compare at most LIMIT bytes.                           |
+| -s         | --quiet, --silent          | Suppress all output. Only return an exit status.       |


### PR DESCRIPTION
Hi again!

This pull request is another contribution towards Issue #190, this time focusing on a complete rewrite of the `cmp` command chapter to make it significantly more practical and educational.

**The Problem:**
The previous version of the chapter showed commands but provided no context or output, making it difficult for a beginner to understand what the command actually does.

**The Solution:**
I have restructured the entire chapter with a focus on clear, reproducible examples.

* **Introduced Example Files:** The guide now defines a set of simple text files (`file1.txt`, `file2.txt`, `file3.txt`) to provide clear context for all commands.
* **Added Actual Command Outputs:** Every single example now includes the exact output a user should expect to see in their terminal.
* **Included Explanations:** The output for more complex flags (like `-l` for verbose) is now explained, clarifying what the numbers and values mean.
* **Improved Flow:** The chapter is now organized logically for a better learning experience.

I believe these changes transform the chapter from a simple reference into a genuinely helpful tutorial. As always, I'm open to any feedback!