### PR TITLE
feat: Tools menu dropdown expands vertically

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -308,9 +308,12 @@ function DropdownMenu({
           style={{ pointerEvents: 'auto' }}
         >
           {/* Menu Content */}
-          <div className="bg-background/95 backdrop-blur-xl border border-border/80 rounded-xl shadow-2xl shadow-black/20 dark:shadow-black/50 overflow-y-auto w-[420px] max-w-[90vw] max-h-[calc(100vh-120px)] ring-1 ring-white/10">
-            <div className="p-6 bg-linear-to-br from-background/50 to-muted/20">
-              <div className="grid grid-cols-1 gap-6">
+          <div className={cn(
+            'bg-background/95 backdrop-blur-xl border border-border/80 rounded-xl shadow-2xl shadow-black/20 dark:shadow-black/50 ring-1 ring-white/10',
+            sections.length > 1 ? 'w-[680px] max-w-[90vw]' : 'w-[340px] max-w-[90vw]'
+          )}>
+            <div className="p-5 bg-linear-to-br from-background/50 to-muted/20">
+              <div className={cn('grid gap-6', sections.length > 1 ? 'grid-cols-2' : 'grid-cols-1')}>
                 {sections.map((section, sectionIndex) => (
                   <div key={sectionIndex} className="space-y-3">
                     {/* Section Header */}


### PR DESCRIPTION
Closes #785

Previously the Tools dropdown used scroll which was tricky - scrolling too much caused the menu to close.

Now uses a 2-column grid layout that expands horizontally, similar to DigitalOcean's approach.

## Changes
- Removed `overflow-y-auto` and `max-h` scroll constraints from dropdown
- Dynamic 2-column layout for menus with multiple sections
- Single-column layout for menus with one section
- Adjusted width to accommodate side-by-side sections (680px for multi-section, 340px for single)