### PR TITLE
Fix DATA packet skipping second-to-last stage on return journey

### DIFF
--- a/components/games/packet-journey.tsx
+++ b/components/games/packet-journey.tsx
@@ -401,21 +401,20 @@ export default function PacketJourney() {
             // Move to next stage
             setCurrentStageIndex((prev) => prev + 1);
             setStageProgress(0);
-          } else {
-            // Reached the end, start return journey
-            setIsReturning(true);
-            if (journeyStages.length > 1) {
-              setCurrentStageIndex((prev) => prev - 1);
-              setStageProgress(0);
-            } else {
-              // Only one stage, complete immediately
-              setJourneyComplete(true);
-              setIsRunning(false);
-              setTotalTime(Date.now() - journeyStartTime.current);
-              return;
-            }
-          }
         } else {
+          // Reached the end, start return journey
+          setIsReturning(true);
+          if (journeyStages.length === 1) {
+            // Only one stage, complete immediately
+            setJourneyComplete(true);
+            setIsRunning(false);
+            setTotalTime(Date.now() - journeyStartTime.current);
+            return;
+          }
+          // For multiple stages, stay at last stage and animate back
+          setStageProgress(0);
+        }
+      } else {
           // Going backward (return journey)
           if (currentStageIndex > 0) {
             // Move to previous stage


### PR DESCRIPTION
Fixes #618

## Problem
The DATA packet was teleporting from the last stage directly to the third-to-last stage, completely skipping the second-to-last stage during the return journey.

## Root Cause
When the packet reached the final stage going outbound, the code immediately decremented the stage index (`setCurrentStageIndex((prev) => prev - 1)`) before starting the return animation. This caused the packet to skip animating through the last stage on the way back.

## Solution
Removed the immediate index decrement. Now when the packet reaches the last stage:
1. Sets `isReturning = true`
2. Resets `stageProgress = 0` (stays at last stage)
3. Allows the normal return journey logic to animate back through all stages naturally

## Testing
- ✅ Packet now visits all stages on return journey
- ✅ No more teleporting between stages
- ✅ Works in both Auto-Play and Step-by-Step modes
- ✅ Tested with all scenarios (HTTP, HTTPS, HTTPS+CDN, etc.)

## Changes
- Modified `components/games/packet-journey.tsx` lines 404-415
- Simplified the return journey initialization logic
- Removed premature stage index decrement