### PR TITLE
feat: Add quizzes count to home page hero statistics

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,18 +5,21 @@ import { ArrowRight, Terminal, GitBranch, Cloud, Cpu, Sparkles } from 'lucide-re
 import { getAllPosts } from '@/lib/posts';
 import { getAllGuides } from '@/lib/guides';
 import { getActiveGames } from '@/lib/games';
+import { getAllQuizzes } from '@/lib/quiz-loader';
 
 export async function Hero() {
   // Fetch counts dynamically
-  const [posts, guides, games] = await Promise.all([
+  const [posts, guides, games, quizzes] = await Promise.all([
     getAllPosts(),
     getAllGuides(),
     getActiveGames(),
+    getAllQuizzes(),
   ]);
 
   const postsCount = posts.length;
   const guidesCount = guides.length;
   const gamesCount = games.length;
+  const quizzesCount = quizzes.length;
 
   return (
     <div className="relative overflow-hidden bg-background">
@@ -76,7 +79,7 @@ export async function Hero() {
           </p>
 
           {/* Stats */}
-          <div className="flex justify-center gap-8 mt-10 text-sm">
+          <div className="flex flex-wrap justify-center gap-6 sm:gap-8 mt-10 text-sm">
             <div className="text-center">
               <div className="text-2xl font-bold text-primary">{postsCount}+</div>
               <div className="text-muted-foreground">Articles</div>
@@ -88,6 +91,10 @@ export async function Hero() {
             <div className="text-center">
               <div className="text-2xl font-bold text-primary">{gamesCount}+</div>
               <div className="text-muted-foreground">Games</div>
+            </div>
+            <div className="text-center">
+              <div className="text-2xl font-bold text-primary">{quizzesCount}+</div>
+              <div className="text-muted-foreground">Quizzes</div>
             </div>
           </div>
 


### PR DESCRIPTION
Implements #522

## Summary
Adds quiz count statistic to the home page hero section, bringing the total to 4 stat cards (Articles, Guides, Games, Quizzes).

## Changes
- Added `getAllQuizzes()` import from quiz-loader
- Fetches quiz count dynamically alongside other content types
- Displays "19+ Quizzes" stat card in hero section
- Updated layout to use `flex-wrap` for responsive 4-item grid
- Maintains consistent styling with existing stat cards

## Benefits
- Better showcases all available content types
- Improves discoverability of quiz features
- Provides more comprehensive site metrics to visitors
- Consistent presentation of all major content categories

## Testing
- [x] All 4314 tests passing
- [x] Quiz count fetched dynamically from quiz files
- [x] Styling consistent with other stat cards
- [x] Mobile responsive layout maintained
- [x] No TypeScript errors

Closes #522