### PR TITLE
fix: use relative paths and content hashing for cross-environment image caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ next-env.d.ts
 
 # Image generation cache
 .image-cache.json
+.png-cache.json
 package-lock.json
 
 # generated static markdown files


### PR DESCRIPTION
Resolves #468

**Problem:**
- Images regenerated on every build in different environments
- Cache used absolute paths (breaks across dev/CI/Docker)
- SVG→PNG conversion used file timestamps (breaks after git pull)

**Solution:**

1. **SVG Generation Script:**
   - Use relative paths for cache keys instead of absolute
   - Remove filesystem checks from fileExists when FORCE_REGENERATE
   - Cache now works across all environments

2. **PNG Conversion Script:**
   - Replace mtime-based checking with content hashing
   - Generate MD5 hash of SVG content
   - Only regenerate PNG when SVG content changes
   - Add separate .png-cache.json for PNG tracking

3. **Benefits:**
   - ✅ Consistent caching across dev/CI/Docker/Cloudflare
   - ✅ Content-based regeneration (not timestamp-based)
   - ✅ Faster incremental builds
   - ✅ No Git repo bloat (caches remain gitignored)
   - ✅ Only regenerate when content actually changes

**Technical Details:**
- Added getRelativePath() helper for cross-env paths
- Added generateSvgHash() for content-based comparison
- Both cache files (.image-cache.json, .png-cache.json) use relative paths
- Preserved --force flag behavior
