### PR TITLE
fix: Remove nested sticky positioning causing sidebar overlap on news pages

### DIFF
--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -168,7 +168,7 @@ export default async function NewsDigestPage({
           {/* Sidebar */}
           <aside className="lg:col-span-3">
             <div className="sticky top-8 space-y-6">
-              <SponsorSidebar />
+              <SponsorSidebar className="!relative !top-auto" />
 
               {/* Share Section */}
               <div className="bg-card border rounded-lg p-6">


### PR DESCRIPTION
Fixes #566

## Problem
The share and newsletter boxes in the sidebar were overlapping on individual news pages.

## Root Cause
The `SponsorSidebar` component has its own `sticky top-8` positioning, but in news pages it was nested inside another `sticky top-8` container. This created a nested sticky situation where both were trying to be sticky at the same position, causing overlap.

## Solution
Override the `SponsorSidebar`'s internal sticky positioning with `!relative !top-auto` classes to make it flow normally within the parent sticky container.

## Changes
- Modified `app/news/[slug]/page.tsx` to add `className="!relative !top-auto"` to `SponsorSidebar`
- This prevents the nested sticky behavior while keeping the parent container sticky
- The sidebar elements now stack properly with correct spacing

## Testing
- Navigate to any news article (e.g., `/news/2025-week-49`)
- Verify that the sponsor section, share buttons, and newsletter subscription box no longer overlap
- Verify the sidebar still sticks to the viewport when scrolling