### PR TITLE
fix: Update author page to use Next.js 16 async params API

### DIFF
--- a/app/authors/[slug]/page.tsx
+++ b/app/authors/[slug]/page.tsx
@@ -24,9 +24,10 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const author = await getAuthorBySlug(params.slug);
+  const { slug } = await params;
+  const author = await getAuthorBySlug(slug);
 
   if (!author) {
     return {};
@@ -36,13 +37,13 @@ export async function generateMetadata({
     title: `${author.name} - Author at DevOps Daily`,
     description: author.bio || `Articles and guides by ${author.name}`,
     alternates: {
-      canonical: `/authors/${params.slug}`,
+      canonical: `/authors/${slug}`,
     },
     openGraph: {
       type: 'profile',
       title: author.name,
       description: author.bio || `Articles and guides by ${author.name}`,
-      url: `/authors/${params.slug}`,
+      url: `/authors/${slug}`,
       images: author.avatar
         ? [
             {
@@ -57,16 +58,17 @@ export async function generateMetadata({
   };
 }
 
-export default async function AuthorPage({ params }: { params: { slug: string } }) {
-  const author = await getAuthorBySlug(params.slug);
+export default async function AuthorPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const author = await getAuthorBySlug(slug);
 
   if (!author) {
     notFound();
   }
 
   const [posts, guides] = await Promise.all([
-    getPostsByAuthor(params.slug),
-    getGuidesByAuthor(params.slug),
+    getPostsByAuthor(slug),
+    getGuidesByAuthor(slug),
   ]);
 
   // Breadcrumb items


### PR DESCRIPTION
## Problem

Author pages were returning 404 errors (e.g., `/authors/devops-daily-team`).

## Root Cause

In Next.js 15+, the `params` prop in dynamic routes changed from a synchronous object to a `Promise`. The author page hadn't been updated to handle this breaking change, while all other dynamic routes (posts, guides, news, exercises, etc.) had already been migrated.

## Solution

Updated `app/authors/[slug]/page.tsx` to:
- Change `params` type from `{ slug: string }` to `Promise<{ slug: string }>`
- Await the `params` object before accessing `slug`
- Apply this pattern in both `generateMetadata()` and the main component

## Changes

**Before:**
```typescript
export async function generateMetadata({ params }: { params: { slug: string } }) {
  const author = await getAuthorBySlug(params.slug);
  // ...
}

export default async function AuthorPage({ params }: { params: { slug: string } }) {
  const author = await getAuthorBySlug(params.slug);
  // ...
}
```

**After:**
```typescript
export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
  const { slug } = await params;
  const author = await getAuthorBySlug(slug);
  // ...
}

export default async function AuthorPage({ params }: { params: Promise<{ slug: string }> }) {
  const { slug } = await params;
  const author = await getAuthorBySlug(slug);
  // ...
}
```

## Testing

- ✅ Author page should now load correctly at `/authors/devops-daily-team`
- ✅ Cloudflare Pages build should pass
- ✅ Matches the pattern used in all other dynamic routes

## Related

- Part of Next.js 15+ migration
- Follows the same pattern as #499 (dependency updates)