### PR TITLE
fix: Correct post dates from 2025 to 2026

### DIFF
--- a/content/posts/devops-vs-sysadmin-vs-sre.md
+++ b/content/posts/devops-vs-sysadmin-vs-sre.md
@@ -4,7 +4,7 @@ excerpt: "Confused about DevOps, SysAdmin, and SRE roles? This beginner-friendly
 category:
   name: 'DevOps'
   slug: 'devops'
-date: '2025-01-25'
+date: '2026-01-25'
 publishedAt: '2025-01-25T10:00:00Z'
 updatedAt: '2025-01-25T10:00:00Z'
 readingTime: '12 min read'

--- a/content/posts/gitops-deploy-docker-containers-github-actions-argocd.md
+++ b/content/posts/gitops-deploy-docker-containers-github-actions-argocd.md
@@ -4,7 +4,7 @@ excerpt: 'Learn how to implement a modern GitOps workflow for Docker deployments
 category:
   name: 'DevOps'
   slug: 'devops'
-date: '2025-01-24'
+date: '2026-01-24'
 publishedAt: '2025-01-24T10:00:00Z'
 updatedAt: '2025-01-24T10:00:00Z'
 readingTime: '14 min read'

--- a/content/posts/how-to-publish-helm-chart.md
+++ b/content/posts/how-to-publish-helm-chart.md
@@ -4,7 +4,7 @@ excerpt: 'Learn how to package and publish your Helm charts to various repositor
 category:
   name: 'Kubernetes'
   slug: 'kubernetes'
-date: '2025-01-24'
+date: '2026-01-24'
 publishedAt: '2025-01-24T09:00:00Z'
 updatedAt: '2025-01-24T09:00:00Z'
 readingTime: '10 min read'

--- a/content/posts/what-is-devops.md
+++ b/content/posts/what-is-devops.md
@@ -4,7 +4,7 @@ excerpt: 'New to DevOps? This beginner-friendly guide explains what DevOps is, w
 category:
   name: 'DevOps'
   slug: 'devops'
-date: '2025-01-25'
+date: '2026-01-25'
 publishedAt: '2025-01-25T09:00:00Z'
 updatedAt: '2025-01-25T09:00:00Z'
 readingTime: '15 min read'


### PR DESCRIPTION
Fixes incorrect year in post dates.

**Posts updated:**
- `how-to-publish-helm-chart.md`: 2025-01-24 → 2026-01-24
- `devops-vs-sysadmin-vs-sre.md`: 2025-01-25 → 2026-01-25
- `what-is-devops.md`: 2025-01-25 → 2026-01-25
- `gitops-deploy-docker-containers-github-actions-argocd.md`: 2025-01-24 → 2026-01-24

All tests pass.