### PR TITLE
Make ebook popup less intrusive

### DIFF
--- a/components/book-promotion-popup.tsx
+++ b/components/book-promotion-popup.tsx
@@ -22,7 +22,7 @@ export function BookPromotionPopup() {
       return
     }
 
-    // Show popup after 10 seconds to avoid overwhelming users
+    // Show popup after 3 minutes to avoid being intrusive
     const timer = setTimeout(() => {
       setIsVisible(true)
       // Small delay for animation
@@ -35,7 +35,7 @@ export function BookPromotionPopup() {
           setTimeout(() => setShowConfetti(false), 5000)
         }, 600)
       }, 100)
-    }, 10000)
+    }, 180000) // 3 minutes (180 seconds)
 
     return () => {
       clearTimeout(timer)


### PR DESCRIPTION
## Summary

Reduces the intrusiveness of the ebook promotion popup by significantly increasing the delay before it appears.

## Changes

- **Increased delay from 10 seconds to 3 minutes (180 seconds)**
- Updated comments to reflect the new timing

## Rationale

**Better User Experience:**
- Users can explore and engage with site content without immediate interruption
- Only users genuinely interested (staying 3+ minutes) see the popup
- Reduces bounce rate from overly aggressive popups

**Maintains Effectiveness:**
- Users who spend 3+ minutes are more likely to be interested in subscribing
- Still captures engaged visitors without alienating newcomers
- localStorage prevents showing popup to users who have already dismissed or subscribed

## Testing

To test the new timing:
1. Clear localStorage for `book-promo-dismissed` and `book-promo-subscribed`
2. Visit any page with the popup
3. Wait 3 minutes - popup should appear
4. Close button and "Maybe later" link still work as expected

## Impact

- More respectful of user attention
- Better first impression for new visitors
- Higher quality leads (engaged users only)
- Maintains all existing functionality