### PR TITLE
Fix: Add Introduction to Git guide to git category page

### DIFF
--- a/content/exercises/git-workflow-collaboration.json
+++ b/content/exercises/git-workflow-collaboration.json
@@ -3,8 +3,8 @@
   "title": "Git Workflow and Collaboration Fundamentals",
   "description": "Master essential Git workflows, branching strategies, and collaboration techniques used in modern development teams.",
   "category": {
-    "name": "Version Control",
-    "slug": "version-control"
+    "name": "Git",
+    "slug": "git"
   },
   "difficulty": "beginner",
   "estimatedTime": "50 minutes",

--- a/content/guides/introduction-to-git/index.md
+++ b/content/guides/introduction-to-git/index.md
@@ -2,8 +2,8 @@
 title: 'Introduction to Git'
 description: 'A guide to understanding and learning Git version control'
 category:
-  name: 'Version Control'
-  slug: 'version-control'
+  name: 'Git'
+  slug: 'git'
 parts: 10
 publishedAt: '2024-06-03T10:00:00Z'
 updatedAt: '2024-06-03T12:00:00Z'


### PR DESCRIPTION
## Summary

Fixes the issue where the "Introduction to Git" guide wasn't appearing on the `/categories/git` page.

## Problem

The guide metadata specified `category.slug: version-control` which doesn't exist as a category in the system. This caused the guide to not be associated with any category page.

## Solution

Updated the category metadata to:
- `name: Git`
- `slug: git`

This matches the existing `git` category, ensuring the guide now appears on the categories/git page.

## Changes

- Updated `content/guides/introduction-to-git/index.md` category metadata
- Updated `content/exercises/git-workflow-collaboration.json` category metadata for consistency

Fixes #607