### PR TITLE
Fix Day 1 Docker challenge: Update with realistic image size requirements

### DIFF
--- a/content/advent-of-devops/day-1.md
+++ b/content/advent-of-devops/day-1.md
@@ -1,10 +1,10 @@
 ---
 title: 'Day 1 - Build a Minimal Docker Image'
 day: 1
-excerpt: 'Learn to create the smallest possible Docker image for a Python or Node.js application. Optimize for size, security, and performance.'
-description: 'Create a minimal Docker image under 25MB using multi-stage builds, Alpine Linux, and best practices for containerization.'
+excerpt: 'Learn to create the smallest possible Docker image for a Go application. Optimize for size, security, and performance using static compilation.'
+description: 'Create a minimal Docker image under 25MB using Go, multi-stage builds, Alpine Linux, and best practices for containerization.'
 publishedAt: '2025-12-01T00:00:00Z'
-updatedAt: '2025-12-01T00:00:00Z'
+updatedAt: '2025-12-14T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:
@@ -12,6 +12,7 @@ tags:
   - Containerization
   - Optimization
   - Alpine
+  - Go
 ---
 
 ## Description
@@ -20,25 +21,239 @@ You're tasked with containerizing a small application, but your manager is conce
 
 ## Task
 
-Create the smallest working Docker image you can for a tiny Python or Node.js application.
+Create the smallest working Docker image you can for a tiny Go application.
 
 **Requirements:**
 - Image must be under 25MB
 - Application must run successfully
 - Use multi-stage builds
-- Use Alpine Linux base images
-- Remove unnecessary dependencies
+- Use Alpine Linux base images or scratch
+- Compile Go binary statically for minimal final image
 
 ## Target
 
-- **Image Size**: Under 25MB
-- **Startup Time**: Under 2 seconds
-- **Security**: Minimal attack surface with Alpine base
+- **Image Size**: Under 25MB (under 10MB possible with scratch!)
+- **Startup Time**: Under 1 second
+- **Security**: Minimal attack surface with Alpine/scratch base
 
 ## Sample App
 
-### Python Example (app.py)
+### Go Example (main.go)
 
+```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "Hello from Advent of DevOps!")
+	})
+
+	fmt.Println("Server running on port 8000...")
+	if err := http.ListenAndServe(":8000", nil); err != nil {
+		fmt.Printf("Error starting server: %v\n", err)
+	}
+}
+```
+
+## Solution
+
+### Optimized Dockerfile (Go + Alpine)
+
+```dockerfile
+# Multi-stage build
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /usr/src/app
+
+# Copy Go source
+COPY main.go .
+
+# Build static binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-s -w' -o main .
+
+# Final stage
+FROM alpine:latest
+
+# Create non-root user
+RUN addgroup -g 1001 appgroup && \
+    adduser -D -u 1001 -G appgroup appuser
+
+WORKDIR /usr/src/app
+
+# Copy from builder
+COPY --from=builder --chown=appuser:appgroup /usr/src/app/main .
+
+# Switch to non-root user
+USER appuser
+
+# Expose port
+EXPOSE 8000
+
+# Run binary
+CMD ["./main"]
+```
+
+### Alternative: Scratch-Based Image (Even Smaller!)
+
+For an even smaller image (under 10MB), you can use a `scratch` base:
+
+```dockerfile
+# Multi-stage build
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /usr/src/app
+COPY main.go .
+
+# Build static binary with all dependencies embedded
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-s -w -extldflags "-static"' -o main .
+
+# Use scratch (empty) base image
+FROM scratch
+
+# Copy only the binary
+COPY --from=builder /usr/src/app/main /main
+
+# Expose port
+EXPOSE 8000
+
+# Run binary
+CMD ["/main"]
+```
+
+### Build and Test
+
+```bash
+# Build the Alpine version
+docker build -t advent-day1:alpine .
+
+# Build the scratch version (use the scratch Dockerfile)
+docker build -f Dockerfile.scratch -t advent-day1:scratch .
+
+# Check image sizes
+docker images advent-day1
+
+# Run the container
+docker run -d -p 8000:8000 --name advent-day1 advent-day1:alpine
+
+# Test the application
+curl http://localhost:8000
+# Should return: Hello from Advent of DevOps!
+
+# Clean up
+docker stop advent-day1 && docker rm advent-day1
+```
+
+## Explanation
+
+### Why This Matters
+
+Image size directly impacts:
+- **Deployment Speed**: Smaller images deploy faster across networks
+- **Storage Costs**: Less disk space and registry storage needed
+- **Security**: Fewer packages mean fewer vulnerabilities
+- **Build Times**: Smaller base images build faster
+
+### Why Go for Minimal Images?
+
+Go compiles to a **static binary** with no runtime dependencies, making it perfect for minimal Docker images:
+
+- **Python/Node.js**: Require ~50-60MB runtime (interpreter + standard library)
+- **Go**: Compiles to single binary (~5-7MB) with zero dependencies
+- **Result**: Go achieves sub-25MB easily, while Python/Node.js struggle to get below 50MB
+
+### Key Optimization Techniques
+
+1. **Alpine Linux Base**: Uses musl libc instead of glibc, significantly reducing size (~7MB)
+2. **Scratch Base**: Completely empty image, only the binary (0MB base!)
+3. **Multi-Stage Builds**: Separates build-time dependencies from runtime
+4. **Static Compilation**: Go binaries include all dependencies
+5. **Strip Debug Symbols**: `-ldflags '-s -w'` removes debug info and symbol table
+6. **Non-Root User**: Security best practice (Alpine version)
+
+### Build Flags Explained
+
+```bash
+CGO_ENABLED=0          # Disable C bindings for pure Go binary
+GOOS=linux             # Target Linux OS
+-a                     # Force rebuild of all packages
+-installsuffix cgo     # Separate build cache
+-ldflags '-s -w'       # Strip debug info and symbol table
+  -s                   # Omit symbol table
+  -w                   # Omit DWARF symbol table
+```
+
+### Size Comparison
+
+| Approach | Image Size | Notes |
+|----------|-----------|--------------------------------------------|
+| golang:1.23 | ~800MB | Full Debian-based image with Go toolchain |
+| golang:1.23-alpine | ~300MB | Alpine with Go toolchain |
+| Alpine + Go binary | **~15MB** | Multi-stage with Alpine base |
+| Scratch + Go binary | **~7MB** | Only the compiled binary, no OS |
+| python:3.12-alpine | ~60MB | Python interpreter required |
+| node:20-alpine | ~70MB | Node.js runtime required |
+
+## Result
+
+You should achieve:
+- ✅ Docker image under 25MB (15MB Alpine, 7MB scratch)
+- ✅ Functional Go web server responding on port 8000
+- ✅ Container runs as non-root user (Alpine version)
+- ✅ Fast build and startup times
+- ✅ Static binary with zero runtime dependencies
+
+## Validation
+
+```bash
+# Check image size
+docker images advent-day1 --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+# Alpine version: ~15MB
+# Scratch version: ~7MB
+
+# Verify non-root user (Alpine version only)
+docker run --rm advent-day1:alpine whoami
+# Should show: appuser
+
+# Test application
+docker run -d -p 8000:8000 --name test advent-day1:alpine
+curl http://localhost:8000
+# Should return: Hello from Advent of DevOps!
+docker stop test && docker rm test
+
+# Inspect image layers
+docker history advent-day1:alpine
+docker history advent-day1:scratch
+```
+
+## Bonus: Python and Node.js Alternatives
+
+If you prefer Python or Node.js, here are **realistic** minimal images. Note that the 25MB target is **not achievable** with interpreted languages due to runtime requirements.
+
+### Python (Realistic: ~60MB)
+
+```dockerfile
+FROM python:3.12-alpine
+
+RUN addgroup -g 1001 appgroup && \
+    adduser -D -u 1001 -G appgroup appuser
+
+WORKDIR /app
+COPY app.py .
+
+USER appuser
+EXPOSE 8000
+
+CMD ["python", "app.py"]
+```
+
+**Python app.py:**
 ```python
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
@@ -55,8 +270,26 @@ if __name__ == '__main__':
     server.serve_forever()
 ```
 
-### Node.js Example (app.js)
+**Note**: Python Alpine images are **~50-60MB minimum** due to the Python interpreter and standard library.
 
+### Node.js (Realistic: ~70MB)
+
+```dockerfile
+FROM node:20-alpine
+
+RUN addgroup -g 1001 appgroup && \
+    adduser -D -u 1001 -G appgroup appuser
+
+WORKDIR /app
+COPY app.js .
+
+USER appuser
+EXPOSE 8000
+
+CMD ["node", "app.js"]
+```
+
+**Node.js app.js:**
 ```javascript
 const http = require('http');
 
@@ -70,146 +303,16 @@ server.listen(8000, '0.0.0.0', () => {
 });
 ```
 
-## Solution
-
-### Optimized Dockerfile (Python)
-
-```dockerfile
-# Multi-stage build
-FROM python:3.12-alpine AS builder
-
-# Create app directory
-WORKDIR /app
-
-# Copy application
-COPY app.py .
-
-# Final stage
-FROM python:3.12-alpine
-
-# Create non-root user
-RUN addgroup -g 1001 appgroup && \
-    adduser -D -u 1001 -G appgroup appuser
-
-# Set working directory
-WORKDIR /app
-
-# Copy from builder
-COPY --from=builder /app/app.py .
-
-# Switch to non-root user
-USER appuser
-
-# Expose port
-EXPOSE 8000
-
-# Run application
-CMD ["python", "app.py"]
-```
-
-### Optimized Dockerfile (Node.js)
-
-```dockerfile
-# Multi-stage build
-FROM node:20-alpine AS builder
-
-WORKDIR /app
-COPY app.js .
-
-# Final stage
-FROM node:20-alpine
-
-# Create non-root user
-RUN addgroup -g 1001 appgroup && \
-    adduser -D -u 1001 -G appgroup appuser
-
-WORKDIR /app
-
-# Copy application
-COPY --from=builder /app/app.js .
-
-# Switch to non-root user
-USER appuser
-
-EXPOSE 8000
-
-CMD ["node", "app.js"]
-```
-
-### Build and Test
-
-```bash
-# Build the image
-docker build -t advent-day1:latest .
-
-# Check image size
-docker images advent-day1:latest
-
-# Run the container
-docker run -p 8000:8000 advent-day1:latest
-
-# Test the application
-curl http://localhost:8000
-```
-
-## Explanation
-
-### Why This Matters
-
-Image size directly impacts:
-- **Deployment Speed**: Smaller images deploy faster across networks
-- **Storage Costs**: Less disk space and registry storage needed
-- **Security**: Fewer packages mean fewer vulnerabilities
-- **Build Times**: Smaller base images build faster
-
-### Key Optimization Techniques
-
-1. **Alpine Linux Base**: Uses musl libc instead of glibc, significantly reducing size
-2. **Multi-Stage Builds**: Separates build-time dependencies from runtime
-3. **Non-Root User**: Security best practice to limit container privileges
-4. **Minimal Layers**: Combines commands to reduce layer count
-5. **No Package Manager Cache**: Alpine doesn't include package indexes by default
-
-### Size Comparison
-
-| Approach | Image Size | Notes |
-|----------|-----------|-------|
-| python:3.12 | ~1000MB | Full Debian-based image |
-| python:3.12-slim | ~150MB | Debian with minimal packages |
-| python:3.12-alpine | ~50MB | Alpine Linux base |
-| Optimized Alpine | **~15MB** | Multi-stage with cleanup |
-
-## Result
-
-You should achieve:
-- ✅ Docker image under 25MB
-- ✅ Functional web server responding on port 8000
-- ✅ Container runs as non-root user
-- ✅ Fast build and startup times
-
-## Validation
-
-```bash
-# Check image size
-docker images advent-day1:latest --format "{{.Size}}"
-# Should show: ~15MB
-
-# Verify non-root user
-docker run --rm advent-day1:latest whoami
-# Should show: appuser
-
-# Test application
-curl http://localhost:8000
-# Should return: Hello from Advent of DevOps!
-```
+**Note**: Node.js Alpine images are **~60-70MB minimum** due to the Node.js runtime and V8 engine.
 
 ## Links
 
 - [Docker Multi-Stage Builds](https://docs.docker.com/build/building/multi-stage/)
 - [Alpine Linux Docker Images](https://hub.docker.com/_/alpine)
 - [Docker Best Practices](https://docs.docker.com/develop/dev-best-practices/)
-- [Python Docker Official Images](https://hub.docker.com/_/python)
-- [Node.js Docker Official Images](https://hub.docker.com/_/node)
+- [Go Docker Official Images](https://hub.docker.com/_/golang)
+- [Building Minimal Go Docker Images](https://chemidy.medium.com/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324)
+- [Scratch Base Images](https://docs.docker.com/develop/develop-images/baseimages/#create-a-simple-parent-image-using-scratch)
 
 ## Share Your Success
 
@@ -217,7 +320,8 @@ Completed this challenge? Share your achievement!
 
 **Tag [@thedevopsdaily](https://x.com/thedevopsdaily)** on X (formerly Twitter) with:
 - Your final image size
+- Which approach you used (Alpine or scratch)
 - Any additional optimizations you discovered
 - Screenshots of your running container
 
-Use hashtags: **#AdventOfDevOps #Docker #Day1**
+Use hashtags: **#AdventOfDevOps #Docker #Day1 #GoLang**


### PR DESCRIPTION
Closes #608

## Problem

The original Day 1 challenge required Docker images **under 25MB** using Python or Node.js, which is technically impossible:

- **Python Alpine images**: ~50-60MB minimum (requires Python interpreter + standard library)
- **Node.js Alpine images**: ~60-70MB minimum (requires Node.js runtime + V8 engine)
- Users reported they couldn't achieve the 25MB target despite following the solution

## Solution

Changed the primary example from Python/Node.js to **Go**, which compiles to static binaries:

### New Achievements:
- **Go + Alpine base**: ~15MB ✅
- **Go + scratch base**: ~7MB ✅
- **Sub-25MB target**: Now achievable!

### Why Go?

Go compiles to a **static binary** with zero runtime dependencies:
- No interpreter needed (Python/Node.js require ~50-60MB runtime)
- Single executable with all dependencies embedded
- Perfect for minimal Docker images

## Changes Made

### Primary Example (Go)

1. **Added Go source code** (`main.go`) - simple HTTP server
2. **Added two Dockerfile approaches**:
   - Alpine base (~15MB) with non-root user
   - Scratch base (~7MB) for absolute minimal size
3. **Documented build flags** for static compilation:
   ```bash
   CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-s -w'
   ```
4. **Added comprehensive size comparison table**

### Bonus Section (Python/Node.js)

Moved Python and Node.js examples to a "Bonus" section with **realistic size expectations**:
- Python: ~60MB (with clear note that 25MB is not achievable)
- Node.js: ~70MB (with clear note that 25MB is not achievable)

### Documentation Updates

- Updated excerpt and description to mention Go
- Added "Why Go for Minimal Images?" explanation
- Added build flags explanation section
- Updated validation steps
- Added scratch base documentation link
- Updated hashtags to include #GoLang

## Size Comparison

| Approach | Image Size | Achieves 25MB? |
|----------|-----------|----------------|
| golang:1.23 | ~800MB | ❌ |
| golang:1.23-alpine | ~300MB | ❌ |
| **Alpine + Go binary** | **~15MB** | **✅** |
| **Scratch + Go binary** | **~7MB** | **✅** |
| python:3.12-alpine | ~60MB | ❌ |
| node:20-alpine | ~70MB | ❌ |

## Testing

The new Go examples have been verified to produce:
- Alpine version: ~15MB image
- Scratch version: ~7MB image
- Both versions successfully serve HTTP requests
- Alpine version runs as non-root user

## Credit

Thanks to [@AlfredoPrograma](https://github.com/AlfredoPrograma) for:
- Identifying the issue with Python/Node.js size requirements
- Suggesting Go as the solution
- Providing a working Go example in the issue comments

## Related

- Issue #608
- User comment: https://github.com/The-DevOps-Daily/devops-daily/issues/608#issuecomment-2544681738