### PR TITLE
feat: Add digest image generation to weekly digest workflow

### DIFF
--- a/.github/workflows/generate-digest.yml
+++ b/.github/workflows/generate-digest.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Generate digest
         run: pnpm devops-daily:generate-news:no-ai
 
+      - name: Generate digest images
+        run: pnpm generate:images
+
+      - name: Convert SVG to PNG
+        run: pnpm convert:svg-to-png
+
       - name: Get current week and year
         id: week
         run: |


### PR DESCRIPTION
## 🎨 Summary

Updates the weekly digest workflow to automatically generate images (SVG and PNG) for the newly created digest.

## 📝 Changes

Added two new workflow steps after digest generation:

1. **Generate digest images** - Runs `pnpm generate:images`
   - Generates SVG images for the new digest
   - Only creates images for content without images or with placeholders
   - Uses the same script that generates images for posts, guides, and exercises

2. **Convert SVG to PNG** - Runs `pnpm convert:svg-to-png`
   - Converts the generated SVG files to PNG format
   - Creates optimized 1200x630 PNG images for social media OG tags
   - Uses sharp and resvg for high-quality conversion

## ✅ Benefits

- Digest PRs will now include both the markdown content and the generated images
- No manual image generation needed after digest is created
- Images will be ready when the PR is merged
- Consistent with how other content (posts, guides) handles images

## 🔍 Technical Details

- Uses existing `generate-post-images-svg.ts` script which already supports news digests
- Only generates images for items without existing images (prevents accidental regeneration)
- Images are placed in `public/images/news/` directory
- Both SVG and PNG formats are generated for flexibility

## 🧪 Testing

The workflow will be tested on the next scheduled run (Monday 9:00 AM UTC) or can be manually triggered via workflow_dispatch.