### PR TITLE
fix: Correct heading hierarchy for accessibility

### DIFF
--- a/components/exercise-card.tsx
+++ b/components/exercise-card.tsx
@@ -187,7 +187,7 @@ export function ExerciseCard({
 
         {/* Learning objectives preview */}
         <div className="pt-4 mt-4 border-t border-border/50">
-          <h4 className="mb-2 text-xs font-medium text-muted-foreground">You'll learn:</h4>
+          <div className="mb-2 text-xs font-medium text-muted-foreground">You'll learn:</div>
           <ul className="space-y-1 text-xs text-muted-foreground">
             {exercise.learningObjectives.slice(0, 2).map((objective, index) => (
               <li key={index} className="flex items-start gap-2">

--- a/components/featured-exercises.tsx
+++ b/components/featured-exercises.tsx
@@ -183,7 +183,7 @@ function FeaturedExerciseCard({ exercise, index }: { exercise: Exercise; index: 
 
           {/* Learning objectives preview */}
           <div className="pt-4 border-t border-border/50">
-            <h4 className="mb-2 text-xs font-medium text-muted-foreground">You'll learn:</h4>
+            <div className="mb-2 text-xs font-medium text-muted-foreground">You'll learn:</div>
             <ul className="space-y-1 text-xs text-muted-foreground">
               {exercise.learningObjectives.slice(0, 2).map((objective, index) => (
                 <li key={index} className="flex items-start gap-2">


### PR DESCRIPTION
## Problem
Google PageSpeed Insights flagged a heading hierarchy issue:
> Heading elements are not in a sequentially-descending order

The issue was caused by `<h4>` elements being used for "You'll learn:" labels without proper heading hierarchy.

## Solution
Changed the `<h4>` elements to `<div>` elements in:
- `components/exercise-card.tsx`
- `components/featured-exercises.tsx`

## Reasoning
The "You'll learn:" text is a styled label, not a semantic heading. Using `<div>` instead of `<h4>`:
- ✅ Maintains the exact same visual styling
- ✅ Follows proper heading hierarchy (h1 → h2 → h3)
- ✅ Improves accessibility for screen readers
- ✅ Ensures WCAG compliance

## Testing
- Visual appearance remains identical
- Heading structure is now properly ordered
- Screen readers will navigate the document structure correctly

## Files Changed
- `components/exercise-card.tsx`
- `components/featured-exercises.tsx`

Fixes the PageSpeed Insights heading hierarchy warning.