### PR TITLE
Remove Print button from checklists

### DIFF
--- a/components/checklists/checklist-actions.tsx
+++ b/components/checklists/checklist-actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Download, Share2, RotateCcw, Printer, Check, Copy } from 'lucide-react';
+import { Download, Share2, RotateCcw, Check, Copy } from 'lucide-react';
 import { Checklist, ChecklistProgress, exportToMarkdown, downloadFile, generateShareUrl } from '@/lib/checklist-utils';
 
 interface ChecklistActionsProps {
@@ -27,10 +27,6 @@ export function ChecklistActions({ checklist, progress, onReset }: ChecklistActi
     } catch (error) {
       console.error('Failed to copy URL:', error);
     }
-  };
-
-  const handlePrint = () => {
-    window.print();
   };
 
   const handleReset = () => {
@@ -64,17 +60,8 @@ export function ChecklistActions({ checklist, progress, onReset }: ChecklistActi
           <>
             <Share2 className="w-4 h-4" />
             Share
-          </>
+        </>
         )}
-      </button>
-
-      <button
-        onClick={handlePrint}
-        className="flex items-center gap-2 px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded-lg transition-colors text-sm font-medium"
-        aria-label="Print checklist"
-      >
-        <Printer className="w-4 h-4" />
-        Print
       </button>
 
       <button


### PR DESCRIPTION
## Summary

Removes the Print button from checklist pages as it provides limited value and the printed output is not polished.

## Changes

- Removed Print button from `components/checklists/checklist-actions.tsx`
- Removed unused `Printer` icon import from lucide-react
- Removed `handlePrint()` function
- Kept Export and Share buttons which provide more value

## Benefits

- Cleaner, more focused UI
- Reduces button clutter in actions bar
- Users can still use browser native print (Cmd/Ctrl+P) if needed
- Maintains Export Markdown and Share functionality

## Testing

- ✅ Print button removed from all checklist pages
- ✅ Export and Share buttons still functional
- ✅ Reset button still works correctly
- ✅ Responsive layout maintained

## Related Issue

Resolves #697