### PR TITLE
Fix theme hydration mismatch in Network Packet Journey

### DIFF
--- a/components/games/packet-journey.tsx
+++ b/components/games/packet-journey.tsx
@@ -224,8 +224,14 @@ const allStages: Record<string, Omit<JourneyStage, 'x' | 'y'>> = {
 };
 
 export default function PacketJourney() {
-  const { theme } = useTheme();
-  const isDark = theme === 'dark';
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const isDark = resolvedTheme === 'dark';
+
+  // Handle theme hydration
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const [scenario, setScenario] = useState<ScenarioType>('https-cdn');
   const [isRunning, setIsRunning] = useState(false);
@@ -504,6 +510,11 @@ export default function PacketJourney() {
 
     return { x, y };
   }, [currentStageIndex, stageProgress, journeyStages, isReturning]);
+
+  // Prevent theme flash on mount
+  if (!mounted) {
+    return null;
+  }
 
   return (
     <div className={cn(


### PR DESCRIPTION
Fixes #620

## Problem
When the Network Packet Journey page first loads, even if the user has dark mode enabled, the page renders in a broken hybrid state with some components in light mode and others in dark mode. After toggling the theme button, it corrects itself.

## Root Cause
The issue was caused by:
1. Using `theme` instead of `resolvedTheme` from `next-themes`
2. No check for client-side hydration completion
3. Theme-dependent content rendering during SSR before theme is resolved

## Solution

### Changed `theme` to `resolvedTheme`
- `resolvedTheme` waits for the theme to be fully determined (including system preference)
- Prevents `undefined` values during initial render

### Added Mounted State
- Track when component has hydrated on client-side
- Only render after `useEffect` runs (client-side only)

### Return Early Pattern
- Return `null` before theme is resolved
- Prevents flash of incorrectly styled content
- Standard pattern for theme-dependent components in Next.js

## Changes
- Modified `components/games/packet-journey.tsx`:
  - Line 227: Changed from `theme` to `resolvedTheme`
  - Lines 228-233: Added mounted state with useEffect
  - Lines 514-517: Added early return if not mounted

## Testing
- ✅ Page loads with correct theme immediately
- ✅ No hybrid light/dark mode flash
- ✅ Dark mode users see consistent dark theme
- ✅ Light mode users see consistent light theme
- ✅ System theme preference respected
- ✅ Theme toggle still works correctly

## Result
The page now renders consistently in the correct theme from the first paint, with no broken hybrid appearance.