### PR TITLE
fix: Add accessible names to code copy buttons

### DIFF
--- a/components/code-block-wrapper.tsx
+++ b/components/code-block-wrapper.tsx
@@ -45,6 +45,7 @@ export function CodeBlock({ children, language }: CodeBlockProps) {
 
       <motion.button
         onClick={handleCopy}
+        aria-label={copied ? "Copied to clipboard" : "Copy code to clipboard"}
         className={cn(
           'absolute top-2 right-2 z-10',
           'flex items-center justify-center',
@@ -130,6 +131,7 @@ export function CodeBlockWrapper({ children }: { children: React.ReactNode }) {
 
         // Create copy button
         const copyButton = document.createElement('button');
+        copyButton.setAttribute('aria-label', 'Copy code to clipboard');
         copyButton.className = `
           copy-button absolute top-2 right-2 z-10 
           flex items-center justify-center 
@@ -156,6 +158,9 @@ export function CodeBlockWrapper({ children }: { children: React.ReactNode }) {
           try {
             await navigator.clipboard.writeText(codeText);
 
+            // Update aria-label for screen readers
+            copyButton.setAttribute('aria-label', 'Copied to clipboard');
+
             // Show check icon
             copyButton.innerHTML = `
               <svg class="h-4 w-4 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -165,6 +170,7 @@ export function CodeBlockWrapper({ children }: { children: React.ReactNode }) {
 
             // Reset after 2 seconds
             setTimeout(() => {
+              copyButton.setAttribute('aria-label', 'Copy code to clipboard');
               copyButton.innerHTML = `
                 <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 


### PR DESCRIPTION
## Problem
Google PageSpeed Insights flagged an accessibility issue with the copy buttons in code blocks:
> Buttons do not have an accessible name. When a button doesn't have an accessible name, screen readers announce it as "button", making it unusable for users who rely on screen readers.

## Solution
Added `aria-label` attributes to all copy buttons in `components/code-block-wrapper.tsx`:

### For the Motion button component:
- Dynamic `aria-label` that changes based on state
- "Copy code to clipboard" (default state)
- "Copied to clipboard" (after successful copy)

### For dynamically created buttons:
- `aria-label` set on button creation
- Updated to "Copied to clipboard" when clicked
- Reset back to "Copy code to clipboard" after timeout

## Benefits
- ✅ Screen readers announce clear button purpose
- ✅ Improved accessibility for assistive technology users
- ✅ WCAG 4.1.2 (Name, Role, Value) compliance
- ✅ Better user experience for all users

## Testing
- Visual appearance unchanged
- Button functionality unchanged
- Screen readers will now properly announce button purpose

## Files Changed
- `components/code-block-wrapper.tsx`

Fixes the PageSpeed Insights accessible name warning for copy buttons.