### PR TITLE
feat: Add SAST Tools guide for DevSecOps roadmap

### DIFF
--- a/app/roadmap/devsecops/page.tsx
+++ b/app/roadmap/devsecops/page.tsx
@@ -165,13 +165,14 @@ const milestones: DevSecOpsMilestone[] = [
         estimatedHours: 25,
         link: '/guides/secure-coding-practices',
       },
-      {
-        name: 'SAST Tools',
-        description: 'Static Application Security Testing with SonarQube, Semgrep, or CodeQL',
-        icon: FileSearch,
-        priority: 'essential',
-        estimatedHours: 20,
-      },
+     {
+       name: 'SAST Tools',
+       description: 'Static Application Security Testing with SonarQube, Semgrep, or CodeQL',
+       icon: FileSearch,
+       priority: 'essential',
+       estimatedHours: 20,
+       link: '/guides/sast-tools',
+     },
       {
         name: 'Dependency Scanning',
         description: 'Find vulnerable dependencies with Dependabot, Snyk, or OWASP Dependency-Check',

--- a/content/guides/sast-tools/01-sast-fundamentals.md
+++ b/content/guides/sast-tools/01-sast-fundamentals.md
@@ -1,0 +1,345 @@
+---
+title: 'SAST Fundamentals'
+description: 'Understand how static analysis works, different analysis techniques, and the limitations of SAST tools.'
+---
+
+Before diving into specific tools, you need to understand how static analysis works and what it can (and cannot) do. This knowledge helps you configure tools effectively, interpret results accurately, and set realistic expectations.
+
+## How Static Analysis Works
+
+Static analysis examines source code without executing it. The analyzer builds a representation of your code—typically an Abstract Syntax Tree (AST)—and then applies rules to detect patterns that indicate vulnerabilities.
+
+### The Analysis Pipeline
+
+```
+Source Code → Parsing → AST → Analysis Engine → Rules → Findings
+     │           │         │          │            │         │
+     ▼           ▼         ▼          ▼            ▼         ▼
+  .java,     Lexical    Tree      Data flow,   Security   Vulnerabilities
+  .py, .js   tokens     structure  taint,      patterns   with severity
+                                   control flow
+```
+
+**Step by step:**
+
+1. **Parsing** — Convert source code into tokens, then build an AST
+2. **Semantic Analysis** — Resolve types, scopes, and symbol references
+3. **Control Flow Analysis** — Map possible execution paths
+4. **Data Flow Analysis** — Track how data moves through the program
+5. **Pattern Matching** — Apply security rules to find vulnerabilities
+6. **Reporting** — Generate findings with severity, location, and remediation
+
+## Types of Static Analysis
+
+Different tools use different analysis techniques. Understanding these helps you choose the right tool.
+
+### Pattern Matching (Syntactic Analysis)
+
+The simplest approach: look for code patterns that match known-bad signatures.
+
+```python
+# Rule: Detect hardcoded passwords
+# Pattern: variable named "password" assigned a string literal
+
+password = "secretpassword123"  # FLAGGED: Hardcoded credential
+
+api_key = "AKIA1234567890ABCDEF"  # FLAGGED: AWS key pattern
+```
+
+**Pros:**
+- Fast execution (simple string/regex matching)
+- Easy to write custom rules
+- Low false positive rate for simple patterns
+
+**Cons:**
+- Misses complex vulnerabilities
+- Easy to bypass (variable renaming, string concatenation)
+- No understanding of data flow
+
+**Tools:** Semgrep (primarily), grep-based custom scripts
+
+### Data Flow Analysis
+
+Tracks how data moves from sources (user input) to sinks (dangerous functions).
+
+```python
+# Data flow analysis tracks this:
+
+def process_user(request):
+    username = request.get('username')     # SOURCE: User input
+    
+    # Data flows through transformations...
+    processed = username.strip()
+    lower_name = processed.lower()
+    
+    # Eventually reaches a dangerous sink
+    query = f"SELECT * FROM users WHERE name = '{lower_name}'"  # SINK: SQL
+    cursor.execute(query)  # FLAGGED: Tainted data reaches SQL sink
+```
+
+The analyzer traces the "taint" from `request.get()` through all transformations to `cursor.execute()`. If no sanitization occurs, it reports a SQL injection.
+
+**Pros:**
+- Catches complex vulnerabilities across function boundaries
+- Understands when data is sanitized
+- Fewer false negatives than pattern matching
+
+**Cons:**
+- More false positives (sanitizers not recognized)
+- Slower analysis (must trace all paths)
+- Requires language-specific implementation
+
+**Tools:** CodeQL, Fortify, Checkmarx
+
+### Taint Tracking
+
+A specialized form of data flow analysis that specifically tracks "tainted" (untrusted) data.
+
+```javascript
+// Taint tracking example
+
+// Configuration defines:
+// - Sources: req.body, req.query, req.params
+// - Sinks: eval(), exec(), innerHTML
+// - Sanitizers: DOMPurify.sanitize(), escapeHtml()
+
+function handleRequest(req, res) {
+    const userInput = req.body.content;    // TAINTED
+    
+    // Option A: No sanitization - VULNERABLE
+    document.innerHTML = userInput;         // FLAGGED: XSS
+    
+    // Option B: With sanitization - SAFE
+    const clean = DOMPurify.sanitize(userInput);  // Taint removed
+    document.innerHTML = clean;             // OK: Input was sanitized
+}
+```
+
+**Pros:**
+- Precise tracking of untrusted data
+- Understands sanitization functions
+- Can trace across file boundaries
+
+**Cons:**
+- Must configure sources, sinks, and sanitizers
+- Cannot track through reflection or dynamic code
+- Complex interprocedural analysis is slow
+
+**Tools:** CodeQL, SonarQube (advanced rules)
+
+### Control Flow Analysis
+
+Examines the possible execution paths through your code.
+
+```python
+def process_payment(user, amount):
+    # Control flow analysis builds this graph:
+    #
+    #     ┌──────────────────┐
+    #     │   Start          │
+    #     └────────┬─────────┘
+    #              │
+    #     ┌────────▼─────────┐
+    #     │ user.is_admin?   │
+    #     └───────┬──┬───────┘
+    #         yes │  │ no
+    #     ┌───────▼┐ │
+    #     │ bypass │ │
+    #     │ check  │ │
+    #     └───┬────┘ │
+    #         │  ┌───▼────────┐
+    #         │  │ verify()   │
+    #         │  └───┬────────┘
+    #         │      │
+    #     ┌───▼──────▼────────┐
+    #     │ execute_payment() │
+    #     └───────────────────┘
+    
+    if user.is_admin:
+        pass  # Admin bypass - potential issue!
+    else:
+        if not verify_payment(amount):
+            raise PaymentError("Verification failed")
+    
+    execute_payment(user, amount)  # Reached on both paths
+```
+
+Control flow analysis can detect:
+- Dead code (unreachable paths)
+- Missing authorization checks on certain paths
+- Exception handling gaps
+
+## Understanding SAST Limitations
+
+SAST tools are powerful but not perfect. Understanding their limitations helps you use them effectively.
+
+### False Positives
+
+A false positive is when the tool reports a vulnerability that is not actually exploitable.
+
+```python
+# Common false positive: Framework-provided sanitization
+
+from django.db import connection
+
+def search_users(request):
+    name = request.GET.get('name')
+    
+    # Django's parameterized queries are safe, but some tools still flag this
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT * FROM users WHERE name = %s",  # Safe: parameterized
+            [name]
+        )
+```
+
+**Managing false positives:**
+
+1. **Tune your rules** — Adjust sensitivity settings
+2. **Add suppression comments** — Mark known false positives
+3. **Configure sanitizers** — Tell the tool about your framework
+4. **Review regularly** — Some "false positives" are actually true issues
+
+### False Negatives
+
+A false negative is when the tool misses a real vulnerability.
+
+```python
+# SAST tools struggle with dynamic code
+
+def execute_dynamic(request):
+    func_name = request.GET.get('action')
+    
+    # Dynamic function lookup - hard to analyze statically
+    func = getattr(my_module, func_name)
+    func()  # Potential command injection, but SAST may miss it
+
+# Also hard to detect:
+# - Vulnerabilities in third-party libraries (SAST only sees your code)
+# - Business logic flaws (tool doesn't understand your requirements)
+# - Configuration issues (SAST analyzes code, not config files)
+```
+
+### Analysis Boundaries
+
+SAST tools have limits on what they can analyze:
+
+| Can Analyze | Cannot Analyze |
+|-------------|----------------|
+| Source code you provide | Binary dependencies |
+| Known frameworks | Custom frameworks |
+| Direct function calls | Reflection/dynamic dispatch |
+| Compile-time values | Runtime configurations |
+| Code paths | Business logic correctness |
+
+## Choosing the Right Analysis Depth
+
+Different tools offer different tradeoffs:
+
+| Tool Type | Speed | Accuracy | Setup Effort |
+|-----------|-------|----------|-------------|
+| Pattern matching (Semgrep) | Fast | Medium | Low |
+| Data flow (SonarQube) | Medium | High | Medium |
+| Semantic analysis (CodeQL) | Slow | Highest | High |
+
+**For most teams, a layered approach works best:**
+
+1. **IDE/Pre-commit** — Fast pattern matching (Semgrep)
+2. **CI Pipeline** — Comprehensive analysis (SonarQube)
+3. **Weekly/Deep Scans** — Semantic analysis (CodeQL) for critical repos
+
+## SAST vs. Other Security Testing
+
+SAST is one tool in your security arsenal:
+
+| Type | When | What It Finds | Limitations |
+|------|------|---------------|-------------|
+| **SAST** | Compile-time | Code vulnerabilities | Misses runtime/config issues |
+| **DAST** | Runtime | Deployment vulnerabilities | Needs running app, slow |
+| **SCA** | Build-time | Vulnerable dependencies | Only known CVEs |
+| **IAST** | Runtime | Runtime code paths | Requires instrumentation |
+| **Secrets Scanning** | Commit-time | Leaked credentials | Only known patterns |
+
+**DAST (Dynamic Application Security Testing)** tests the running application from the outside—like an attacker would. It catches issues SAST misses (misconfigured servers, deployment issues) but requires a deployed environment.
+
+**SCA (Software Composition Analysis)** scans your dependencies for known vulnerabilities. SAST only analyzes your code, not the libraries you use.
+
+## Integrating SAST Into Your Workflow
+
+For maximum effectiveness, integrate SAST at multiple points:
+
+### 1. Developer IDE
+
+Catch issues as code is written:
+
+```
+Developer writes code → IDE plugin highlights issue → Immediate fix
+```
+
+**Benefits:** Fastest feedback, easiest to fix
+**Challenge:** Must keep IDE plugins updated
+
+### 2. Pre-commit Hooks
+
+Prevent vulnerable code from being committed:
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+
+semgrep --config=p/security-audit --error .
+if [ \$? -ne 0 ]; then
+    echo "Security issues detected. Please fix before committing."
+    exit 1
+fi
+```
+
+**Benefits:** Prevents issues from entering codebase
+**Challenge:** Can slow down commits
+
+### 3. CI/CD Pipeline
+
+Run comprehensive scans on every pull request:
+
+```yaml
+# GitHub Actions example
+security-scan:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - name: Run SAST
+      run: |
+        sonar-scanner \\
+          -Dsonar.projectKey=my-project \\
+          -Dsonar.sources=. \\
+          -Dsonar.host.url=\${{ secrets.SONAR_URL }}
+```
+
+**Benefits:** Catches issues before merge, detailed reports
+**Challenge:** Adds time to CI pipeline
+
+### 4. Scheduled Scans
+
+Run deep analysis periodically:
+
+```yaml
+# Weekly CodeQL scan
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # Every Sunday at 3 AM
+```
+
+**Benefits:** Catches issues introduced by dependency updates
+**Challenge:** Delayed feedback
+
+## Key Takeaways
+
+Before proceeding to specific tools, remember:
+
+1. **No single tool catches everything** — Use SAST alongside DAST, SCA, and manual review
+2. **Tune for your stack** — Configure tools to understand your frameworks and sanitizers
+3. **Start with high-confidence rules** — Reduce false positives to build developer trust
+4. **Shift left gradually** — Add IDE plugins and pre-commit hooks once CI integration is stable
+5. **Treat findings as tech debt** — Track, prioritize, and fix systematically
+
+Now let's get hands-on with SonarQube, Semgrep, and CodeQL.

--- a/content/guides/sast-tools/02-sonarqube.md
+++ b/content/guides/sast-tools/02-sonarqube.md
@@ -1,0 +1,458 @@
+---
+title: 'SonarQube'
+description: 'Set up SonarQube for comprehensive code quality and security analysis. Learn configuration, quality gates, and CI/CD integration.'
+---
+
+SonarQube is an open-source platform for continuous code quality and security inspection. It analyzes source code for bugs, vulnerabilities, and code smells across 30+ programming languages, making it a popular choice for enterprise DevSecOps pipelines.
+
+## SonarQube Architecture
+
+SonarQube consists of three main components:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  SonarScanner   │ ───▶ │  SonarQube     │ ───▶ │    Database     │
+│  (CI Runner)    │     │  Server        │     │  (PostgreSQL)   │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+     Analyzes            Processes               Stores
+     source code         results                 history
+```
+
+- **SonarScanner** — Runs in your CI/CD pipeline, analyzes code, sends results to server
+- **SonarQube Server** — Web interface, API, rule engine, and compute engine
+- **Database** — PostgreSQL, Oracle, or SQL Server (not embedded H2 for production)
+
+## Setting Up SonarQube with Docker
+
+The fastest way to get started is with Docker:
+
+```bash
+# Create a network for SonarQube and PostgreSQL
+docker network create sonarnet
+
+# Start PostgreSQL database
+docker run -d --name sonar-postgres \\
+  --network sonarnet \\
+  -e POSTGRES_USER=sonar \\
+  -e POSTGRES_PASSWORD=sonar_password \\
+  -e POSTGRES_DB=sonarqube \\
+  -v sonar_postgres_data:/var/lib/postgresql/data \\
+  postgres:15-alpine
+
+# Start SonarQube server
+docker run -d --name sonarqube \\
+  --network sonarnet \\
+  -p 9000:9000 \\
+  -e SONAR_JDBC_URL=jdbc:postgresql://sonar-postgres:5432/sonarqube \\
+  -e SONAR_JDBC_USERNAME=sonar \\
+  -e SONAR_JDBC_PASSWORD=sonar_password \\
+  -v sonar_data:/opt/sonarqube/data \\
+  -v sonar_extensions:/opt/sonarqube/extensions \\
+  -v sonar_logs:/opt/sonarqube/logs \\
+  sonarqube:lts-community
+```
+
+**Important:** Wait 1-2 minutes for SonarQube to initialize, then access `http://localhost:9000`.
+
+Default credentials: `admin` / `admin` (change immediately after first login).
+
+### Docker Compose Setup
+
+For a more maintainable setup, use Docker Compose:
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  sonarqube:
+    image: sonarqube:lts-community
+    container_name: sonarqube
+    depends_on:
+      - db
+    ports:
+      - "9000:9000"
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonarqube
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar_password
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  db:
+    image: postgres:15-alpine
+    container_name: sonar-postgres
+    environment:
+      POSTGRES_USER: sonar
+      POSTGRES_PASSWORD: sonar_password
+      POSTGRES_DB: sonarqube
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+
+volumes:
+  sonarqube_data:
+  sonarqube_extensions:
+  sonarqube_logs:
+  postgresql_data:
+```
+
+Start with `docker compose up -d`.
+
+## Configuring Your First Project
+
+### Step 1: Create a Project in SonarQube
+
+1. Log into SonarQube at `http://localhost:9000`
+2. Click **Create Project** > **Manually**
+3. Enter a project key (e.g., `my-webapp`) and display name
+4. Choose **Locally** for the analysis method (for initial setup)
+5. Generate a token and save it securely
+
+### Step 2: Create sonar-project.properties
+
+In your project root, create a configuration file:
+
+```properties
+# sonar-project.properties
+
+# Required: Unique project identifier
+sonar.projectKey=my-webapp
+
+# Optional but recommended
+sonar.projectName=My Web Application
+sonar.projectVersion=1.0.0
+
+# Source code location (relative to this file)
+sonar.sources=src
+
+# Test code location
+sonar.tests=tests
+
+# Exclude files from analysis
+sonar.exclusions=**/node_modules/**,**/vendor/**,**/*.min.js
+
+# Language-specific settings (for Python example)
+sonar.python.version=3.11
+
+# Coverage report location (if using coverage tools)
+sonar.python.coverage.reportPaths=coverage.xml
+```
+
+### Step 3: Run the Scanner
+
+Install and run SonarScanner:
+
+```bash
+# Install SonarScanner (macOS)
+brew install sonar-scanner
+
+# Or download from sonarqube.org and add to PATH
+
+# Run the scan
+sonar-scanner \\
+  -Dsonar.host.url=http://localhost:9000 \\
+  -Dsonar.token=your_generated_token
+```
+
+After the scan completes, view results in the SonarQube web interface.
+
+## Understanding SonarQube Metrics
+
+SonarQube categorizes issues into several types:
+
+### Issue Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Bug** | Code that is demonstrably wrong | Null pointer dereference |
+| **Vulnerability** | Security weakness | SQL injection, XSS |
+| **Code Smell** | Maintainability issue | Duplicate code, long methods |
+| **Security Hotspot** | Needs manual review | Hardcoded IP address |
+
+### Severity Levels
+
+| Severity | Description |
+|----------|-------------|
+| **Blocker** | Must be fixed immediately |
+| **Critical** | High impact, fix soon |
+| **Major** | Significant issue |
+| **Minor** | Low impact |
+| **Info** | Informational only |
+
+### Key Metrics
+
+```
+┌───────────────────────────────────────────────┐
+│              Quality Gate: PASSED               │
+├───────────────────────────────────────────────┤
+│  Bugs: 3          Vulnerabilities: 1            │
+│  Code Smells: 47  Security Hotspots: 5          │
+├───────────────────────────────────────────────┤
+│  Coverage: 78%    Duplications: 2.3%            │
+└───────────────────────────────────────────────┘
+```
+
+- **Coverage** — Percentage of code covered by tests
+- **Duplications** — Percentage of duplicated code blocks
+- **Technical Debt** — Estimated time to fix all code smells
+
+## Quality Gates
+
+Quality Gates define the minimum quality standards for your project. If code fails the gate, the build should fail.
+
+### Default Quality Gate
+
+SonarQube's default "Sonar way" quality gate requires:
+
+- No new bugs
+- No new vulnerabilities
+- All security hotspots reviewed
+- Code coverage on new code >= 80%
+- Duplications on new code < 3%
+
+### Creating Custom Quality Gates
+
+1. Go to **Quality Gates** in the SonarQube UI
+2. Click **Create**
+3. Add conditions:
+
+```
+Condition: Coverage on New Code
+Operator: is less than
+Value: 80%
+Status: Error
+```
+
+Example custom quality gate for security-focused projects:
+
+| Condition | Operator | Value | Status |
+|-----------|----------|-------|--------|
+| New Bugs | is greater than | 0 | Error |
+| New Vulnerabilities | is greater than | 0 | Error |
+| New Security Hotspots Reviewed | is less than | 100% | Error |
+| New Code Coverage | is less than | 70% | Warning |
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/sonarqube.yml
+name: SonarQube Analysis
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sonarqube:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for blame information
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies and run tests
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+          pytest --cov=src --cov-report=xml
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+```
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+sonarqube-check:
+  stage: test
+  image: sonarsource/sonar-scanner-cli:latest
+  variables:
+    SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"
+    GIT_DEPTH: "0"
+  cache:
+    key: "${CI_JOB_NAME}"
+    paths:
+      - .sonar/cache
+  script:
+    - sonar-scanner
+        -Dsonar.projectKey=${CI_PROJECT_PATH_SLUG}
+        -Dsonar.host.url=${SONAR_HOST_URL}
+        -Dsonar.token=${SONAR_TOKEN}
+  allow_failure: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+### Jenkins Pipeline
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent any
+    
+    environment {
+        SONAR_TOKEN = credentials('sonar-token')
+    }
+    
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+        
+        stage('Build & Test') {
+            steps {
+                sh 'mvn clean verify'
+            }
+        }
+        
+        stage('SonarQube Analysis') {
+            steps {
+                withSonarQubeEnv('SonarQube') {
+                    sh 'mvn sonar:sonar'
+                }
+            }
+        }
+        
+        stage('Quality Gate') {
+            steps {
+                timeout(time: 5, unit: 'MINUTES') {
+                    waitForQualityGate abortPipeline: true
+                }
+            }
+        }
+    }
+}
+```
+
+## Security Rules Deep Dive
+
+SonarQube includes extensive security rules based on OWASP, CWE, and SANS standards.
+
+### Vulnerability Categories
+
+| Category | CWE | Example Rule |
+|----------|-----|-------------|
+| Injection | CWE-89 | SQL queries should not be vulnerable to injection |
+| XSS | CWE-79 | HTTP responses should not be vulnerable to XSS |
+| CSRF | CWE-352 | Server-side requests should not be vulnerable to forging |
+| Hardcoded Secrets | CWE-798 | Credentials should not be hardcoded |
+| Weak Crypto | CWE-327 | Cryptographic algorithms should be secure |
+
+### Viewing Security Reports
+
+1. Navigate to your project in SonarQube
+2. Click **Security Reports** in the left menu
+3. View reports by:
+   - **OWASP Top 10** — Categorized by OWASP 2021 risks
+   - **CWE Top 25** — Most dangerous software weaknesses
+   - **Security Hotspots** — Code requiring manual security review
+
+### Customizing Security Rules
+
+```
+Administration > Quality Profiles > [Your Profile] > Activate More Rules
+```
+
+Filter by:
+- **Tag:** security, vulnerability, cwe-top-25
+- **Type:** Vulnerability, Security Hotspot
+- **Severity:** Blocker, Critical
+
+## Best Practices
+
+### 1. Start with the Default Quality Gate
+
+SonarQube's "Sonar way" gate is well-calibrated. Customize only after understanding your project's needs.
+
+### 2. Focus on New Code
+
+Don't try to fix all legacy issues at once. SonarQube's "Clean as You Code" approach focuses on keeping new code clean.
+
+### 3. Review Security Hotspots Regularly
+
+Hotspots are not confirmed vulnerabilities—they require human judgment. Schedule weekly reviews.
+
+### 4. Integrate with Pull Requests
+
+Block merges that fail the quality gate. This prevents new vulnerabilities from entering the main branch.
+
+### 5. Exclude Generated Code
+
+Don't waste time analyzing auto-generated files:
+
+```properties
+# sonar-project.properties
+sonar.exclusions=**/generated/**,**/migrations/**,**/*.min.js
+```
+
+## SonarQube Editions
+
+| Feature | Community | Developer | Enterprise |
+|---------|-----------|-----------|------------|
+| Price | Free | Paid | Paid |
+| Languages | 19+ | 24+ | 30+ |
+| Branch Analysis | Main only | All branches | All branches |
+| PR Decoration | No | Yes | Yes |
+| SAST Depth | Basic | Advanced | Advanced |
+| Portfolio Mgmt | No | No | Yes |
+
+Community Edition is sufficient for most open-source projects. Developer Edition adds branch analysis and PR integration essential for enterprise workflows.
+
+## Troubleshooting
+
+### Common Issues
+
+**Scanner cannot connect to server:**
+```bash
+# Check server is running
+curl -s http://localhost:9000/api/system/status | jq
+
+# Verify token is valid
+curl -u your_token: http://localhost:9000/api/projects/search
+```
+
+**Out of memory during analysis:**
+```bash
+# Increase scanner memory
+export SONAR_SCANNER_OPTS="-Xmx2048m"
+sonar-scanner
+```
+
+**Analysis takes too long:**
+```properties
+# Limit scope in sonar-project.properties
+sonar.exclusions=**/test/**,**/docs/**
+sonar.cpd.exclusions=**/test/**
+```
+
+## Key Takeaways
+
+1. **SonarQube provides comprehensive analysis** — Bugs, vulnerabilities, code smells, and coverage in one platform
+2. **Quality Gates enforce standards** — Block merges that don't meet your security requirements
+3. **CI/CD integration is essential** — Automate analysis on every commit
+4. **Focus on new code** — Don't get overwhelmed by legacy issues
+5. **Review Security Hotspots** — These require human judgment, not automated fixes
+
+Next, we'll explore Semgrep for fast, customizable security scanning.

--- a/content/guides/sast-tools/03-semgrep.md
+++ b/content/guides/sast-tools/03-semgrep.md
@@ -1,0 +1,451 @@
+---
+title: 'Semgrep'
+description: 'Learn Semgrep for fast, customizable security scanning. Write custom rules, use the registry, and integrate into your CI/CD pipeline.'
+---
+
+Semgrep is a fast, open-source static analysis tool that excels at pattern matching across codebases. Unlike tools that require complex setup, Semgrep runs quickly with minimal configuration—making it ideal for pre-commit hooks and rapid CI feedback.
+
+## Why Semgrep?
+
+Semgrep fills a unique niche:
+
+| Feature | Semgrep | Traditional SAST |
+|---------|---------|------------------|
+| Setup time | Minutes | Hours/Days |
+| Scan speed | Fast (pattern matching) | Slower (deep analysis) |
+| Custom rules | Easy (YAML) | Complex (proprietary) |
+| False positives | Lower (precise patterns) | Higher |
+| Analysis depth | Pattern + data flow | Full data flow |
+
+**Best for:**
+- Pre-commit hooks (fast feedback)
+- Enforcing coding standards
+- Custom security rules for your frameworks
+- Catching common vulnerability patterns
+
+## Installation
+
+```bash
+# macOS
+brew install semgrep
+
+# pip (any platform)
+pip install semgrep
+
+# Docker
+docker run -v "${PWD}:/src" semgrep/semgrep semgrep --config=auto /src
+```
+
+Verify installation:
+
+```bash
+semgrep --version
+# semgrep 1.56.0
+```
+
+## Running Your First Scan
+
+Semgrep can auto-detect your languages and apply relevant rules:
+
+```bash
+# Scan current directory with auto-detected rules
+semgrep --config=auto .
+
+# Use specific rule packs
+semgrep --config=p/security-audit .
+semgrep --config=p/owasp-top-ten .
+semgrep --config=p/python .
+
+# Combine multiple configs
+semgrep --config=p/security-audit --config=p/secrets .
+```
+
+### Output Formats
+
+```bash
+# Default: human-readable
+semgrep --config=auto .
+
+# JSON for CI/CD processing
+semgrep --config=auto --json .
+
+# SARIF for GitHub Code Scanning
+semgrep --config=auto --sarif > results.sarif
+
+# JUnit XML for test reporting
+semgrep --config=auto --junit-xml > results.xml
+```
+
+## Semgrep Rule Registry
+
+Semgrep maintains a curated registry of rules at [semgrep.dev/explore](https://semgrep.dev/explore).
+
+### Popular Rule Packs
+
+| Pack | Description | Rules |
+|------|-------------|-------|
+| `p/security-audit` | Comprehensive security rules | 500+ |
+| `p/owasp-top-ten` | OWASP Top 10 vulnerabilities | 100+ |
+| `p/secrets` | Hardcoded secrets detection | 50+ |
+| `p/ci` | Rules optimized for CI (high confidence) | 200+ |
+| `p/python` | Python-specific rules | 150+ |
+| `p/javascript` | JavaScript/TypeScript rules | 150+ |
+| `p/java` | Java rules | 100+ |
+
+```bash
+# See all available rules in a pack
+semgrep --config=p/security-audit --dry-run .
+```
+
+## Writing Custom Rules
+
+Semgrep rules are written in YAML. The pattern syntax is similar to the target language, making rules intuitive to write.
+
+### Basic Rule Structure
+
+```yaml
+# my-rules/hardcoded-secrets.yaml
+rules:
+  - id: hardcoded-api-key
+    patterns:
+      - pattern: $VAR = "AKIA..."
+    message: "Hardcoded AWS access key detected"
+    severity: ERROR
+    languages:
+      - python
+      - javascript
+    metadata:
+      category: security
+      cwe: "CWE-798"
+      owasp: "A07:2021 - Identification and Authentication Failures"
+```
+
+Run your custom rule:
+
+```bash
+semgrep --config=my-rules/hardcoded-secrets.yaml .
+```
+
+### Pattern Syntax
+
+Semgrep patterns look like the code they match:
+
+```yaml
+# Match any eval() call
+pattern: eval(...)
+
+# Match specific function with arguments
+pattern: subprocess.call($CMD, shell=True)
+
+# Match string concatenation in SQL
+pattern: cursor.execute("..." + $VAR + "...")
+```
+
+**Metavariables:**
+- `$VAR` — Matches any single expression
+- `$...ARGS` — Matches zero or more arguments
+- `$_` — Matches anything (wildcard)
+
+### Pattern Operators
+
+#### pattern-either (OR)
+
+Match any of several patterns:
+
+```yaml
+rules:
+  - id: dangerous-exec
+    pattern-either:
+      - pattern: eval($X)
+      - pattern: exec($X)
+      - pattern: os.system($X)
+    message: "Dangerous code execution function"
+    severity: WARNING
+    languages: [python]
+```
+
+#### patterns (AND)
+
+Require all patterns to match:
+
+```yaml
+rules:
+  - id: sql-injection-flask
+    patterns:
+      - pattern: cursor.execute($QUERY)
+      - pattern-inside: |
+          @app.route(...)
+          def $FUNC(...):
+            ...
+    message: "SQL query in Flask route - check for injection"
+    severity: WARNING
+    languages: [python]
+```
+
+#### pattern-not (exclusion)
+
+Exclude safe patterns:
+
+```yaml
+rules:
+  - id: unparameterized-query
+    patterns:
+      - pattern: cursor.execute($QUERY)
+      - pattern-not: cursor.execute($QUERY, $PARAMS)
+    message: "SQL query without parameters - potential injection"
+    severity: ERROR
+    languages: [python]
+```
+
+#### pattern-inside (context)
+
+Limit matches to specific code contexts:
+
+```yaml
+rules:
+  - id: hardcoded-password-in-function
+    patterns:
+      - pattern: password = "..."
+      - pattern-inside: |
+          def $FUNC(...):
+            ...
+    message: "Hardcoded password in function"
+    severity: ERROR
+    languages: [python]
+```
+
+### Real-World Example: Flask Security Rules
+
+```yaml
+# flask-security.yaml
+rules:
+  - id: flask-debug-mode
+    pattern: app.run(..., debug=True, ...)
+    message: "Flask debug mode should not be enabled in production"
+    severity: WARNING
+    languages: [python]
+    metadata:
+      category: security
+      cwe: "CWE-489"
+
+  - id: flask-secret-key-hardcoded
+    patterns:
+      - pattern-either:
+          - pattern: app.secret_key = "..."
+          - pattern: app.config["SECRET_KEY"] = "..."
+    message: "Flask secret key should not be hardcoded"
+    severity: ERROR
+    languages: [python]
+    metadata:
+      category: security
+      cwe: "CWE-798"
+
+  - id: flask-sql-injection
+    patterns:
+      - pattern-either:
+          - pattern: |
+              db.execute(f"...{$VAR}...")
+          - pattern: |
+              db.execute("..." + $VAR + "...")
+          - pattern: |
+              db.execute("..." % $VAR)
+          - pattern: |
+              db.execute("...".format($VAR))
+      - pattern-not: |
+          db.execute($QUERY, $PARAMS)
+    message: "Potential SQL injection - use parameterized queries"
+    severity: ERROR
+    languages: [python]
+    metadata:
+      category: security
+      cwe: "CWE-89"
+      owasp: "A03:2021 - Injection"
+```
+
+### Taint Tracking (Advanced)
+
+Semgrep Pro supports taint tracking to trace data flow:
+
+```yaml
+rules:
+  - id: flask-xss
+    mode: taint
+    pattern-sources:
+      - pattern: request.args.get(...)
+      - pattern: request.form.get(...)
+    pattern-sinks:
+      - pattern: return $X
+    pattern-sanitizers:
+      - pattern: escape($X)
+      - pattern: Markup.escape($X)
+    message: "User input flows to response without sanitization - XSS risk"
+    severity: ERROR
+    languages: [python]
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/semgrep.yml
+name: Semgrep
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: semgrep scan --config=p/security-audit --error
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+```
+
+### Pre-commit Hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/semgrep/semgrep
+    rev: v1.56.0
+    hooks:
+      - id: semgrep
+        args: ['--config', 'p/security-audit', '--error']
+```
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+semgrep:
+  stage: test
+  image: semgrep/semgrep
+  script:
+    - semgrep scan --config=p/security-audit --error --sarif > semgrep.sarif
+  artifacts:
+    reports:
+      sast: semgrep.sarif
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+## Ignoring False Positives
+
+### Inline Ignores
+
+```python
+# Safe use of eval for configuration loading
+result = eval(config_string)  # nosemgrep: dangerous-eval
+
+# Or with rule ID
+result = eval(config_string)  # nosemgrep: python.lang.security.audit.eval-detected
+```
+
+### File-Level Ignores
+
+Create `.semgrepignore`:
+
+```
+# Ignore test files
+tests/
+
+# Ignore generated code
+**/generated/
+
+# Ignore specific files
+legacy_code.py
+
+# Ignore patterns
+*.min.js
+```
+
+### Rule-Level Configuration
+
+Create `semgrep.yaml` in your project root:
+
+```yaml
+# semgrep.yaml
+rules:
+  - id: my-org-rules
+    pattern: ...
+    paths:
+      include:
+        - src/
+      exclude:
+        - src/vendor/
+        - src/generated/
+```
+
+## Performance Optimization
+
+### Targeting Specific Directories
+
+```bash
+# Only scan source directories
+semgrep --config=p/security-audit src/ lib/
+
+# Exclude test directories
+semgrep --config=p/security-audit --exclude='**/test/**' .
+```
+
+### Limiting Rules
+
+```bash
+# Use high-confidence rules only
+semgrep --config=p/ci .
+
+# Exclude slow rules
+semgrep --config=p/security-audit --exclude-rule='*taint*' .
+```
+
+### Caching
+
+Semgrep caches results between runs:
+
+```bash
+# Enable caching (default in CI)
+export SEMGREP_SEND_METRICS=off
+semgrep --config=p/security-audit --metrics=off .
+```
+
+## Semgrep vs. Other Tools
+
+| Aspect | Semgrep | CodeQL | SonarQube |
+|--------|---------|--------|----------|
+| Speed | Very fast | Slow | Medium |
+| Custom rules | Easy (YAML) | Complex (QL) | Medium |
+| Free tier | Generous | Free for OSS | Community Edition |
+| Taint analysis | Pro only | Yes | Yes |
+| IDE integration | Yes | Limited | Yes |
+
+**Use Semgrep when:**
+- You need fast feedback in pre-commit or CI
+- You want to write custom rules easily
+- You're enforcing team coding standards
+
+**Use CodeQL when:**
+- You need deep semantic analysis
+- You're auditing for complex vulnerabilities
+- You have time for thorough scans
+
+## Key Takeaways
+
+1. **Semgrep is fast and easy** — Minutes to set up, seconds to run
+2. **Pattern syntax is intuitive** — Rules look like the code they match
+3. **Registry has 2000+ rules** — Start with `p/security-audit` or `p/ci`
+4. **Great for pre-commit** — Fast enough to run on every commit
+5. **Custom rules are powerful** — Enforce your team's security standards
+
+Next, we'll explore CodeQL for deep semantic analysis and GitHub integration.

--- a/content/guides/sast-tools/04-codeql.md
+++ b/content/guides/sast-tools/04-codeql.md
@@ -1,0 +1,487 @@
+---
+title: 'CodeQL'
+description: 'Master CodeQL for deep semantic code analysis. Learn the query language, run security queries, and integrate with GitHub Advanced Security.'
+---
+
+CodeQL is GitHub's semantic code analysis engine. Unlike pattern-based tools, CodeQL treats code as data—you query it using a specialized language to find complex vulnerabilities that simpler tools miss.
+
+## How CodeQL Works
+
+CodeQL operates in two phases:
+
+```
+1. Database Creation
+   Source Code → CodeQL Extractor → CodeQL Database
+   
+2. Query Execution
+   CodeQL Database + Queries → Results
+```
+
+**Database creation** parses your code into a relational database containing:
+- Abstract Syntax Tree (AST) nodes
+- Data flow information
+- Control flow graphs
+- Type information
+- Call graphs
+
+**Query execution** runs QL queries against this database to find patterns.
+
+## Installation
+
+### CodeQL CLI
+
+```bash
+# macOS
+brew install codeql
+
+# Download from GitHub
+# https://github.com/github/codeql-cli-binaries/releases
+
+# Verify installation
+codeql --version
+# CodeQL command-line toolchain release 2.16.0
+```
+
+### Standard Query Packs
+
+```bash
+# Download standard libraries and queries
+codeql pack download codeql/python-queries
+codeql pack download codeql/javascript-queries
+codeql pack download codeql/java-queries
+```
+
+## Creating a CodeQL Database
+
+Before running queries, you must create a database from your source code:
+
+```bash
+# Python project
+codeql database create ./codeql-db \\
+  --language=python \\
+  --source-root=./src
+
+# JavaScript/TypeScript project
+codeql database create ./codeql-db \\
+  --language=javascript \\
+  --source-root=.
+
+# Java project (requires build)
+codeql database create ./codeql-db \\
+  --language=java \\
+  --command='mvn clean compile'
+```
+
+**Note:** Compiled languages (Java, C++, Go) require CodeQL to observe the build process. Interpreted languages (Python, JavaScript) don't need a build command.
+
+## Running Security Queries
+
+### Using Query Packs
+
+```bash
+# Run all security queries for Python
+codeql database analyze ./codeql-db \\
+  codeql/python-queries:codeql-suites/python-security-extended.qls \\
+  --format=sarif-latest \\
+  --output=results.sarif
+
+# Run specific query
+codeql database analyze ./codeql-db \\
+  codeql/python-queries:Security/CWE-089/SqlInjection.ql \\
+  --format=sarif-latest \\
+  --output=sql-injection.sarif
+```
+
+### Query Suites
+
+| Suite | Description | Use Case |
+|-------|-------------|----------|
+| `security-extended.qls` | Comprehensive security queries | Deep security audits |
+| `security-and-quality.qls` | Security + code quality | General CI scanning |
+| `code-scanning.qls` | GitHub Code Scanning defaults | PR checks |
+
+## Understanding the QL Language
+
+QL is a declarative, object-oriented query language. Learning the basics helps you understand query results and write custom queries.
+
+### Basic Query Structure
+
+```ql
+/**
+ * @name Find calls to eval
+ * @description Detects calls to the eval function
+ * @kind problem
+ * @problem.severity warning
+ * @id py/call-to-eval
+ */
+
+import python
+
+from Call call, Name name
+where
+  call.getFunc() = name and
+  name.getId() = "eval"
+select call, "Call to eval() detected"
+```
+
+**Query components:**
+
+- `import python` — Import the Python standard library
+- `from ... where ... select` — SQL-like query structure
+- `@kind problem` — Query produces alert-style results
+- `@problem.severity` — warning, error, or recommendation
+
+### Finding SQL Injection (Python)
+
+```ql
+/**
+ * @name SQL injection vulnerability
+ * @description User input flows to SQL query without sanitization
+ * @kind path-problem
+ * @problem.severity error
+ * @id py/sql-injection
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.Concepts
+
+module SqlInjectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source instanceof RemoteFlowSource
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(SqlExecution sql | sql.getSql() = sink)
+  }
+}
+
+module SqlInjectionFlow = TaintTracking::Global<SqlInjectionConfig>;
+
+from SqlInjectionFlow::PathNode source, SqlInjectionFlow::PathNode sink
+where SqlInjectionFlow::flowPath(source, sink)
+select sink.getNode(), source, sink, "SQL injection from $@", source.getNode(), "user input"
+```
+
+This query:
+1. Defines sources (user input from HTTP requests)
+2. Defines sinks (SQL execution functions)
+3. Uses taint tracking to find paths from sources to sinks
+4. Reports vulnerabilities with data flow paths
+
+### Common QL Concepts
+
+**Classes and predicates:**
+
+```ql
+// Class representing function calls
+class DangerousCall extends Call {
+  DangerousCall() {
+    this.getFunc().(Name).getId() in ["eval", "exec", "compile"]
+  }
+}
+
+// Predicate (reusable condition)
+predicate isUserInput(Expr e) {
+  exists(Call call | 
+    call.getFunc().(Attribute).getName() = "get" and
+    call.getFunc().(Attribute).getObject().(Name).getId() in ["request", "args", "form"] and
+    call = e
+  )
+}
+```
+
+**Data flow:**
+
+```ql
+// Track data from source to sink
+from DataFlow::Node source, DataFlow::Node sink
+where
+  source instanceof RemoteFlowSource and
+  sink = any(Call c | c.getFunc().(Name).getId() = "eval").getAnArg() and
+  DataFlow::localFlow(source, sink)
+select sink, "User input flows to eval"
+```
+
+## GitHub Code Scanning Integration
+
+The easiest way to use CodeQL is through GitHub's free Code Scanning feature.
+
+### Enable Code Scanning
+
+1. Go to your repository on GitHub
+2. Click **Security** > **Code scanning**
+3. Click **Set up code scanning**
+4. Select **CodeQL Analysis**
+5. Review and commit the workflow
+
+### Default Workflow
+
+```yaml
+# .github/workflows/codeql.yml
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['python', 'javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+```
+
+### Custom Queries in CI
+
+Add your own queries to the analysis:
+
+```yaml
+- name: Initialize CodeQL
+  uses: github/codeql-action/init@v3
+  with:
+    languages: ${{ matrix.language }}
+    queries: +security-and-quality
+    # Add custom query pack
+    packs: my-org/my-custom-queries@1.0.0
+```
+
+Or reference local queries:
+
+```yaml
+- name: Initialize CodeQL
+  uses: github/codeql-action/init@v3
+  with:
+    languages: python
+    queries: ./codeql/custom-queries/
+```
+
+## Writing Custom Queries
+
+### Query Pack Structure
+
+```
+my-queries/
+├── qlpack.yml          # Pack metadata
+├── codeql-suites/
+│   └── my-suite.qls    # Query suite definition
+└── src/
+    └── security/
+        ├── HardcodedCredentials.ql
+        └── InsecureRandomness.ql
+```
+
+**qlpack.yml:**
+
+```yaml
+name: my-org/my-queries
+version: 1.0.0
+dependencies:
+  codeql/python-all: "*"
+```
+
+**Query suite (my-suite.qls):**
+
+```yaml
+- queries: .
+- include:
+    kind: problem
+- include:
+    kind: path-problem
+```
+
+### Example: Detecting Hardcoded Secrets
+
+```ql
+/**
+ * @name Hardcoded credentials
+ * @description Credentials should not be hardcoded in source code
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id py/hardcoded-credentials
+ * @tags security
+ *       external/cwe/cwe-798
+ */
+
+import python
+
+predicate isCredentialVariable(Name name) {
+  name.getId().toLowerCase().regexpMatch(".*\\b(password|passwd|pwd|secret|api_key|apikey|token|auth)\\b.*")
+}
+
+from Assign assign, Name target, StrConst value
+where
+  assign.getATarget() = target and
+  assign.getValue() = value and
+  isCredentialVariable(target) and
+  value.getText().length() > 4  // Ignore empty/short strings
+select assign, "Potential hardcoded credential in variable '" + target.getId() + "'"
+```
+
+### Testing Your Queries
+
+CodeQL supports unit testing for queries:
+
+```
+my-queries/
+└── test/
+    └── security/
+        ├── HardcodedCredentials/
+        │   ├── test.py           # Test code
+        │   └── HardcodedCredentials.expected  # Expected results
+```
+
+**test.py:**
+
+```python
+# Test file for hardcoded credentials detection
+
+password = "secret123"  # $result
+api_key = "AKIA1234567890ABCDEF"  # $result
+
+username = "admin"  # Safe - not a credential variable
+safe_value = get_password_from_vault()  # Safe - not a string literal
+```
+
+**Run tests:**
+
+```bash
+codeql test run my-queries/test/
+```
+
+## Best Practices
+
+### 1. Start with Standard Queries
+
+CodeQL's built-in queries are well-tested. Customize only when you have specific needs.
+
+### 2. Use Path Queries for Data Flow
+
+Path queries (`@kind path-problem`) show the complete data flow from source to sink, making vulnerabilities easier to understand and fix.
+
+### 3. Tune for Your Codebase
+
+Exclude generated code and vendor directories:
+
+```yaml
+# codeql-config.yml
+paths-ignore:
+  - node_modules
+  - vendor
+  - "**/*.generated.py"
+```
+
+### 4. Cache Databases
+
+CodeQL database creation is expensive. Cache it in CI:
+
+```yaml
+- name: Cache CodeQL database
+  uses: actions/cache@v3
+  with:
+    path: .codeql-db
+    key: codeql-${{ hashFiles('**/*.py') }}
+```
+
+### 5. Review Alerts Systematically
+
+GitHub Code Scanning shows alerts in the Security tab. Triage them:
+- **Dismiss** with reason if false positive
+- **Create issue** for real vulnerabilities
+- **Fix in PR** for easy fixes
+
+## CodeQL vs. Other Tools
+
+| Feature | CodeQL | Semgrep | SonarQube |
+|---------|--------|---------|----------|
+| Analysis depth | Deepest | Pattern-based | Deep |
+| Speed | Slow | Fast | Medium |
+| Custom rules | Complex (QL) | Easy (YAML) | Medium |
+| Data flow | Excellent | Pro only | Good |
+| Free for private repos | Paid | Limited | Community Ed |
+| GitHub integration | Native | Good | Good |
+
+**Use CodeQL when:**
+- You need to find complex vulnerabilities
+- You're using GitHub and want native integration
+- You have time for thorough analysis (weekly scans)
+- You're auditing security-critical code
+
+## GitHub Advanced Security Pricing
+
+- **Free** for public repositories
+- **Paid** for private repositories (GitHub Advanced Security license)
+- Includes: Code Scanning, Secret Scanning, Dependency Review
+
+## Troubleshooting
+
+### Database Creation Fails
+
+```bash
+# Verbose output for debugging
+codeql database create ./codeql-db \\
+  --language=python \\
+  --source-root=. \\
+  --verbosity=progress
+```
+
+### Query Times Out
+
+```bash
+# Increase timeout (default 5 minutes)
+codeql database analyze ./codeql-db \\
+  codeql/python-queries:codeql-suites/python-security-extended.qls \\
+  --timeout=1800  # 30 minutes
+```
+
+### Too Many Results
+
+```bash
+# Limit to high-precision queries
+codeql database analyze ./codeql-db \\
+  codeql/python-queries:codeql-suites/python-security-extended.qls \\
+  --sarif-add-snippets \\
+  --threads=4
+```
+
+## Key Takeaways
+
+1. **CodeQL is the deepest analysis** — Best for finding complex vulnerabilities
+2. **Database creation is a separate step** — Plan for build time
+3. **QL is powerful but complex** — Start with standard queries
+4. **GitHub integration is seamless** — Free for open source
+5. **Combine with faster tools** — Use Semgrep for pre-commit, CodeQL for weekly deep scans
+
+You now have a comprehensive SAST toolkit: SonarQube for platform-wide visibility, Semgrep for fast custom rules, and CodeQL for deep semantic analysis. Layer these tools to catch vulnerabilities at every stage of development.

--- a/content/guides/sast-tools/index.md
+++ b/content/guides/sast-tools/index.md
@@ -1,0 +1,69 @@
+---
+title: 'Static Application Security Testing (SAST)'
+description: 'Master Static Application Security Testing (SAST) with SonarQube, Semgrep, and CodeQL. Learn to detect vulnerabilities in source code before they reach production.'
+category:
+  name: 'Security'
+  slug: 'security'
+publishedAt: '2025-01-24'
+updatedAt: '2025-01-24'
+author:
+  name: 'DevOps Daily Team'
+  slug: 'devops-daily-team'
+tags:
+  - Security
+  - DevSecOps
+  - SAST
+  - SonarQube
+  - Semgrep
+  - CodeQL
+---
+
+Static Application Security Testing (SAST) analyzes source code to find security vulnerabilities without executing the application. Unlike dynamic testing that requires a running application, SAST can catch issues early in development—when they're cheapest to fix.
+
+SAST tools scan your codebase for patterns that indicate security weaknesses: SQL injection, cross-site scripting, hardcoded secrets, insecure cryptography, and hundreds of other vulnerability classes. They integrate into your IDE, CI/CD pipeline, and code review process to provide continuous security feedback.
+
+This guide covers three of the most popular SAST tools, each with different strengths:
+
+- **SonarQube** — Comprehensive code quality and security platform
+- **Semgrep** — Fast, customizable pattern matching for security rules
+- **CodeQL** — Powerful semantic code analysis from GitHub
+
+## What You'll Learn
+
+This guide consists of the following parts:
+
+1. SAST Fundamentals - How static analysis works, types of analysis, limitations
+2. SonarQube - Setup, configuration, quality gates, and CI/CD integration
+3. Semgrep - Writing custom rules, registry usage, and pipeline integration
+4. CodeQL - Query language basics, security queries, and GitHub integration
+
+## Why SAST Matters for DevOps
+
+Consider these scenarios:
+
+- A SQL injection vulnerability ships to production because no one noticed the string concatenation
+- Hardcoded AWS credentials in a config file get committed and exposed
+- A junior developer uses MD5 for password hashing, unaware it's insecure
+- An open redirect vulnerability sits in the codebase for months before discovery
+
+SAST tools catch these issues automatically during development, not after deployment. They provide a safety net that scales with your team—every commit gets the same thorough security review.
+
+## Prerequisites
+
+This guide assumes you have:
+
+- Basic understanding of common vulnerabilities (SQL injection, XSS, etc.)
+- Familiarity with CI/CD pipelines (GitHub Actions, GitLab CI, Jenkins)
+- Experience with at least one programming language
+- Docker installed (for running SonarQube locally)
+
+## Who This Guide Is For
+
+This guide is designed for:
+
+- DevOps engineers implementing security in CI/CD pipelines
+- Security engineers evaluating or deploying SAST tools
+- Developers wanting to catch security issues earlier
+- Teams building a DevSecOps practice from scratch
+
+Let's start finding vulnerabilities before attackers do!


### PR DESCRIPTION
Partial fix for #750 - adds SAST Tools guide (skill 6 of 24)

## Changes
- 5 new guide files covering SonarQube, Semgrep, and CodeQL
- Updated DevSecOps roadmap with link to guide

## Guide Contents
1. **SAST Fundamentals** - How static analysis works, types (pattern matching, data flow, taint tracking), limitations
2. **SonarQube** - Docker setup, quality gates, CI/CD integration (GitHub Actions, GitLab CI, Jenkins)
3. **Semgrep** - Custom rules, registry usage, pre-commit hooks, pattern syntax
4. **CodeQL** - QL language basics, security queries, GitHub Code Scanning integration

## Fact-Check Summary
- SonarQube default port 9000 ✅
- Semgrep rule packs (p/security-audit, p/owasp-top-ten) ✅
- CodeQL two-phase approach (database creation → query) ✅
- GitHub Code Scanning free for public repos ✅

All 4470 tests pass.