### PR TITLE
feat: Add game pages to sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,6 +5,7 @@ import { getAllGuides } from '@/lib/guides';
 import { getAllExercises } from '@/lib/exercises';
 import { getQuizMetadata } from '@/lib/quiz-loader';
 import { getAllNews } from '@/lib/news';
+import { getActiveGames } from '@/lib/games';
 
 export const dynamic = 'force-static';
 
@@ -12,13 +13,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://devops-daily.com';
 
   // Get all content
-  const [posts, categories, guides, exercises, quizzes, news] = await Promise.all([
+  const [posts, categories, guides, exercises, quizzes, news, games] = await Promise.all([
     getAllPosts(),
     getAllCategories(),
     getAllGuides(),
     getAllExercises(),
     getQuizMetadata(),
     getAllNews(),
+    getActiveGames(),
   ]);
 
   // Static routes
@@ -143,6 +145,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }));
 
+  // Game routes (only active games, excludes coming soon)
+  const gameRoutes = games.map((game) => ({
+    url: `${baseUrl}${game.href}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
   return [
     ...routes,
     ...postRoutes,
@@ -152,5 +162,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...exerciseRoutes,
     ...quizRoutes,
     ...newsRoutes,
+    ...gameRoutes,
   ];
 }


### PR DESCRIPTION
Adds all 13 active game pages to sitemap.xml for improved SEO discoverability.

**Changes:**
- Added `getActiveGames()` import and call in sitemap generation
- Created `gameRoutes` array mapping all active games to sitemap entries
- Excluded 'coming soon' games from sitemap (automatically filtered by `getActiveGames()`)
- Each game route has priority 0.7 and monthly change frequency

**Benefits:**
- Improves game page discoverability in search engines
- Better crawling and indexing of interactive game content
- Consistent with other content types (posts, exercises, quizzes)

**Games included:**
- TCP vs UDP Simulator
- DevOps Scorecard
- K8s Scheduler Simulator
- Rate Limit Simulator
- DDoS Simulator
- Scalable Sentry
- Packet Journey
- CI/CD Stack Generator
- DevOps Memes
- Cards Against DevOps
- Infra Tarot
- Git Quiz
- Uptime Defender