### PR TITLE
fix: Hide header and footer when printing checklists

### DIFF
--- a/components/checklists/checklist-page-client.tsx
+++ b/components/checklists/checklist-page-client.tsx
@@ -64,19 +64,20 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
   const completedCount = checklist.items.filter(item => progress[item.id]).length;
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-4xl">
+    <div className="container mx-auto px-4 py-12 max-w-4xl print:py-0">
       {showConfetti && mounted && (
         <Confetti
           width={typeof window !== 'undefined' ? window.innerWidth : 0}
           height={typeof window !== 'undefined' ? window.innerHeight : 0}
           recycle={false}
           numberOfPieces={500}
+          className="print:hidden"
         />
       )}
 
       <Link
         href="/checklists"
-        className="inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline mb-6"
+        className="inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:underline mb-6 print:hidden"
       >
         <ArrowLeft className="w-4 h-4" />
         Back to all checklists
@@ -84,12 +85,12 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
 
       <div className="mb-8">
         <div className="flex flex-wrap items-center gap-2 mb-4">
-          <span className={`text-sm px-3 py-1 rounded-full font-semibold ${
+          <span className={`text-sm px-3 py-1 rounded-full font-semibold print:bg-gray-100 print:text-gray-900 ${
             categoryColors[checklist.category as keyof typeof categoryColors] || 'bg-gray-100 text-gray-700'
           }`}>
             {checklist.category}
           </span>
-          <span className={`text-sm px-3 py-1 rounded-full font-semibold ${
+          <span className={`text-sm px-3 py-1 rounded-full font-semibold print:bg-gray-100 print:text-gray-900 ${
             difficultyColors[checklist.difficulty]
           }`}>
             {checklist.difficulty.charAt(0).toUpperCase() + checklist.difficulty.slice(1)}
@@ -137,7 +138,7 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
         />
       </div>
 
-      <div className="mb-8">
+      <div className="mb-8 print:hidden">
         <ChecklistActions
           checklist={checklist}
           progress={progress}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import { EasterEggTerminal } from '@/components/easter-egg-terminal';
 
 export function Footer() {
   return (
-    <footer className="bg-linear-to-br from-background via-background to-muted/20 border-t border-border/50 relative overflow-hidden">
+    <footer className="bg-linear-to-br from-background via-background to-muted/20 border-t border-border/50 relative overflow-hidden print:hidden">
       {/* Background decorative elements */}
       <div className="absolute inset-0 opacity-30">
         <div className="absolute top-0 right-0 w-96 h-96 bg-linear-to-bl from-primary/5 to-purple-500/5 rounded-full blur-3xl" />

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -479,7 +479,7 @@ export function Header() {
   }, [mobileMenuOpen]);
 
   return (
-    <header className="sticky top-0 z-40 bg-background/95">
+    <header className="sticky top-0 z-40 bg-background/95 print:hidden">
       <nav className="container flex items-center justify-between p-4 mx-auto lg:px-8">
         {/* Logo */}
         <div className="flex lg:flex-1">


### PR DESCRIPTION
## Summary
Fixes the print functionality for checklist pages by hiding navigation and footer elements when printing.

## Changes Made

### Component Updates
- **Header** (`components/header.tsx`): Added `print:hidden` class to hide navigation during print
- **Footer** (`components/footer.tsx`): Added `print:hidden` class to hide footer during print
- **Checklist Page Client** (`components/checklists/checklist-page-client.tsx`):
  - Hide back link when printing
  - Hide confetti animation when printing
  - Hide action buttons (Export, Share, Print, Reset) when printing
  - Optimize badge colors for print (grayscale instead of color)
  - Remove vertical padding on container for better print layout

## Problem Solved

Before this fix, clicking the print button would show both the navigation menu and footer in the print preview/output, making printed checklists look cluttered and unprofessional.

## Print Output Now Includes

✅ Checklist title and description  
✅ Category and difficulty badges (print-optimized colors)  
✅ Estimated time and item count  
✅ Tags  
✅ Progress bar with completion stats  
✅ All checklist items with checkboxes  
✅ Code blocks and solutions  

## Print Output Excludes

❌ Navigation header  
❌ Footer  
❌ Back to all checklists link  
❌ Action buttons (Export, Share, Print, Reset)  
❌ Confetti animation  
❌ Additional resources section (to keep print concise)  

## Testing

Tested locally:
- [ ] Print preview shows only checklist content
- [ ] No header/footer visible in print output
- [ ] Badge colors are print-friendly (grayscale)
- [ ] Layout is clean and professional
- [ ] All checklist items are visible and properly formatted
- [ ] Code blocks print correctly

## Related Issue

Fixes #685 (Print Button Shows Menu and Footer)

## Screenshots

_Screenshots can be added after deployment to show before/after comparison_

---

**Note:** This PR addresses only the print functionality issue. Other improvements from issue #685 (SEO tags, og:image, filters, navigation changes) will be handled in separate PRs.