### PR TITLE
feat: Add SVG template generator for quiz OG images

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "quiz:create": "tsx scripts/quiz-dev.ts create",
     "quiz:list": "tsx scripts/quiz-dev.ts list",
     "quiz:stats": "tsx scripts/quiz-dev.ts stats",
+    "generate-quiz-og": "tsx scripts/generate-quiz-og.ts",
     "generate:images": "tsx scripts/generate-post-images-svg.ts",
     "convert:svg-to-png": "tsx scripts/convert-svg-to-png.ts",
     "svg2png": "tsx scripts/svg-to-png.ts",

--- a/scripts/generate-quiz-og.ts
+++ b/scripts/generate-quiz-og.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env tsx
+
+import fs from 'fs/promises';
+import path from 'path';
+import { execSync } from 'child_process';
+
+interface QuizOGOptions {
+  title: string;
+  category: string;
+  slug: string;
+  theme?: 'default' | 'security' | 'devops' | 'cloud' | 'sre';
+}
+
+interface ThemeConfig {
+  template: string;
+  bgGradient: [string, string];
+  accentGradient: [string, string];
+  textColor: string;
+}
+
+const THEMES: Record<string, ThemeConfig> = {
+  default: {
+    template: 'quiz-template-default.svg',
+    bgGradient: ['#1e1b4b', '#312e81'],
+    accentGradient: ['#8b5cf6', '#a78bfa'],
+    textColor: '#a78bfa',
+  },
+  security: {
+    template: 'quiz-template-security.svg',
+    bgGradient: ['#5b21b6', '#1e40af'],
+    accentGradient: ['#8b5cf6', '#60a5fa'],
+    textColor: '#a78bfa',
+  },
+  devops: {
+    template: 'quiz-template-devops.svg',
+    bgGradient: ['#c2410c', '#b45309'],
+    accentGradient: ['#fb923c', '#fbbf24'],
+    textColor: '#fbbf24',
+  },
+  cloud: {
+    template: 'quiz-template-cloud.svg',
+    bgGradient: ['#1e3a8a', '#1e40af'],
+    accentGradient: ['#3b82f6', '#60a5fa'],
+    textColor: '#60a5fa',
+  },
+  sre: {
+    template: 'quiz-template-sre.svg',
+    bgGradient: ['#991b1b', '#c2410c'],
+    accentGradient: ['#ef4444', '#fb923c'],
+    textColor: '#fb923c',
+  },
+};
+
+/**
+ * Escape XML special characters
+ */
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Split long title into multiple lines
+ */
+function splitTitle(title: string, maxCharsPerLine = 30): string[] {
+  const words = title.split(' ');
+  const lines: string[] = [];
+  let currentLine = '';
+
+  for (const word of words) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    
+    if (testLine.length <= maxCharsPerLine) {
+      currentLine = testLine;
+    } else {
+      if (currentLine) {
+        lines.push(currentLine);
+      }
+      currentLine = word;
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  return lines.slice(0, 3); // Max 3 lines
+}
+
+/**
+ * Generate title text elements for SVG
+ */
+function generateTitleLines(title: string): string {
+  const lines = splitTitle(title);
+  const baseY = 280;
+  const lineHeight = 65;
+
+  return lines
+    .map((line, index) => {
+      const y = baseY + index * lineHeight;
+      const fontSize = lines.length === 1 ? 56 : lines.length === 2 ? 52 : 48;
+      return `  <!-- Title line ${index + 1} -->
+  <text x="80" y="${y}" font-family="system-ui, -apple-system, sans-serif" font-size="${fontSize}" font-weight="bold" fill="#ffffff">${escapeXml(line)}</text>`;
+    })
+    .join('\n');
+}
+
+/**
+ * Calculate badge width based on category length
+ */
+function calculateBadgeWidth(category: string): number {
+  const baseWidth = 100;
+  const charWidth = 12; // Approximate width per character
+  return baseWidth + category.length * charWidth;
+}
+
+/**
+ * Generate quiz OG image
+ */
+async function generateQuizOG(options: QuizOGOptions): Promise<void> {
+  const { title, category, slug, theme = 'default' } = options;
+
+  // Validate inputs
+  if (!title || !category || !slug) {
+    throw new Error('Missing required parameters: title, category, and slug are required');
+  }
+
+  const themeConfig = THEMES[theme];
+  if (!themeConfig) {
+    throw new Error(`Invalid theme: ${theme}. Available themes: ${Object.keys(THEMES).join(', ')}`);
+  }
+
+  // Paths
+  const templatePath = path.join(process.cwd(), 'templates', 'svg', themeConfig.template);
+  const outputSvgPath = path.join(process.cwd(), 'public', 'images', 'games', `${slug}-og.svg`);
+  const outputPngPath = path.join(process.cwd(), 'public', 'images', 'games', `${slug}-og.png`);
+
+  // Read template
+  let svgContent = await fs.readFile(templatePath, 'utf-8');
+
+  // Calculate badge width
+  const badgeWidth = calculateBadgeWidth(category);
+
+  // Generate title lines
+  const titleLines = generateTitleLines(title);
+
+  // Replace placeholders
+  svgContent = svgContent
+    .replace(/{{TITLE}}/g, escapeXml(title))
+    .replace(/{{CATEGORY}}/g, escapeXml(category))
+    .replace(/{{BADGE_WIDTH}}/g, badgeWidth.toString())
+    .replace(/{{TITLE_LINES}}/g, titleLines);
+
+  // Write SVG file
+  await fs.writeFile(outputSvgPath, svgContent, 'utf-8');
+  console.log(`✅ Created: ${outputSvgPath}`);
+
+  // Generate PNG from SVG
+  try {
+    execSync(`pnpm svg2png "${outputSvgPath}"`, { stdio: 'inherit' });
+    console.log(`✅ Created: ${outputPngPath}`);
+  } catch (error) {
+    console.error(`❌ Failed to generate PNG: ${error}`);
+    throw error;
+  }
+}
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs(): QuizOGOptions {
+  const args = process.argv.slice(2);
+  const options: Partial<QuizOGOptions> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    if (arg === '--title' && nextArg) {
+      options.title = nextArg;
+      i++;
+    } else if (arg === '--category' && nextArg) {
+      options.category = nextArg;
+      i++;
+    } else if (arg === '--slug' && nextArg) {
+      options.slug = nextArg;
+      i++;
+    } else if (arg === '--theme' && nextArg) {
+      options.theme = nextArg as QuizOGOptions['theme'];
+      i++;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  if (!options.title || !options.category || !options.slug) {
+    console.error('❌ Error: Missing required arguments\n');
+    printHelp();
+    process.exit(1);
+  }
+
+  return options as QuizOGOptions;
+}
+
+/**
+ * Print usage help
+ */
+function printHelp(): void {
+  console.log(`
+Quiz OG Image Generator
+
+Usage:
+  pnpm generate-quiz-og --title "Quiz Title" --category "Category" --slug "quiz-slug" [--theme theme]
+
+Options:
+  --title      Quiz title (required)
+  --category   Quiz category badge text (required)
+  --slug       Output filename slug (required)
+  --theme      Theme template (optional)
+               Available: default, security, devops, cloud, sre
+               Default: default
+  --help, -h   Show this help message
+
+Examples:
+  # Basic usage with default theme
+  pnpm generate-quiz-og \\
+    --title "Kubernetes Security Quiz" \\
+    --category "Security" \\
+    --slug "kubernetes-security-quiz"
+
+  # Using security theme
+  pnpm generate-quiz-og \\
+    --title "Network & Security Fundamentals" \\
+    --category "Networking/Security" \\
+    --slug "network-security-quiz" \\
+    --theme security
+
+  # DevOps/CI-CD theme
+  pnpm generate-quiz-og \\
+    --title "Jenkins Pipeline Quiz" \\
+    --category "CI/CD" \\
+    --slug "jenkins-quiz" \\
+    --theme devops
+
+Output:
+  - SVG: public/images/games/{slug}-og.svg
+  - PNG: public/images/games/{slug}-og.png
+`);
+}
+
+// Main execution
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const options = parseArgs();
+  
+  generateQuizOG(options)
+    .then(() => {
+      console.log('\n✨ Quiz OG images generated successfully!\n');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('\n❌ Error generating quiz OG images:', error.message);
+      process.exit(1);
+    });
+}
+
+export { generateQuizOG, type QuizOGOptions };

--- a/templates/svg/README.md
+++ b/templates/svg/README.md
@@ -12,9 +12,24 @@ Reusable SVG templates for creating consistent, professional images for exercise
 **Quiz Templates:**
 - `quiz-template-default.svg` - Purple theme
 - `quiz-template-green.svg` - Green achievement theme
+- `quiz-template-security.svg` - Purple-blue theme for security/networking quizzes
+- `quiz-template-devops.svg` - Orange-amber theme for DevOps/CI-CD quizzes
+- `quiz-template-cloud.svg` - Blue theme for cloud/infrastructure quizzes
+- `quiz-template-sre.svg` - Red-orange theme for SRE/operations quizzes
 
 ## Quick Start
 
+**For Quizzes (Using Generator):**
+```bash
+# Generate quiz OG image with automatic theme
+pnpm generate-quiz-og \
+  --title "Kubernetes Security Quiz" \
+  --category "Security" \
+  --slug "kubernetes-security-quiz" \
+  --theme security
+```
+
+**For Exercises (Manual Method):**
 ```bash
 # 1. Copy template
 cp templates/svg/exercise-template-default.svg public/images/exercises/my-exercise.svg
@@ -26,6 +41,53 @@ cp templates/svg/exercise-template-default.svg public/images/exercises/my-exerci
 # 3. Convert to PNG
 pnpm run convert:svg-to-png:parallel
 ```
+
+## Quiz OG Image Generator
+
+The automated quiz OG image generator creates both SVG and PNG files with proper XML escaping and multi-line title support.
+
+**Usage:**
+```bash
+pnpm generate-quiz-og --title "Title" --category "Category" --slug "slug" [--theme theme]
+```
+
+**Available Themes:**
+- `default` - Purple gradient (general quizzes)
+- `security` - Purple-blue gradient (security, networking)
+- `devops` - Orange-amber gradient (DevOps, CI/CD, automation)
+- `cloud` - Blue gradient (cloud platforms, infrastructure)
+- `sre` - Red-orange gradient (SRE, operations, monitoring)
+
+**Examples:**
+```bash
+# Security quiz
+pnpm generate-quiz-og \
+  --title "Network & Security Fundamentals" \
+  --category "Networking/Security" \
+  --slug "network-security-quiz" \
+  --theme security
+
+# DevOps quiz
+pnpm generate-quiz-og \
+  --title "Jenkins Pipeline Quiz" \
+  --category "CI/CD" \
+  --slug "jenkins-quiz" \
+  --theme devops
+
+# Cloud quiz
+pnpm generate-quiz-og \
+  --title "AWS Solutions Architect Quiz" \
+  --category "Cloud Computing" \
+  --slug "aws-quiz" \
+  --theme cloud
+```
+
+**Features:**
+- Automatic XML character escaping (`&`, `<`, `>`, `"`, `'`)
+- Multi-line title support (automatically splits long titles)
+- Dynamic category badge width calculation
+- Automatic PNG generation from SVG
+- Responsive font sizing based on title length
 
 ## Customization
 

--- a/templates/svg/quiz-template-cloud.svg
+++ b/templates/svg/quiz-template-cloud.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Quiz Template - Cloud/Infrastructure Theme -->
+  <!-- INSTRUCTIONS: Replace {{TITLE}} and {{CATEGORY}} with your content -->
+
+  <defs>
+    <!-- Background gradient - blue shades -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a8a;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1e40af;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Quiz accent gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#60a5fa;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Cloud pattern -->
+   <pattern id="clouds" x="0" y="0" width="120" height="120" patternUnits="userSpaceOnUse">
+      <ellipse cx="40" cy="60" rx="15" ry="10" fill="#3b82f6" opacity="0.08"/>
+      <ellipse cx="55" cy="55" rx="18" ry="12" fill="#3b82f6" opacity="0.08"/>
+      <ellipse cx="70" cy="60" rx="15" ry="10" fill="#3b82f6" opacity="0.08"/>
+   </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+
+  <!-- Cloud pattern overlay -->
+  <rect width="1200" height="630" fill="url(#clouds)"/>
+
+  <!-- Category badge -->
+  <rect x="80" y="80" width="{{BADGE_WIDTH}}" height="40" rx="20" fill="url(#accentGradient)"/>
+  <text x="100" y="107" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">{{CATEGORY}}</text>
+
+  <!-- Quiz icon -->
+  <g transform="translate(80, 160)">
+    <circle cx="30" cy="30" r="30" fill="#3b82f6" opacity="0.8"/>
+    <text x="20" y="45" font-family="system-ui" font-size="40" font-weight="bold" fill="#ffffff">?</text>
+  </g>
+
+  <!-- Quiz label -->
+  <text x="150" y="188" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="600" fill="#60a5fa">INTERACTIVE QUIZ</text>
+
+  {{TITLE_LINES}}
+
+  <!-- Decorative cloud elements -->
+  <g opacity="0.15">
+    <!-- Cloud icon -->
+    <ellipse cx="980" cy="150" rx="40" ry="25" fill="#3b82f6"/>
+    <ellipse cx="1010" cy="140" rx="50" ry="30" fill="#3b82f6"/>
+    <ellipse cx="1040" cy="150" rx="40" ry="25" fill="#3b82f6"/>
+    
+    <!-- Server racks -->
+    <rect x="980" y="450" width="60" height="60" rx="5" fill="none" stroke="#3b82f6" stroke-width="4"/>
+    <line x1="985" y1="465" x2="1035" y2="465" stroke="#3b82f6" stroke-width="2"/>
+    <line x1="985" y1="480" x2="1035" y2="480" stroke="#3b82f6" stroke-width="2"/>
+    <line x1="985" y1="495" x2="1035" y2="495" stroke="#3b82f6" stroke-width="2"/>
+    
+    <rect x="1060" y="450" width="60" height="60" rx="5" fill="none" stroke="#60a5fa" stroke-width="4"/>
+    <line x1="1065" y1="465" x2="1115" y2="465" stroke="#60a5fa" stroke-width="2"/>
+    <line x1="1065" y1="480" x2="1115" y2="480" stroke="#60a5fa" stroke-width="2"/>
+    <line x1="1065" y1="495" x2="1115" y2="495" stroke="#60a5fa" stroke-width="2"/>
+  </g>
+
+  <!-- DevOps Daily branding -->
+  <text x="80" y="550" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="bold" fill="#60a5fa">DevOps Daily</text>
+</svg>

--- a/templates/svg/quiz-template-devops.svg
+++ b/templates/svg/quiz-template-devops.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Quiz Template - DevOps/CI-CD Theme -->
+  <!-- INSTRUCTIONS: Replace {{TITLE}} and {{CATEGORY}} with your content -->
+
+  <defs>
+    <!-- Background gradient - orange to amber -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#c2410c;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#b45309;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Quiz accent gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#fb923c;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#fbbf24;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Pipeline pattern -->
+   <pattern id="pipelines" x="0" y="0" width="120" height="120" patternUnits="userSpaceOnUse">
+      <circle cx="30" cy="60" r="6" fill="#fb923c" opacity="0.1"/>
+      <circle cx="90" cy="60" r="6" fill="#fb923c" opacity="0.1"/>
+      <line x1="36" y1="60" x2="84" y2="60" stroke="#fb923c" stroke-width="2" opacity="0.1"/>
+   </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+
+  <!-- Pipeline pattern overlay -->
+  <rect width="1200" height="630" fill="url(#pipelines)"/>
+
+  <!-- Category badge -->
+  <rect x="80" y="80" width="{{BADGE_WIDTH}}" height="40" rx="20" fill="url(#accentGradient)"/>
+  <text x="100" y="107" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">{{CATEGORY}}</text>
+
+  <!-- Quiz icon -->
+  <g transform="translate(80, 160)">
+    <circle cx="30" cy="30" r="30" fill="#fb923c" opacity="0.8"/>
+    <text x="20" y="45" font-family="system-ui" font-size="40" font-weight="bold" fill="#ffffff">?</text>
+  </g>
+
+  <!-- Quiz label -->
+  <text x="150" y="188" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="600" fill="#fbbf24">INTERACTIVE QUIZ</text>
+
+  {{TITLE_LINES}}
+
+  <!-- Decorative pipeline elements -->
+  <g opacity="0.15">
+    <!-- Pipeline nodes -->
+    <circle cx="950" cy="150" r="20" fill="#fb923c"/>
+    <circle cx="1050" cy="150" r="20" fill="#fbbf24"/>
+    <circle cx="1100" cy="200" r="20" fill="#fb923c"/>
+    <line x1="970" y1="150" x2="1030" y2="150" stroke="#fb923c" stroke-width="3"/>
+    <line x1="1050" y1="170" x2="1080" y2="190" stroke="#fb923c" stroke-width="3"/>
+    
+    <!-- Deploy icon -->
+    <rect x="980" y="450" width="80" height="60" rx="5" fill="none" stroke="#fb923c" stroke-width="4"/>
+    <polygon points="1020,470 1040,470 1040,490 1045,490 1030,500 1015,490 1020,490" fill="#fb923c"/>
+  </g>
+
+  <!-- DevOps Daily branding -->
+  <text x="80" y="550" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="bold" fill="#fbbf24">DevOps Daily</text>
+</svg>

--- a/templates/svg/quiz-template-security.svg
+++ b/templates/svg/quiz-template-security.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Quiz Template - Security/Network Theme -->
+  <!-- INSTRUCTIONS: Replace {{TITLE}} and {{CATEGORY}} with your content -->
+
+  <defs>
+    <!-- Background gradient - purple to blue -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#5b21b6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1e40af;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Quiz accent gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#60a5fa;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Lock icon pattern -->
+   <pattern id="locks" x="0" y="0" width="120" height="120" patternUnits="userSpaceOnUse">
+      <circle cx="60" cy="55" r="8" fill="#8b5cf6" opacity="0.08"/>
+      <rect x="52" y="55" width="16" height="18" rx="2" fill="#8b5cf6" opacity="0.08"/>
+   </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+
+  <!-- Lock pattern overlay -->
+  <rect width="1200" height="630" fill="url(#locks)"/>
+
+  <!-- Category badge -->
+  <rect x="80" y="80" width="{{BADGE_WIDTH}}" height="40" rx="20" fill="url(#accentGradient)"/>
+  <text x="100" y="107" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">{{CATEGORY}}</text>
+
+  <!-- Lock icon -->
+ <g transform="translate(80, 160)">
+   <circle cx="30" cy="30" r="30" fill="#8b5cf6" opacity="0.9"/>
+    <!-- Lock icon SVG -->
+    <g transform="translate(18, 18)">
+      <circle cx="12" cy="10" r="6" fill="none" stroke="#ffffff" stroke-width="2"/>
+      <rect x="6" y="16" width="12" height="14" rx="1" fill="#ffffff"/>
+      <circle cx="12" cy="23" r="2" fill="#8b5cf6"/>
+    </g>
+ </g>
+
+  <!-- Quiz label -->
+  <text x="150" y="188" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="600" fill="#a78bfa">INTERACTIVE QUIZ</text>
+
+  {{TITLE_LINES}}
+
+  <!-- Decorative network/security icons -->
+  <g opacity="0.15">
+    <!-- Shield icon -->
+    <path d="M 950 120 L 1000 120 L 1000 180 Q 1000 200 980 210 Q 960 220 950 210 Q 930 200 930 180 L 930 120 Z M 950 120 L 975 100 L 1000 120" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="3"/>
+    
+    <!-- Network nodes -->
+    <circle cx="1050" cy="150" r="15" fill="#60a5fa"/>
+    <circle cx="1100" cy="120" r="15" fill="#60a5fa"/>
+    <circle cx="1100" cy="180" r="15" fill="#60a5fa"/>
+    <line x1="1050" y1="150" x2="1100" y2="120" stroke="#60a5fa" stroke-width="2"/>
+    <line x1="1050" y1="150" x2="1100" y2="180" stroke="#60a5fa" stroke-width="2"/>
+    
+    <!-- Firewall icon -->
+    <rect x="980" y="450" width="80" height="60" rx="5" fill="none" stroke="#8b5cf6" stroke-width="4"/>
+    <line x1="1000" y1="450" x2="1000" y2="510" stroke="#8b5cf6" stroke-width="3"/>
+    <line x1="1020" y1="450" x2="1020" y2="510" stroke="#8b5cf6" stroke-width="3"/>
+    <line x1="1040" y1="450" x2="1040" y2="510" stroke="#8b5cf6" stroke-width="3"/>
+    
+    <!-- Key icon -->
+    <circle cx="1100" cy="480" r="12" fill="none" stroke="#60a5fa" stroke-width="3"/>
+    <line x1="1112" y1="480" x2="1140" y2="480" stroke="#60a5fa" stroke-width="3"/>
+    <line x1="1125" y1="475" x2="1125" y2="485" stroke="#60a5fa" stroke-width="3"/>
+    <line x1="1135" y1="475" x2="1135" y2="485" stroke="#60a5fa" stroke-width="3"/>
+  </g>
+
+  <!-- DevOps Daily branding -->
+  <text x="80" y="550" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="bold" fill="#a78bfa">DevOps Daily</text>
+</svg>

--- a/templates/svg/quiz-template-sre.svg
+++ b/templates/svg/quiz-template-sre.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <!-- Quiz Template - SRE/Operations Theme -->
+  <!-- INSTRUCTIONS: Replace {{TITLE}} and {{CATEGORY}} with your content -->
+
+  <defs>
+    <!-- Background gradient - red to orange -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#991b1b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#c2410c;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Quiz accent gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#fb923c;stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Shield pattern -->
+   <pattern id="shields" x="0" y="0" width="120" height="120" patternUnits="userSpaceOnUse">
+      <path d="M 55 45 L 60 45 L 60 75 Q 60 78 58 80 Q 56 82 55 80 Q 53 78 53 75 L 53 45 Z M 55 45 L 57.5 42 L 60 45" fill="#ef4444" opacity="0.08"/>
+   </pattern>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+
+  <!-- Shield pattern overlay -->
+  <rect width="1200" height="630" fill="url(#shields)"/>
+
+  <!-- Category badge -->
+  <rect x="80" y="80" width="{{BADGE_WIDTH}}" height="40" rx="20" fill="url(#accentGradient)"/>
+  <text x="100" y="107" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#ffffff">{{CATEGORY}}</text>
+
+  <!-- Quiz icon -->
+  <g transform="translate(80, 160)">
+    <circle cx="30" cy="30" r="30" fill="#ef4444" opacity="0.8"/>
+    <text x="20" y="45" font-family="system-ui" font-size="40" font-weight="bold" fill="#ffffff">?</text>
+  </g>
+
+  <!-- Quiz label -->
+  <text x="150" y="188" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="600" fill="#fb923c">INTERACTIVE QUIZ</text>
+
+  {{TITLE_LINES}}
+
+  <!-- Decorative SRE elements -->
+  <g opacity="0.15">
+    <!-- Shield icon -->
+    <path d="M 950 120 L 1000 120 L 1000 180 Q 1000 200 980 210 Q 960 220 950 210 Q 930 200 930 180 L 930 120 Z M 950 120 L 975 100 L 1000 120" fill="#ef4444" stroke="#ef4444" stroke-width="3"/>
+    
+    <!-- Monitoring graph -->
+    <polyline points="980,460 1000,440 1020,470 1040,450 1060,480 1080,460 1100,490" fill="none" stroke="#ef4444" stroke-width="4"/>
+    <rect x="975" y="430" width="130" height="80" rx="5" fill="none" stroke="#fb923c" stroke-width="3"/>
+  </g>
+
+  <!-- DevOps Daily branding -->
+  <text x="80" y="550" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="bold" fill="#fb923c">DevOps Daily</text>
+</svg>


### PR DESCRIPTION
Implements Issue #519

## Summary
Adds automated quiz OG image generation with themed templates and CLI tool.

## What's Included

**Templates:**
- `quiz-template-security.svg` - Purple-blue theme for security/networking
- `quiz-template-devops.svg` - Orange-amber theme for DevOps/CI-CD
- `quiz-template-cloud.svg` - Blue theme for cloud/infrastructure  
- `quiz-template-sre.svg` - Red-orange theme for SRE/operations
- Uses existing `quiz-template-default.svg` for general quizzes

**Generator Script:**
- CLI tool at `scripts/generate-quiz-og.ts`
- Automatic XML character escaping (`&`, `<`, `>`, `"`, `'`)
- Multi-line title support (automatically splits long titles)
- Dynamic category badge width calculation
- Automatic PNG generation via svg2png
- Responsive font sizing based on title length

**Usage:**
```bash
pnpm generate-quiz-og --title "Quiz Title" --category "Category" --slug "slug" [--theme theme]
```

**Examples:**
```bash
# Security quiz
pnpm generate-quiz-og \\
  --title "Network & Security Fundamentals" \\
  --category "Networking/Security" \\
  --slug "network-security-quiz" \\
  --theme security

# DevOps quiz
pnpm generate-quiz-og \\
  --title "Jenkins Pipeline Quiz" \\
  --category "CI/CD" \\
  --slug "jenkins-quiz" \\
  --theme devops
```

## Testing
- [x] Generator tested with all themes
- [x] XML escaping verified with special characters
- [x] Multi-line title splitting validated
- [x] All 4314 tests passing
- [x] No TypeScript errors
- [x] Documentation updated in `templates/svg/README.md`

## Benefits
- Automates manual SVG creation process
- Ensures consistent quiz OG image quality
- Prevents XML syntax errors
- Reduces time to create new quizzes
- Provides clear theme guidelines

Closes #519