### PR TITLE
feat: Add interview questions to search (issue #782)

### DIFF
--- a/components/search-page-client.tsx
+++ b/components/search-page-client.tsx
@@ -23,6 +23,7 @@ import {
   Sparkles,
   ChevronDown,
   ListChecks,
+  MessageSquare,
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -72,6 +73,7 @@ const TYPE_ICONS: Record<string, React.ElementType> = {
   news: Newspaper,
   page: Home,
   checklist: ListChecks,
+  'interview-question': MessageSquare,
 };
 
 export function SearchPageClient() {

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -2,7 +2,7 @@ import Fuse from 'fuse.js';
 
 export interface SearchItem {
   id: string;
-  type: 'post' | 'guide' | 'exercise' | 'quiz' | 'game' | 'news' | 'page' | 'checklist';
+  type: 'post' | 'guide' | 'exercise' | 'quiz' | 'game' | 'news' | 'page' | 'checklist' | 'interview-question';
   title: string;
   description: string;
   url: string;
@@ -202,6 +202,7 @@ export const TYPE_LABELS: Record<string, string> = {
   news: 'News',
   page: 'Pages',
   checklist: 'Checklists',
+  'interview-question': 'Interview Questions',
 };
 
 export const TYPE_COLORS: Record<string, string> = {
@@ -213,6 +214,7 @@ export const TYPE_COLORS: Record<string, string> = {
   news: 'bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/20',
   page: 'bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20',
   checklist: 'bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20',
+  'interview-question': 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/20',
 };
 
 // Popular searches for "no results" state

--- a/scripts/generate-search-index.ts
+++ b/scripts/generate-search-index.ts
@@ -7,10 +7,11 @@ import { getAllExercises } from '../lib/exercises.js';
 import { getAllNews } from '../lib/news.js';
 import { getActiveGames } from '../lib/games.js';
 import { checklists } from '../content/checklists/index.js';
+import { interviewQuestions } from '../content/interview-questions/index.js';
 
 interface SearchItem {
   id: string;
-  type: 'post' | 'guide' | 'exercise' | 'quiz' | 'game' | 'news' | 'page' | 'checklist';
+  type: 'post' | 'guide' | 'exercise' | 'quiz' | 'game' | 'news' | 'page' | 'checklist' | 'interview-question';
   title: string;
   description: string;
   url: string;
@@ -119,12 +120,44 @@ const PAGES: SearchItem[] = [
     icon: '📑',
   },
   {
-    id: 'page-checklists',
+   id: 'page-checklists',
+   type: 'page',
+   title: 'Checklists',
+   description: 'Interactive DevOps and security checklists',
+   url: '/checklists',
+   icon: '✅',
+ },
+  {
+    id: 'page-interview-questions',
     type: 'page',
-    title: 'Checklists',
-    description: 'Interactive DevOps and security checklists',
-    url: '/checklists',
-    icon: '✅',
+    title: 'Interview Questions',
+    description: 'Practice DevOps interview questions by experience level',
+    url: '/interview-questions',
+    icon: '💬',
+  },
+  {
+    id: 'page-interview-questions-junior',
+    type: 'interview-question',
+    title: 'Junior Interview Questions',
+    description: 'Entry-level DevOps interview questions for beginners',
+    url: '/interview-questions/junior',
+    icon: '🌱',
+  },
+  {
+    id: 'page-interview-questions-mid',
+    type: 'interview-question',
+    title: 'Mid-Level Interview Questions',
+    description: 'Intermediate DevOps interview questions for experienced practitioners',
+    url: '/interview-questions/mid',
+    icon: '🚀',
+  },
+  {
+    id: 'page-interview-questions-senior',
+    type: 'interview-question',
+    title: 'Senior Interview Questions',
+    description: 'Advanced DevOps interview questions for senior engineers and architects',
+    url: '/interview-questions/senior',
+    icon: '🎯',
   },
 ];
 
@@ -275,6 +308,21 @@ async function generateSearchIndex() {
   }));
   searchIndex.push(...checklistItems);
   console.log(`  ✓ Added ${checklistItems.length} checklists`);
+
+  // Add interview questions
+  console.log('💬 Adding interview questions...');
+  const interviewItems: SearchItem[] = interviewQuestions.map((question) => ({
+    id: `interview-${question.slug}`,
+    type: 'interview-question',
+    title: question.title,
+    description: question.question,
+    url: `/interview-questions/${question.tier}`,
+    category: question.category,
+    tags: question.tags,
+    icon: '💬',
+  }));
+  searchIndex.push(...interviewItems);
+  console.log(`  ✓ Added ${interviewItems.length} interview questions`);
 
   // Calculate size
   const json = JSON.stringify(searchIndex);


### PR DESCRIPTION
Closes #782

Adds interview questions to the search index so users can find them when searching.

**Changes:**
- Added `interview-question` type to search system (`lib/search.ts`)
- Interview questions page added to static pages
- All 36 interview questions now indexed with title, question text, category, and tags
- Added MessageSquare icon for interview questions in search results

**Pre-merge checks:**
- ✅ `npm test` — 4422 tests passed
- ✅ `npm run og:validate` — passed (212 pre-existing warnings)