### PR TITLE
feat: Add Secrets Management guide

### DIFF
--- a/app/roadmap/devsecops/page.tsx
+++ b/app/roadmap/devsecops/page.tsx
@@ -239,6 +239,7 @@ const milestones: DevSecOpsMilestone[] = [
         icon: Key,
         priority: 'essential',
         estimatedHours: 25,
+        link: '/guides/secrets-management',
       },
       {
         name: 'DAST Integration',

--- a/content/guides/secrets-management/01-fundamentals.md
+++ b/content/guides/secrets-management/01-fundamentals.md
@@ -1,0 +1,304 @@
+---
+title: "Secrets Management Fundamentals"
+description: "Core concepts of secrets management: threat models, secret types, lifecycle, and security principles"
+---
+
+# Secrets Management Fundamentals
+
+Before diving into specific tools, you need to understand the principles that make secrets management effective. This foundation helps you make better decisions regardless of which platform you choose.
+
+## What Are Secrets?
+
+Secrets are any sensitive data that grants access to systems or data:
+
+- **API Keys** - Access tokens for external services (Stripe, GitHub, Slack)
+- **Database Credentials** - Usernames and passwords for databases
+- **Encryption Keys** - Symmetric keys for data encryption
+- **Certificates** - TLS/SSL certificates and private keys
+- **SSH Keys** - Private keys for server access
+- **OAuth Tokens** - Access and refresh tokens for OAuth flows
+- **Signing Keys** - Keys for code signing, JWT signing, etc.
+
+## The Threat Model
+
+Understanding how secrets get compromised helps you defend against attacks:
+
+```
+Secret Compromise Vectors
+=========================
+
+Source Code       -> Hardcoded secrets, committed .env files
+CI/CD Logs        -> Secrets printed to build output
+Config Files      -> Unencrypted secrets in deployment configs
+Memory Dumps      -> Secrets in application memory
+Network Traffic   -> Secrets transmitted without TLS
+Backups           -> Secrets in unencrypted database backups
+Developer Laptops -> Local copies of production secrets
+Third-Party Apps  -> Secrets shared with external services
+```
+
+### Real-World Breaches
+
+- **Uber (2016)** - AWS credentials in a GitHub repo led to 57 million user records exposed
+- **CircleCI (2023)** - Compromised secrets affected thousands of customers
+- **LastPass (2022)** - Encrypted vault backups stolen along with encryption keys
+
+## Core Principles
+
+### 1. Least Privilege
+
+Every service, user, and process should have access only to the secrets it needs.
+
+```
+Bad:  Production database password accessible to all developers
+Good: Production database password accessible only to production services
+```
+
+### 2. Short-Lived Credentials
+
+Credentials that expire quickly limit the window of opportunity for attackers.
+
+```
+Static credential: Valid forever until manually rotated
+Dynamic credential: Valid for 1 hour, automatically revoked
+```
+
+### 3. Encryption at Rest and in Transit
+
+Secrets should never be stored or transmitted in plaintext.
+
+```yaml
+# Bad - plaintext in environment
+DATABASE_URL=postgres://admin:password123@db.example.com/prod
+
+# Good - encrypted reference
+DATABASE_URL=vault:secret/data/prod/database#url
+```
+
+### 4. Audit Everything
+
+Every secret access should be logged with:
+- Who accessed it
+- When it was accessed
+- From where (IP, service identity)
+- What they did with it
+
+### 5. Rotation Without Downtime
+
+You should be able to rotate any secret without service interruption.
+
+```
+Rotation Flow
+-------------
+1. Generate new credential
+2. Update secrets manager
+3. Applications fetch new credential
+4. Old credential remains valid briefly
+5. Revoke old credential
+```
+
+## Secret Lifecycle
+
+Every secret goes through these stages:
+
+```
+Creation -> Storage -> Distribution -> Usage -> Rotation -> Revocation
+    |          |           |            |          |            |
+    v          v           v            v          v            v
+ Generate  Encrypt     Deliver      Access     Update       Delete
+ securely  at rest    securely     control    regularly    completely
+```
+
+### Creation
+
+- Generate secrets with sufficient entropy (256+ bits)
+- Never use predictable patterns or dictionary words
+- Use cryptographically secure random number generators
+
+```python
+# Python - Generating secure secrets
+import secrets
+
+# API key (URL-safe)
+api_key = secrets.token_urlsafe(32)  # 256 bits
+
+# Database password
+password = secrets.token_hex(32)  # 256 bits
+
+# Numeric PIN (if required)
+pin = ''.join(str(secrets.randbelow(10)) for _ in range(6))
+```
+
+### Storage
+
+Secrets must be encrypted at rest with proper key management:
+
+- Use envelope encryption (data key encrypted by master key)
+- Store master keys in HSMs when possible
+- Implement key rotation for encryption keys
+
+### Distribution
+
+Secrets should be pulled, not pushed:
+
+```
+Bad:  CI/CD injects secrets as environment variables at build time
+Good: Application fetches secrets from vault at runtime
+```
+
+### Usage
+
+- Load secrets into memory only when needed
+- Clear secrets from memory after use
+- Never log secrets or include them in error messages
+
+```python
+# Bad - secret in logs
+logger.info(f"Connecting to database with password: {db_password}")
+
+# Good - no secrets in logs
+logger.info("Connecting to database")
+```
+
+### Rotation
+
+Implement automated rotation:
+
+- **Time-based**: Rotate every N days
+- **Event-based**: Rotate on suspected compromise
+- **Usage-based**: Rotate after N uses
+
+### Revocation
+
+When secrets are compromised or no longer needed:
+
+- Revoke immediately
+- Verify revocation is complete
+- Audit for unauthorized use during exposure window
+
+## Secret Types and Strategies
+
+Different secrets require different management strategies:
+
+| Secret Type | Rotation Frequency | Storage | Notes |
+|-------------|-------------------|---------|-------|
+| API Keys | 90 days | Vault/Cloud SM | Multiple active keys for rotation |
+| Database Creds | Dynamic | Vault | Generate per-session when possible |
+| TLS Certificates | 90 days | Vault PKI | Automate with ACME/Vault |
+| SSH Keys | 1 year | Vault SSH | Consider signed certificates |
+| Encryption Keys | 1-2 years | HSM/KMS | Never export, rotate with re-encryption |
+| OAuth Tokens | Per session | Memory only | Use refresh tokens, short-lived access |
+
+## Environment Segregation
+
+Never share secrets across environments:
+
+```
+Environments and Secrets
+------------------------
+
+Development:  dev-db-password     (local/test data only)
+Staging:      staging-db-password (synthetic data)
+Production:   prod-db-password    (real customer data)
+
+Each environment has completely separate secrets.
+Developers NEVER have access to production secrets.
+```
+
+## Access Control Patterns
+
+### Role-Based Access Control (RBAC)
+
+```
+Role: backend-service
+  Can read: secret/data/prod/database
+  Can read: secret/data/prod/api-keys
+  Cannot read: secret/data/prod/admin/*
+
+Role: developer
+  Can read: secret/data/dev/*
+  Can read: secret/data/staging/*
+  Cannot read: secret/data/prod/*
+```
+
+### Identity-Based Access
+
+Modern platforms support workload identity:
+
+- **Kubernetes**: ServiceAccount tokens
+- **AWS**: IAM roles for EC2/ECS/Lambda
+- **Azure**: Managed Identity
+- **GCP**: Workload Identity
+
+```yaml
+# Kubernetes pod with service account
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  serviceAccountName: myapp-sa  # Identity for secrets access
+  containers:
+    - name: app
+      image: myapp:latest
+```
+
+## Secrets in CI/CD
+
+CI/CD pipelines need special consideration:
+
+### Do's
+
+- Use platform-native secrets (GitHub Secrets, GitLab CI Variables)
+- Fetch secrets at runtime, not build time
+- Use OIDC for cloud authentication when possible
+- Mask secrets in logs
+
+### Don'ts
+
+- Echo secrets to verify they're set
+- Pass secrets as command-line arguments (visible in `ps`)
+- Store secrets in artifacts or caches
+- Use the same secrets for PR builds as production
+
+```yaml
+# GitHub Actions - Good pattern
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC
+    steps:
+      - name: Configure AWS (OIDC - no stored credentials)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789:role/deploy
+          aws-region: us-east-1
+```
+
+## Secrets Detection
+
+Prevent secrets from leaking with automated scanning:
+
+```bash
+# Pre-commit with gitleaks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
+
+Tools to consider:
+- **gitleaks** - Git repository scanner
+- **truffleHog** - Regex and entropy-based detection
+- **detect-secrets** - Yelp's secret detection tool
+- **GitHub Secret Scanning** - Built into GitHub
+
+## Key Takeaways
+
+1. **Secrets are high-value targets** - Treat them with appropriate care
+2. **Short-lived beats long-lived** - Dynamic secrets reduce risk
+3. **Audit everything** - You can't respond to what you can't see
+4. **Automate rotation** - Manual rotation doesn't scale
+5. **Segregate environments** - Production secrets are special

--- a/content/guides/secrets-management/02-hashicorp-vault.md
+++ b/content/guides/secrets-management/02-hashicorp-vault.md
@@ -1,0 +1,456 @@
+---
+title: 'HashiCorp Vault'
+description: 'Deploy and operate HashiCorp Vault for centralized secrets management'
+---
+
+# HashiCorp Vault
+
+HashiCorp Vault is the industry standard for secrets management. It provides a unified interface to any secret while providing tight access control and recording a detailed audit log.
+
+## Architecture Overview
+
+Vault uses a client-server architecture with pluggable backends:
+
+```
+                     +------------------+
+                     |     Clients      |
+                     |  (CLI/API/UI)    |
+                     +--------+---------+
+                              |
+                              v
+                     +--------+---------+
+                     |   Vault Server   |
+                     |   (API Layer)    |
+                     +--------+---------+
+                              |
+          +-------------------+-------------------+
+          |                   |                   |
+          v                   v                   v
+    +-----+-----+       +-----+-----+       +-----+-----+
+    |  Secrets  |       |   Auth    |       |   Audit   |
+    |  Engines  |       |  Methods  |       |  Devices  |
+    +-----------+       +-----------+       +-----------+
+          |                   |                   |
+          v                   v                   v
+    +-----+-----+       +-----+-----+       +-----+-----+
+    |  Storage  |       |   LDAP/   |       |   File/   |
+    |  Backend  |       | OIDC/etc  |       |  Syslog   |
+    +-----------+       +-----------+       +-----------+
+```
+
+## Installation and Setup
+
+### Development Mode
+
+For learning and testing (never use in production):
+
+```bash
+# Start Vault in dev mode
+vault server -dev
+
+# Dev mode automatically:
+# - Unseals the vault
+# - Sets root token to 'root'
+# - Enables in-memory storage
+# - Listens on localhost:8200
+```
+
+### Production Deployment with Docker
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  vault:
+    image: hashicorp/vault:1.15
+    container_name: vault
+    ports:
+      - "8200:8200"
+    environment:
+      VAULT_ADDR: 'http://127.0.0.1:8200'
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - ./vault/config:/vault/config
+      - ./vault/data:/vault/data
+      - ./vault/logs:/vault/logs
+    command: vault server -config=/vault/config/config.hcl
+```
+
+```hcl
+# vault/config/config.hcl
+storage "raft" {
+  path    = "/vault/data"
+  node_id = "vault-1"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = false
+  tls_cert_file = "/vault/config/tls/vault.crt"
+  tls_key_file  = "/vault/config/tls/vault.key"
+}
+
+api_addr = "https://vault.example.com:8200"
+cluster_addr = "https://vault.example.com:8201"
+ui = true
+
+# Telemetry for monitoring
+telemetry {
+  prometheus_retention_time = "30s"
+  disable_hostname = true
+}
+```
+
+### Initialization and Unsealing
+
+```bash
+# Initialize Vault (only once, on first setup)
+vault operator init -key-shares=5 -key-threshold=3
+
+# Output:
+# Unseal Key 1: abc123...
+# Unseal Key 2: def456...
+# Unseal Key 3: ghi789...
+# Unseal Key 4: jkl012...
+# Unseal Key 5: mno345...
+# Initial Root Token: hvs.xxxxx
+
+# CRITICAL: Store these keys securely and separately!
+# Use Shamir's Secret Sharing - no single person should have all keys
+
+# Unseal Vault (requires threshold number of keys)
+vault operator unseal  # Enter key 1
+vault operator unseal  # Enter key 2
+vault operator unseal  # Enter key 3
+
+# Login with root token
+vault login hvs.xxxxx
+```
+
+## Secrets Engines
+
+### KV (Key-Value) Secrets Engine
+
+The most common secrets engine for storing arbitrary secrets:
+
+```bash
+# Enable KV v2 (versioned)
+vault secrets enable -path=secret kv-v2
+
+# Store a secret
+vault kv put secret/myapp/database \
+    username="dbuser" \
+    password="s3cr3t" \
+    host="db.example.com"
+
+# Read a secret
+vault kv get secret/myapp/database
+
+# Read specific field
+vault kv get -field=password secret/myapp/database
+
+# Read specific version
+vault kv get -version=1 secret/myapp/database
+
+# Delete a secret (soft delete, can be recovered)
+vault kv delete secret/myapp/database
+
+# Permanently destroy
+vault kv destroy -versions=1,2 secret/myapp/database
+```
+
+### Database Secrets Engine (Dynamic Secrets)
+
+Generate on-demand, short-lived database credentials:
+
+```bash
+# Enable the database secrets engine
+vault secrets enable database
+
+# Configure PostgreSQL connection
+vault write database/config/mydb \
+    plugin_name=postgresql-database-plugin \
+    connection_url="postgresql://{{username}}:{{password}}@localhost:5432/mydb" \
+    allowed_roles="readonly,readwrite" \
+    username="vault_admin" \
+    password="vault_admin_password"
+
+# Create a role that generates credentials
+vault write database/roles/readonly \
+    db_name=mydb \
+    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
+    default_ttl="1h" \
+    max_ttl="24h"
+
+# Generate credentials
+vault read database/creds/readonly
+
+# Output:
+# Key                Value
+# lease_id           database/creds/readonly/abc123
+# lease_duration     1h
+# username           v-root-readonly-xyz789
+# password           A1B2C3D4E5...
+```
+
+### AWS Secrets Engine
+
+Generate dynamic AWS IAM credentials:
+
+```bash
+# Enable AWS secrets engine
+vault secrets enable aws
+
+# Configure root credentials
+vault write aws/config/root \
+    access_key=AKIAIOSFODNN7EXAMPLE \
+    secret_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+    region=us-east-1
+
+# Create role for EC2 admin
+vault write aws/roles/ec2-admin \
+    credential_type=iam_user \
+    policy_document=-<<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:*",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+# Generate credentials
+vault read aws/creds/ec2-admin
+```
+
+## Authentication Methods
+
+### AppRole (for Applications)
+
+Most common method for automated workloads:
+
+```bash
+# Enable AppRole auth
+vault auth enable approle
+
+# Create a role for your application
+vault write auth/approle/role/myapp \
+    token_policies="myapp-policy" \
+    token_ttl=1h \
+    token_max_ttl=4h \
+    secret_id_ttl=10m \
+    secret_id_num_uses=1
+
+# Get role ID (can be embedded in app config)
+vault read auth/approle/role/myapp/role-id
+
+# Generate secret ID (should be delivered securely)
+vault write -f auth/approle/role/myapp/secret-id
+
+# Application authenticates with both
+vault write auth/approle/login \
+    role_id="abc123" \
+    secret_id="def456"
+```
+
+### Kubernetes Authentication
+
+For applications running in Kubernetes:
+
+```bash
+# Enable Kubernetes auth
+vault auth enable kubernetes
+
+# Configure with cluster info
+vault write auth/kubernetes/config \
+    kubernetes_host="https://kubernetes.default.svc:443" \
+    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+# Create a role bound to a service account
+vault write auth/kubernetes/role/myapp \
+    bound_service_account_names=myapp-sa \
+    bound_service_account_namespaces=production \
+    policies=myapp-policy \
+    ttl=1h
+```
+
+```yaml
+# Kubernetes pod spec using Vault Agent Injector
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+  annotations:
+    vault.hashicorp.com/agent-inject: 'true'
+    vault.hashicorp.com/role: 'myapp'
+    vault.hashicorp.com/agent-inject-secret-db-creds: 'secret/data/myapp/database'
+    vault.hashicorp.com/agent-inject-template-db-creds: |
+      {{- with secret "secret/data/myapp/database" -}}
+      export DB_USER="{{ .Data.data.username }}"
+      export DB_PASS="{{ .Data.data.password }}"
+      {{- end -}}
+spec:
+  serviceAccountName: myapp-sa
+  containers:
+    - name: myapp
+      image: myapp:latest
+```
+
+## Policies
+
+Vault policies define what secrets a token can access:
+
+```hcl
+# myapp-policy.hcl
+
+# Read application secrets
+path "secret/data/myapp/*" {
+  capabilities = ["read", "list"]
+}
+
+# Generate database credentials
+path "database/creds/myapp-readonly" {
+  capabilities = ["read"]
+}
+
+# No access to other apps
+path "secret/data/otherapp/*" {
+  capabilities = ["deny"]
+}
+
+# Allow token renewal
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+```
+
+```bash
+# Create policy
+vault policy write myapp-policy myapp-policy.hcl
+
+# List policies
+vault policy list
+
+# Read policy
+vault policy read myapp-policy
+```
+
+## Audit Logging
+
+Enable audit logging for compliance:
+
+```bash
+# Enable file audit device
+vault audit enable file file_path=/vault/logs/audit.log
+
+# Enable syslog audit
+vault audit enable syslog tag="vault" facility="AUTH"
+
+# Audit log entry (JSON)
+# {
+#   "time": "2024-01-15T10:30:00Z",
+#   "type": "response",
+#   "auth": {
+#     "client_token": "hmac-sha256:abc123",
+#     "policies": ["myapp-policy"]
+#   },
+#   "request": {
+#     "operation": "read",
+#     "path": "secret/data/myapp/database"
+#   }
+# }
+```
+
+## High Availability
+
+### Raft Storage (Integrated)
+
+```hcl
+# vault-node-1.hcl
+storage "raft" {
+  path    = "/vault/data"
+  node_id = "vault-1"
+  
+  retry_join {
+    leader_api_addr = "https://vault-2.example.com:8200"
+  }
+  retry_join {
+    leader_api_addr = "https://vault-3.example.com:8200"
+  }
+}
+```
+
+```bash
+# Check raft peers
+vault operator raft list-peers
+
+# Add a new node
+vault operator raft join https://vault-1.example.com:8200
+```
+
+## Application Integration Example
+
+### Python Application
+
+```python
+import hvac
+import os
+
+class VaultClient:
+    def __init__(self):
+        self.client = hvac.Client(
+            url=os.environ.get('VAULT_ADDR', 'http://localhost:8200')
+        )
+        self._authenticate()
+    
+    def _authenticate(self):
+        # AppRole authentication
+        role_id = os.environ['VAULT_ROLE_ID']
+        secret_id = os.environ['VAULT_SECRET_ID']
+        
+        response = self.client.auth.approle.login(
+            role_id=role_id,
+            secret_id=secret_id
+        )
+        self.client.token = response['auth']['client_token']
+    
+    def get_secret(self, path, key=None):
+        secret = self.client.secrets.kv.v2.read_secret_version(
+            path=path
+        )
+        data = secret['data']['data']
+        return data.get(key) if key else data
+    
+    def get_database_credentials(self, role='readonly'):
+        creds = self.client.secrets.database.generate_credentials(
+            name=role
+        )
+        return {
+            'username': creds['data']['username'],
+            'password': creds['data']['password'],
+            'lease_id': creds['lease_id'],
+            'lease_duration': creds['lease_duration']
+        }
+
+# Usage
+vault = VaultClient()
+db_config = vault.get_secret('myapp/database')
+dynamic_creds = vault.get_database_credentials()
+```
+
+## Best Practices
+
+1. **Never store root token** - Generate and revoke after initial setup
+2. **Use short TTLs** - Minimize blast radius of compromised credentials
+3. **Enable audit logging** - Required for compliance and forensics
+4. **Rotate credentials regularly** - Use dynamic secrets where possible
+5. **Principle of least privilege** - Grant minimum required permissions
+6. **Encrypt in transit and at rest** - Always use TLS
+7. **Separate unseal keys** - Use Shamir's Secret Sharing properly

--- a/content/guides/secrets-management/03-aws-secrets-manager.md
+++ b/content/guides/secrets-management/03-aws-secrets-manager.md
@@ -1,0 +1,406 @@
+---
+title: 'AWS Secrets Manager'
+description: 'Use AWS Secrets Manager for cloud-native secrets management'
+---
+
+# AWS Secrets Manager
+
+AWS Secrets Manager is a fully managed service for storing, rotating, and retrieving secrets in AWS. It integrates natively with AWS services and provides automatic rotation capabilities.
+
+## Core Concepts
+
+```
++-----------------+     +-----------------+     +-----------------+
+|  Application    |     |    Secrets      |     |    Backend      |
+|                 | --> |    Manager      | --> |    (RDS/etc)    |
++-----------------+     +-----------------+     +-----------------+
+        |                       |
+        |                       v
+        |               +-----------------+
+        |               |    Lambda       |
+        +-------------->|   (Rotation)    |
+                        +-----------------+
+```
+
+- **Secrets** - Key-value pairs or JSON documents stored encrypted
+- **Versions** - Each secret can have multiple versions with staging labels
+- **Rotation** - Automated credential rotation via Lambda functions
+- **Resource policies** - Cross-account access control
+
+## Creating and Managing Secrets
+
+### Using AWS CLI
+
+```bash
+# Create a simple secret
+aws secretsmanager create-secret \
+    --name myapp/database \
+    --description "Database credentials for MyApp" \
+    --secret-string '{"username":"admin","password":"s3cr3t","host":"db.example.com"}'
+
+# Create secret from file
+aws secretsmanager create-secret \
+    --name myapp/api-key \
+    --secret-string file://secret.json
+
+# Retrieve a secret
+aws secretsmanager get-secret-value \
+    --secret-id myapp/database
+
+# Update a secret
+aws secretsmanager update-secret \
+    --secret-id myapp/database \
+    --secret-string '{"username":"admin","password":"newpassword","host":"db.example.com"}'
+
+# List all secrets
+aws secretsmanager list-secrets
+
+# Delete a secret (with recovery window)
+aws secretsmanager delete-secret \
+    --secret-id myapp/database \
+    --recovery-window-in-days 7
+
+# Force delete immediately (no recovery)
+aws secretsmanager delete-secret \
+    --secret-id myapp/database \
+    --force-delete-without-recovery
+```
+
+### Using Terraform
+
+```hcl
+# Create a secret
+resource "aws_secretsmanager_secret" "database" {
+  name        = "myapp/database"
+  description = "Database credentials"
+  
+  tags = {
+    Environment = "production"
+    Application = "myapp"
+  }
+}
+
+# Set secret value
+resource "aws_secretsmanager_secret_version" "database" {
+  secret_id = aws_secretsmanager_secret.database.id
+  secret_string = jsonencode({
+    username = "admin"
+    password = random_password.db.result
+    host     = aws_db_instance.main.address
+    port     = 5432
+  })
+}
+
+# Generate random password
+resource "random_password" "db" {
+  length  = 32
+  special = true
+}
+
+# Output secret ARN
+output "database_secret_arn" {
+  value = aws_secretsmanager_secret.database.arn
+}
+```
+
+## Automatic Rotation
+
+### RDS Rotation Setup
+
+```hcl
+# Enable rotation for RDS credentials
+resource "aws_secretsmanager_secret_rotation" "database" {
+  secret_id           = aws_secretsmanager_secret.database.id
+  rotation_lambda_arn = aws_lambda_function.rotation.arn
+  
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}
+
+# Create rotation Lambda
+resource "aws_lambda_function" "rotation" {
+  filename         = "rotation_lambda.zip"
+  function_name    = "SecretsManagerRotation"
+  role             = aws_iam_role.rotation.arn
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.11"
+  timeout          = 30
+  
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.rotation.id]
+  }
+  
+  environment {
+    variables = {
+      SECRETS_MANAGER_ENDPOINT = "https://secretsmanager.${var.region}.amazonaws.com"
+    }
+  }
+}
+
+# Allow Secrets Manager to invoke Lambda
+resource "aws_lambda_permission" "rotation" {
+  statement_id  = "AllowSecretsManager"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.rotation.function_name
+  principal     = "secretsmanager.amazonaws.com"
+}
+```
+
+### Rotation Lambda Function
+
+```python
+import boto3
+import json
+import logging
+import psycopg2
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    arn = event['SecretId']
+    token = event['ClientRequestToken']
+    step = event['Step']
+    
+    client = boto3.client('secretsmanager')
+    
+    if step == "createSecret":
+        create_secret(client, arn, token)
+    elif step == "setSecret":
+        set_secret(client, arn, token)
+    elif step == "testSecret":
+        test_secret(client, arn, token)
+    elif step == "finishSecret":
+        finish_secret(client, arn, token)
+    else:
+        raise ValueError(f"Invalid step: {step}")
+
+def create_secret(client, arn, token):
+    # Get current secret
+    current = client.get_secret_value(
+        SecretId=arn,
+        VersionStage="AWSCURRENT"
+    )
+    secret = json.loads(current['SecretString'])
+    
+    # Generate new password
+    new_password = client.get_random_password(
+        PasswordLength=32,
+        ExcludeCharacters='/@"\'\\'  # Exclude problematic chars
+    )['RandomPassword']
+    
+    secret['password'] = new_password
+    
+    # Store as pending
+    client.put_secret_value(
+        SecretId=arn,
+        ClientRequestToken=token,
+        SecretString=json.dumps(secret),
+        VersionStages=['AWSPENDING']
+    )
+
+def set_secret(client, arn, token):
+    # Get pending secret
+    pending = client.get_secret_value(
+        SecretId=arn,
+        VersionId=token,
+        VersionStage="AWSPENDING"
+    )
+    secret = json.loads(pending['SecretString'])
+    
+    # Update database password
+    conn = get_connection(client, arn, "AWSCURRENT")
+    with conn.cursor() as cur:
+        cur.execute(
+            "ALTER USER %s WITH PASSWORD %s",
+            (secret['username'], secret['password'])
+        )
+    conn.commit()
+    conn.close()
+
+def test_secret(client, arn, token):
+    # Verify new credentials work
+    conn = get_connection(client, arn, "AWSPENDING", token)
+    conn.close()
+    logger.info("Successfully tested new credentials")
+
+def finish_secret(client, arn, token):
+    # Move AWSCURRENT label to new version
+    metadata = client.describe_secret(SecretId=arn)
+    
+    for version, stages in metadata['VersionIdsToStages'].items():
+        if 'AWSCURRENT' in stages and version != token:
+            # Move current to previous
+            client.update_secret_version_stage(
+                SecretId=arn,
+                VersionStage='AWSCURRENT',
+                MoveToVersionId=token,
+                RemoveFromVersionId=version
+            )
+            break
+
+def get_connection(client, arn, stage, version=None):
+    kwargs = {'SecretId': arn, 'VersionStage': stage}
+    if version:
+        kwargs['VersionId'] = version
+    
+    response = client.get_secret_value(**kwargs)
+    secret = json.loads(response['SecretString'])
+    
+    return psycopg2.connect(
+        host=secret['host'],
+        database=secret.get('dbname', 'postgres'),
+        user=secret['username'],
+        password=secret['password']
+    )
+```
+
+## Application Integration
+
+### Python SDK
+
+```python
+import boto3
+import json
+from functools import lru_cache
+from botocore.exceptions import ClientError
+
+class SecretsManager:
+    def __init__(self, region='us-east-1'):
+        self.client = boto3.client(
+            'secretsmanager',
+            region_name=region
+        )
+    
+    @lru_cache(maxsize=100)
+    def get_secret(self, secret_name):
+        try:
+            response = self.client.get_secret_value(
+                SecretId=secret_name
+            )
+            if 'SecretString' in response:
+                return json.loads(response['SecretString'])
+            return response['SecretBinary']
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                raise ValueError(f"Secret {secret_name} not found")
+            raise
+    
+    def get_database_url(self, secret_name):
+        secret = self.get_secret(secret_name)
+        return (
+            f"postgresql://{secret['username']}:{secret['password']}"
+            f"@{secret['host']}:{secret.get('port', 5432)}/{secret.get('dbname', 'postgres')}"
+        )
+
+# Usage
+secrets = SecretsManager()
+db_creds = secrets.get_secret('myapp/database')
+database_url = secrets.get_database_url('myapp/database')
+```
+
+### Using with ECS
+
+```json
+{
+  "family": "myapp",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "myapp:latest",
+      "secrets": [
+        {
+          "name": "DB_USERNAME",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789:secret:myapp/database:username::"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789:secret:myapp/database:password::"
+        }
+      ]
+    }
+  ],
+  "executionRoleArn": "arn:aws:iam::123456789:role/ecsTaskExecutionRole"
+}
+```
+
+### Using with Lambda
+
+```python
+import json
+import boto3
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities import parameters
+
+logger = Logger()
+
+# Using Lambda Powertools (recommended)
+@logger.inject_lambda_context
+def handler(event, context):
+    # Automatic caching and refresh
+    db_secret = parameters.get_secret(
+        "myapp/database",
+        transform='json',
+        max_age=300  # Cache for 5 minutes
+    )
+    
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'status': 'connected'})
+    }
+```
+
+## Cross-Account Access
+
+### Resource Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCrossAccountAccess",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::999888777666:role/CrossAccountRole"
+      },
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "secretsmanager:VersionStage": "AWSCURRENT"
+        }
+      }
+    }
+  ]
+}
+```
+
+```bash
+# Attach resource policy
+aws secretsmanager put-resource-policy \
+    --secret-id myapp/database \
+    --resource-policy file://policy.json
+```
+
+## Pricing
+
+As of 2024:
+- **Storage**: $0.40 per secret per month
+- **API calls**: $0.05 per 10,000 API calls
+- **Rotation**: No additional cost (Lambda execution costs apply)
+
+## Best Practices
+
+1. **Use IAM policies** - Restrict access using least privilege
+2. **Enable rotation** - Automate credential rotation where possible
+3. **Use resource policies** - For cross-account access instead of sharing credentials
+4. **Cache secrets** - Reduce API calls and costs
+5. **Tag secrets** - For cost allocation and access control
+6. **Monitor with CloudTrail** - Track all secret access
+7. **Use VPC endpoints** - Keep traffic within AWS network

--- a/content/guides/secrets-management/04-azure-key-vault.md
+++ b/content/guides/secrets-management/04-azure-key-vault.md
@@ -1,0 +1,412 @@
+---
+title: 'Azure Key Vault'
+description: 'Implement secrets management with Azure Key Vault'
+---
+
+# Azure Key Vault
+
+Azure Key Vault provides secure storage for secrets, keys, and certificates in Azure. It integrates with Azure Active Directory for authentication and supports managed identities for seamless application access.
+
+## Core Concepts
+
+```
++-----------------+     +-----------------+     +-----------------+
+|  Application    |     |   Azure AD      |     |   Key Vault     |
+|  (with MI)      | --> |   (AuthN)       | --> |   (Secrets)     |
++-----------------+     +-----------------+     +-----------------+
+        |                                               |
+        v                                               v
++-----------------+                             +-----------------+
+|   Managed       |                             |   Access        |
+|   Identity      |                             |   Policies      |
++-----------------+                             +-----------------+
+```
+
+- **Secrets** - API keys, passwords, connection strings
+- **Keys** - Cryptographic keys for encryption
+- **Certificates** - SSL/TLS certificates with auto-renewal
+- **Managed Identity** - Azure-managed service principal
+
+## Creating a Key Vault
+
+### Using Azure CLI
+
+```bash
+# Create resource group
+az group create \
+    --name myapp-rg \
+    --location eastus
+
+# Create Key Vault
+az keyvault create \
+    --name myapp-vault \
+    --resource-group myapp-rg \
+    --location eastus \
+    --enable-rbac-authorization true
+
+# Set a secret
+az keyvault secret set \
+    --vault-name myapp-vault \
+    --name database-password \
+    --value "s3cr3t"
+
+# Get a secret
+az keyvault secret show \
+    --vault-name myapp-vault \
+    --name database-password
+
+# List all secrets
+az keyvault secret list \
+    --vault-name myapp-vault
+
+# Delete a secret (soft delete)
+az keyvault secret delete \
+    --vault-name myapp-vault \
+    --name database-password
+
+# Purge a deleted secret (permanent)
+az keyvault secret purge \
+    --vault-name myapp-vault \
+    --name database-password
+```
+
+### Using Terraform
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "main" {
+  name                = "myapp-vault"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+  
+  # Enable RBAC (recommended over access policies)
+  enable_rbac_authorization = true
+  
+  # Soft delete settings
+  soft_delete_retention_days = 90
+  purge_protection_enabled   = true
+  
+  # Network rules
+  network_acls {
+    bypass         = "AzureServices"
+    default_action = "Deny"
+    ip_rules       = ["10.0.0.0/24"]
+    virtual_network_subnet_ids = [
+      azurerm_subnet.app.id
+    ]
+  }
+
+  tags = {
+    Environment = "production"
+  }
+}
+
+# Create a secret
+resource "azurerm_key_vault_secret" "database_password" {
+  name         = "database-password"
+  value        = random_password.db.result
+  key_vault_id = azurerm_key_vault.main.id
+  
+  content_type = "text/plain"
+  
+  tags = {
+    Application = "myapp"
+  }
+}
+
+# Grant access to an application
+resource "azurerm_role_assignment" "app_secrets_reader" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.app.principal_id
+}
+```
+
+## Authentication with Managed Identity
+
+### System-Assigned Managed Identity
+
+```hcl
+# Azure App Service with system-assigned identity
+resource "azurerm_linux_web_app" "main" {
+  name                = "myapp-web"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  service_plan_id     = azurerm_service_plan.main.id
+  
+  identity {
+    type = "SystemAssigned"
+  }
+  
+  app_settings = {
+    AZURE_KEY_VAULT_URL = azurerm_key_vault.main.vault_uri
+  }
+  
+  site_config {
+    application_stack {
+      python_version = "3.11"
+    }
+  }
+}
+
+# Grant the app access to secrets
+resource "azurerm_role_assignment" "app_secrets" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_linux_web_app.main.identity[0].principal_id
+}
+```
+
+### User-Assigned Managed Identity
+
+```hcl
+resource "azurerm_user_assigned_identity" "app" {
+  name                = "myapp-identity"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+# Use with AKS
+resource "azurerm_kubernetes_cluster" "main" {
+  # ... other config ...
+  
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.app.id]
+  }
+}
+```
+
+## Application Integration
+
+### Python SDK
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
+from functools import lru_cache
+
+class AzureKeyVault:
+    def __init__(self, vault_url):
+        credential = DefaultAzureCredential()
+        self.client = SecretClient(
+            vault_url=vault_url,
+            credential=credential
+        )
+    
+    @lru_cache(maxsize=100)
+    def get_secret(self, name, version=None):
+        secret = self.client.get_secret(name, version=version)
+        return secret.value
+    
+    def set_secret(self, name, value, content_type=None, tags=None):
+        return self.client.set_secret(
+            name,
+            value,
+            content_type=content_type,
+            tags=tags
+        )
+    
+    def list_secrets(self):
+        return [
+            {'name': s.name, 'enabled': s.enabled}
+            for s in self.client.list_properties_of_secrets()
+        ]
+
+# Usage
+vault = AzureKeyVault('https://myapp-vault.vault.azure.net/')
+db_password = vault.get_secret('database-password')
+```
+
+### .NET SDK
+
+```csharp
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+
+public class KeyVaultService
+{
+    private readonly SecretClient _client;
+    
+    public KeyVaultService(string vaultUrl)
+    {
+        _client = new SecretClient(
+            new Uri(vaultUrl),
+            new DefaultAzureCredential()
+        );
+    }
+    
+    public async Task<string> GetSecretAsync(string name)
+    {
+        KeyVaultSecret secret = await _client.GetSecretAsync(name);
+        return secret.Value;
+    }
+    
+    public async Task SetSecretAsync(string name, string value)
+    {
+        await _client.SetSecretAsync(name, value);
+    }
+}
+
+// In Program.cs with configuration
+builder.Configuration.AddAzureKeyVault(
+    new Uri("https://myapp-vault.vault.azure.net/"),
+    new DefaultAzureCredential()
+);
+
+// Access as configuration
+var dbPassword = builder.Configuration["database-password"];
+```
+
+### Using with AKS (CSI Driver)
+
+```yaml
+# SecretProviderClass for Azure Key Vault
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: azure-kv-secrets
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "true"
+    userAssignedIdentityID: "<client-id-of-managed-identity>"
+    keyvaultName: "myapp-vault"
+    objects: |
+      array:
+        - |
+          objectName: database-password
+          objectType: secret
+        - |
+          objectName: api-key
+          objectType: secret
+    tenantId: "<tenant-id>"
+  secretObjects:
+    - secretName: app-secrets
+      type: Opaque
+      data:
+        - objectName: database-password
+          key: DB_PASSWORD
+        - objectName: api-key
+          key: API_KEY
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+    - name: app
+      image: myapp:latest
+      volumeMounts:
+        - name: secrets
+          mountPath: "/mnt/secrets"
+          readOnly: true
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: app-secrets
+              key: DB_PASSWORD
+  volumes:
+    - name: secrets
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: azure-kv-secrets
+```
+
+## Certificate Management
+
+```bash
+# Create a certificate (self-signed for testing)
+az keyvault certificate create \
+    --vault-name myapp-vault \
+    --name myapp-cert \
+    --policy "$(az keyvault certificate get-default-policy)"
+
+# Import existing certificate
+az keyvault certificate import \
+    --vault-name myapp-vault \
+    --name myapp-cert \
+    --file certificate.pfx \
+    --password "pfx-password"
+
+# Download certificate
+az keyvault certificate download \
+    --vault-name myapp-vault \
+    --name myapp-cert \
+    --file cert.pem
+```
+
+## Access Policies vs RBAC
+
+### Access Policies (Legacy)
+
+```bash
+# Grant access via access policy
+az keyvault set-policy \
+    --name myapp-vault \
+    --object-id "<principal-id>" \
+    --secret-permissions get list
+```
+
+### RBAC (Recommended)
+
+```bash
+# Built-in roles for Key Vault:
+# - Key Vault Administrator
+# - Key Vault Secrets User
+# - Key Vault Secrets Officer
+# - Key Vault Certificates Officer
+# - Key Vault Crypto Officer
+
+# Grant secrets read access
+az role assignment create \
+    --role "Key Vault Secrets User" \
+    --assignee "<principal-id>" \
+    --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/myapp-vault"
+```
+
+## Monitoring and Auditing
+
+```bash
+# Enable diagnostic logging
+az monitor diagnostic-settings create \
+    --name kv-diagnostics \
+    --resource "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/myapp-vault" \
+    --logs '[{"category": "AuditEvent", "enabled": true}]' \
+    --workspace "<log-analytics-workspace-id>"
+```
+
+```kusto
+// Log Analytics query for secret access
+AzureDiagnostics
+| where ResourceProvider == "MICROSOFT.KEYVAULT"
+| where OperationName == "SecretGet"
+| project TimeGenerated, CallerIPAddress, identity_claim_upn_s, id_s
+| order by TimeGenerated desc
+```
+
+## Pricing
+
+As of 2024:
+- **Standard tier**: $0.03 per 10,000 operations
+- **Premium tier**: $1 per key per month (HSM-backed)
+- **Secrets**: No storage cost, only operations
+- **Certificates**: $3 per renewal
+
+## Best Practices
+
+1. **Use RBAC over access policies** - More granular control
+2. **Enable managed identity** - No credentials to manage
+3. **Enable soft delete and purge protection** - Prevent accidental loss
+4. **Use private endpoints** - Keep traffic on Azure backbone
+5. **Enable diagnostic logging** - Track all access
+6. **Rotate secrets regularly** - Use automation where possible
+7. **Tag resources** - For cost tracking and management

--- a/content/guides/secrets-management/index.md
+++ b/content/guides/secrets-management/index.md
@@ -1,0 +1,87 @@
+---
+title: 'Secrets Management'
+description: 'Learn enterprise secrets management with HashiCorp Vault, AWS Secrets Manager, and Azure Key Vault. Master dynamic secrets, rotation, and secure access patterns for DevOps.'
+category:
+  name: 'Security'
+  slug: 'security'
+publishedAt: '2025-01-24'
+updatedAt: '2025-01-24'
+author:
+  name: 'DevOps Daily Team'
+  slug: 'devops-daily-team'
+tags:
+  - Security
+  - DevSecOps
+  - Secrets Management
+  - HashiCorp Vault
+  - AWS
+---
+
+Secrets are the keys to your kingdom: API tokens, database credentials, encryption keys, certificates. A single leaked secret can compromise your entire infrastructure. Yet many organizations still store secrets in environment variables, config files, or worse—hardcoded in source code.
+
+Modern secrets management goes beyond simple storage. It provides dynamic secret generation, automatic rotation, fine-grained access control, and comprehensive audit logging. The goal is to minimize the blast radius when (not if) a secret is compromised.
+
+This guide covers the leading secrets management platforms and teaches you how to implement secure secrets workflows in your DevOps pipelines.
+
+## What You'll Learn
+
+This guide consists of the following parts:
+
+1. **Secrets Management Fundamentals** - Why secrets management matters, threat models, and core concepts
+2. **HashiCorp Vault** - The industry standard for secrets management, dynamic secrets, and PKI
+3. **AWS Secrets Manager** - Native AWS secrets with rotation and cross-account access
+4. **Azure Key Vault** - Microsoft's secrets, keys, and certificates management service
+
+## Why Dedicated Secrets Management?
+
+Consider these common anti-patterns:
+
+- Secrets in `.env` files committed to git
+- Shared credentials across environments (dev/staging/prod)
+- Static credentials that never rotate
+- No audit trail of who accessed what secret
+- Secrets exposed in CI/CD logs
+
+Each of these creates risk. A dedicated secrets manager addresses all of them:
+
+| Problem | Solution |
+|---------|----------|
+| Secrets in code | Centralized, encrypted storage |
+| Shared credentials | Per-environment, per-service secrets |
+| Static credentials | Dynamic secrets with short TTLs |
+| No audit trail | Comprehensive access logging |
+| Log exposure | Just-in-time secret retrieval |
+
+## Choosing a Secrets Manager
+
+| Feature | Vault | AWS Secrets Manager | Azure Key Vault |
+|---------|-------|---------------------|------------------|
+| Dynamic secrets | Excellent | Limited | Limited |
+| Multi-cloud | Yes | AWS only | Azure-focused |
+| Self-hosted option | Yes | No | No |
+| PKI/Certificates | Built-in | Via ACM | Built-in |
+| Learning curve | Steep | Low | Low |
+| Cost | Free (OSS) | Per-secret/API call | Per-operation |
+
+**Choose Vault if:** You need multi-cloud support, dynamic secrets, or full control over your secrets infrastructure.
+
+**Choose AWS Secrets Manager if:** You're AWS-native and want simple integration with RDS, Lambda, and other AWS services.
+
+**Choose Azure Key Vault if:** You're in the Microsoft ecosystem and need tight integration with Azure services and Active Directory.
+
+## Prerequisites
+
+This guide assumes you have:
+
+- Basic understanding of authentication and authorization concepts
+- Experience with at least one cloud provider (AWS, Azure, or GCP)
+- Familiarity with CI/CD pipelines
+- Command-line proficiency
+
+## Time Investment
+
+- **Quick start**: 1-2 hours (basic setup and first secret)
+- **Production setup**: 1-2 days (HA, policies, integration)
+- **Mastery**: Ongoing (dynamic secrets, PKI, advanced patterns)
+
+Let's secure your secrets!


### PR DESCRIPTION
Partial fix for #750 - adds Secrets Management guide (skill 11 of 24)

## Changes
- 5 new guide files covering secrets management fundamentals, HashiCorp Vault, AWS Secrets Manager, and Azure Key Vault
- Updated DevSecOps roadmap with link to guide

## Guide Contents
1. **Fundamentals** - Threat models, secret types, lifecycle, core principles
2. **HashiCorp Vault** - Setup, secrets engines, auth methods, policies, HA
3. **AWS Secrets Manager** - CLI/Terraform, rotation with Lambda, ECS/Lambda integration
4. **Azure Key Vault** - Managed identity, RBAC, CSI driver for AKS

All 4505 tests pass.