### PR TITLE
fix: Repair corrupt .png-cache.json that caused mass image regeneration

### DIFF
--- a/.png-cache.json
+++ b/.png-cache.json
@@ -519,7 +519,6 @@
   "public/images/posts/gitops-deploy-docker-containers-github-actions-argocd.svg": "855412f96012b098",
   "public/images/games/deployment-strategies-og.svg": "cd56c3b1e26bbfc1",
   "public/images/games/rest-vs-graphql-og.svg": "affa238a388c78ce",
-  "public/images/games/caching-simulator-og.svg": "8fa10c59bd0afbbf"
-},
+  "public/images/games/caching-simulator-og.svg": "8fa10c59bd0afbbf",
   "public/images/games/db-indexing-simulator-og.svg": "16544155e5faa281"
 }


### PR DESCRIPTION
## Problem
The `.png-cache.json` file was corrupted in commit 33ab6f5 (Database Indexing Simulator merge) with invalid JSON syntax:
```json
},
  "public/images/games/db-indexing-simulator-og.svg": "16544155e5faa281"
}
```

This caused `convert:svg-to-png:parallel` to silently fail when parsing the cache file, and fall back to regenerating ALL 511 PNG images.

## Fix
- Restored valid JSON structure from commit 34890ff (before corruption)
- Properly added the db-indexing-simulator entry inside the object

## Testing
- Verified JSON parses correctly with `JSON.parse()`
- Entry for db-indexing-simulator is present

## Impact
This should be merged ASAP to prevent future PRs from accidentally regenerating all images.