### PR TITLE
feat: Add server failure simulation to load balancer

### DIFF
--- a/components/games/load-balancer-simulator.tsx
+++ b/components/games/load-balancer-simulator.tsx
@@ -194,7 +194,7 @@ export default function LoadBalancerSimulator() {
   const totalRequests = servers.reduce((sum, s) => sum + s.requests, 0);
 
   // Pre-compute server Y positions for consistent line/dot placement
-  const serverYPositions = [20, 50, 80]; // top, middle, bottom as percentages
+  const serverYPositions = [18, 50, 82]; // top, middle, bottom as percentages
 
   return (
     <div className="w-full max-w-4xl mx-auto">
@@ -262,7 +262,7 @@ export default function LoadBalancerSimulator() {
           </div>
 
           {/* Visualization */}
-          <div className="relative h-72 bg-gradient-to-br from-slate-100 to-slate-50 dark:from-slate-800 dark:to-slate-900 rounded-xl overflow-hidden">
+          <div className="relative h-80 bg-gradient-to-br from-slate-100 to-slate-50 dark:from-slate-800 dark:to-slate-900 rounded-xl overflow-hidden">
             {/* Connection Lines */}
             <svg className="absolute inset-0 w-full h-full">
               {/* Users to Load Balancer */}
@@ -315,7 +315,7 @@ export default function LoadBalancerSimulator() {
             </div>
 
             {/* Servers (Right) - positioned to match serverYPositions */}
-            <div className="absolute right-[4%] top-0 bottom-0 flex flex-col justify-around py-6 z-10">
+            <div className="absolute right-[4%] top-0 bottom-0 flex flex-col justify-around py-4 z-10">
               {servers.map((server, idx) => (
                 <div
                   key={server.id}
@@ -337,7 +337,7 @@ export default function LoadBalancerSimulator() {
                       <XCircle className="h-9 w-9 text-white" />
                     )}
                   </div>
-                  <div className={`mt-2 text-sm font-semibold ${!server.healthy ? 'text-red-500' : ''}`}>
+                  <div className={`mt-1 text-xs font-semibold ${!server.healthy ? 'text-red-500' : ''}`}>
                     {server.name}
                   </div>
                 </div>


### PR DESCRIPTION
Closes #794

Adds the ability to simulate server failures in the load balancer visualization, demonstrating how different algorithms handle outages.

## Features

- **Click servers** to toggle between healthy/offline states
- **Visual feedback**: grayed-out icons, dashed lines, red borders for failed servers
- **Failed requests animation**: red dots bounce back from load balancer
- **Stats panel**: shows failed request count alongside successful ones

## Algorithm Behaviors

| Algorithm | Failure Handling |
|-----------|------------------|
| Round Robin | Skips unhealthy servers, continues rotation with healthy ones |
| Least Connections | Only considers healthy servers when choosing |
| IP Hash | Requests fail if assigned server is down (demonstrates sticky session problem) |
| Random | Only picks from healthy servers |

## How to Test

1. Start the simulation
2. Click any server to take it offline
3. Watch how traffic redistributes to healthy servers
4. Try IP Hash with the assigned server down to see requests fail
5. Bring servers back online to restore normal operation