### PR TITLE
fix: Add missing metadata to Dependency Scanning guide

### DIFF
--- a/content/guides/dependency-scanning/index.md
+++ b/content/guides/dependency-scanning/index.md
@@ -1,6 +1,20 @@
 ---
 title: 'Dependency Scanning'
 description: 'Learn how to identify and remediate vulnerabilities in your project dependencies using Snyk, Dependabot, and native package manager tools.'
+category:
+  name: 'Security'
+  slug: 'security'
+publishedAt: '2025-01-24'
+updatedAt: '2025-01-24'
+author:
+  name: 'DevOps Daily Team'
+  slug: 'devops-daily-team'
+tags:
+  - Security
+  - DevSecOps
+  - Dependency Scanning
+  - Vulnerabilities
+  - Supply Chain
 ---
 
 Modern applications rely heavily on third-party dependencies—often 80-90% of your codebase consists of external packages. This creates a massive attack surface: a single vulnerable dependency can compromise your entire application.


### PR DESCRIPTION
The Dependency Scanning guide was not showing up because its `index.md` was missing required frontmatter fields.

## Root Cause
The `getAllGuides()` function in `lib/guides.ts` filters out guides without a `publishedAt` field (line 58-60). The dependency-scanning guide was missing:
- `publishedAt`
- `category`
- `author`
- `tags`

## Fix
Added the required frontmatter fields to match other guides like `secure-coding-practices`.

All 4491 tests pass.