### PR TITLE
chore: Remove datafa.st analytics script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -130,12 +130,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           title="DevOps Daily RSS Feed"
           href="/feed.xml"
         />
-        <script
-          defer
-          data-website-id="686fb625b5233b4e8e67112c"
-          data-domain="devops-daily.com"
-          src="https://datafa.st/js/script.js"
-        ></script>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <WebsiteSchema />


### PR DESCRIPTION
This PR removes the datafa.st analytics script from the codebase since the service is no longer in use.

## Changes
- Removed datafa.st script tag from `app/layout.tsx`

## Rationale
The datafa.st service is no longer being used by DevOps Daily, so the script can be safely removed to clean up the codebase and reduce unnecessary external dependencies.