### PR TITLE
fix: Move Advent calendar date logic to client-side for static export

### DIFF
--- a/app/advent-of-devops/page.tsx
+++ b/app/advent-of-devops/page.tsx
@@ -2,12 +2,10 @@ import { getAllAdventDays, getAdventIndex } from '@/lib/advent';
 import { PostContent } from '@/components/post-content';
 import { InlineSponsors } from '@/components/inline-sponsors';
 import { AdventLandingClient } from '@/components/advent-landing-client';
+import { AdventHeroProgress } from '@/components/advent-hero-progress';
 import { Calendar, Trophy, Star, Sparkles, Target, Gift, ChevronRight } from 'lucide-react';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-
-// Force dynamic rendering to ensure current date is always evaluated fresh
-export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'Advent of DevOps - 25 Day Challenge | DevOps Daily',
@@ -43,11 +41,6 @@ export const metadata: Metadata = {
 export default async function AdventOfDevOpsPage() {
   const days = await getAllAdventDays();
   const indexContent = await getAdventIndex();
-
-  // Calculate progress (unlock based on December dates)
-  const today = new Date();
-  const isDecember = today.getMonth() === 11; // December is month 11
-  const currentDay = isDecember ? Math.min(today.getDate(), 25) : 25;
 
   return (
     <>
@@ -134,19 +127,8 @@ export default async function AdventOfDevOpsPage() {
               </a>
             </div>
 
-            {/* Progress Bar */}
-            <div className="mt-12 max-w-md mx-auto">
-              <div className="flex items-center justify-between text-sm mb-2">
-                <span className="text-muted-foreground">Community Progress</span>
-                <span className="font-medium text-primary">{currentDay} / 25 days</span>
-              </div>
-              <div className="h-3 bg-card border border-border rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-linear-to-r from-red-500 via-primary to-green-500 transition-all duration-1000 ease-out"
-                  style={{ width: `${(currentDay / 25) * 100}%` }}
-                />
-              </div>
-            </div>
+            {/* Progress Bar - Client Component */}
+            <AdventHeroProgress />
           </div>
         </div>
       </div>
@@ -162,7 +144,7 @@ export default async function AdventOfDevOpsPage() {
 
       {/* Challenges Grid with Progress Tracking */}
       <div id="challenges">
-        <AdventLandingClient days={days} currentDay={currentDay} />
+        <AdventLandingClient days={days} />
       </div>
 
       {/* Sponsors Section */}

--- a/components/advent-hero-progress.tsx
+++ b/components/advent-hero-progress.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function AdventHeroProgress() {
+  const [currentDay, setCurrentDay] = useState(25);
+
+  useEffect(() => {
+    const today = new Date();
+    const isDecember = today.getMonth() === 11; // December is month 11
+    const calculatedDay = isDecember ? Math.min(today.getDate(), 25) : 25;
+    setCurrentDay(calculatedDay);
+  }, []);
+
+  return (
+    <div className="mt-12 max-w-md mx-auto">
+      <div className="flex items-center justify-between text-sm mb-2">
+        <span className="text-muted-foreground">Community Progress</span>
+        <span className="font-medium text-primary">{currentDay} / 25 days</span>
+      </div>
+      <div className="h-3 bg-card border border-border rounded-full overflow-hidden">
+        <div
+          className="h-full bg-linear-to-r from-red-500 via-primary to-green-500 transition-all duration-1000 ease-out"
+          style={{ width: `${(currentDay / 25) * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/advent-landing-client.tsx
+++ b/components/advent-landing-client.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { AdventProgressProvider } from './advent-progress-provider';
 import { AdventProgressStats } from './advent-progress-stats';
 import { AdventCalendarGrid } from './advent-calendar-grid';
@@ -7,10 +8,19 @@ import type { AdventDay } from '@/lib/advent';
 
 interface AdventLandingClientProps {
   days: AdventDay[];
-  currentDay: number;
 }
 
-export function AdventLandingClient({ days, currentDay }: AdventLandingClientProps) {
+export function AdventLandingClient({ days }: AdventLandingClientProps) {
+  // Calculate current day on client side to avoid static build issues
+  const [currentDay, setCurrentDay] = useState(25);
+
+  useEffect(() => {
+    const today = new Date();
+    const isDecember = today.getMonth() === 11; // December is month 11
+    const calculatedDay = isDecember ? Math.min(today.getDate(), 25) : 25;
+    setCurrentDay(calculatedDay);
+  }, []);
+
   return (
     <AdventProgressProvider>
       {/* Progress Stats - sticky sidebar */}


### PR DESCRIPTION
## Problem

PR #649 introduced `dynamic = 'force-dynamic'` to fix the Advent calendar date unlocking, but this breaks the static export build:

```
Error: Page with `dynamic = "force-dynamic"` couldn't be exported. `output: "export"` requires all pages be renderable statically.
```

## Solution

Move the date calculation logic to client-side React components:

1. **Created `AdventHeroProgress` component** - Client component that calculates and displays the progress bar with current day
2. **Updated `AdventLandingClient`** - Now calculates `currentDay` internally using `useState` and `useEffect`
3. **Removed server-side date logic** - Removed `dynamic = 'force-dynamic'` and date calculation from the server page

## How It Works

- The page is statically exported with default state (day 25)
- On client-side mount, `useEffect` calculates the actual current day based on `new Date()`
- Progress bar and calendar grid update dynamically on the client
- Compatible with Next.js static export (`output: "export"`)

## Files Changed

- `app/advent-of-devops/page.tsx` - Removed server-side date logic, added client component import
- `components/advent-hero-progress.tsx` - New client component for hero progress bar
- `components/advent-landing-client.tsx` - Moved date calculation to client-side with hooks

Closes issue introduced by #649