### PR TITLE
Fix missing breadcrumbs in DBMS simulator

### DIFF
--- a/components/games/dbms-simulator.tsx
+++ b/components/games/dbms-simulator.tsx
@@ -313,6 +313,19 @@ export default function DbmsSimulator() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 p-6">
         <div className="max-w-4xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+            <Link
+              href="/games"
+              className="hover:text-primary transition-colors flex items-center gap-1"
+            >
+              <Home className="w-4 h-4" />
+              Games
+            </Link>
+            <span>/</span>
+            <span className="text-foreground">Database Management Systems</span>
+          </nav>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -414,6 +427,19 @@ export default function DbmsSimulator() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 p-6">
         <div className="max-w-7xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+            <Link
+              href="/games"
+              className="hover:text-primary transition-colors flex items-center gap-1"
+            >
+              <Home className="w-4 h-4" />
+              Games
+            </Link>
+            <span>/</span>
+            <span className="text-foreground">Database Management Systems</span>
+          </nav>
+
           {/* Header */}
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -672,6 +698,19 @@ export default function DbmsSimulator() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 p-6">
         <div className="max-w-5xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+            <Link
+              href="/games"
+              className="hover:text-primary transition-colors flex items-center gap-1"
+            >
+              <Home className="w-4 h-4" />
+              Games
+            </Link>
+            <span>/</span>
+            <span className="text-foreground">Database Management Systems</span>
+          </nav>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -798,6 +837,19 @@ export default function DbmsSimulator() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 p-6">
         <div className="max-w-3xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+            <Link
+              href="/games"
+              className="hover:text-primary transition-colors flex items-center gap-1"
+            >
+              <Home className="w-4 h-4" />
+              Games
+            </Link>
+            <span>/</span>
+            <span className="text-foreground">Database Management Systems</span>
+          </nav>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -918,6 +970,19 @@ export default function DbmsSimulator() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 p-6">
       <div className="max-w-3xl mx-auto">
+        {/* Breadcrumb */}
+        <nav className="flex items-center space-x-2 text-sm text-muted-foreground mb-6">
+          <Link
+            href="/games"
+            className="hover:text-primary transition-colors flex items-center gap-1"
+          >
+            <Home className="w-4 h-4" />
+            Games
+          </Link>
+          <span>/</span>
+          <span className="text-foreground">Database Management Systems</span>
+        </nav>
+
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}


### PR DESCRIPTION
## Summary

Adds breadcrumb navigation to the DBMS simulator game to match the pattern used in other games.

## Changes

- Added breadcrumb navigation to all 5 game phases:
  - Intro phase
  - Explorer phase
  - Playground phase
  - Quiz phase
  - Complete phase
- Breadcrumbs display "Games / Database Management Systems" path
- Matches existing pattern from DDoS Simulator and other games
- Links back to `/games` page for easy navigation

## Related Issue

Resolves #682 - The DBMS simulator is missing breadcrumbs

## Testing

- ✅ Breadcrumbs added to all 5 phases of the game
- ✅ Navigation links work correctly
- ✅ Styling matches other games breadcrumbs
- ✅ Responsive design maintained

## Screenshots

The breadcrumbs now appear at the top of each phase, showing:
```
Games / Database Management Systems
```

With "Games" being a clickable link back to the games listing page.