### PR TITLE
Add affiliate disclosure notice to posts with referral links

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -88,6 +88,16 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
   const relatedPosts = await getRelatedPosts(post.slug, post.category?.slug || '', 6);
 
+  // Check if post content contains affiliate links
+  const affiliatePatterns = [
+    'm.do.co',           // DigitalOcean referral
+    'amzn.to',           // Amazon short links
+    'amazon.com/.*tag=', // Amazon affiliate tags
+  ];
+  const hasAffiliateLinks = affiliatePatterns.some(pattern =>
+    new RegExp(pattern).test(post.content)
+  );
+
   // Split related posts for main section and sidebar
   const mainRelatedPosts = relatedPosts.slice(0, 3);
   const sidebarRelatedPosts = relatedPosts.slice(3, 6);
@@ -119,6 +129,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                   readingTime: post.readingTime || '5 min read',
                   category: post.category || { name: '', slug: '' },
                 }}
+                hasAffiliateLinks={hasAffiliateLinks}
               />
               {/* Post image */}
               {post.image && (

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
-import { Clock, Calendar, User } from 'lucide-react';
+import { Clock, Calendar, User, Info } from 'lucide-react';
 
 interface PostHeaderProps {
   post: {
@@ -16,9 +16,10 @@ interface PostHeaderProps {
       slug: string;
     };
   };
+  hasAffiliateLinks?: boolean;
 }
 
-export function PostHeader({ post }: PostHeaderProps) {
+export function PostHeader({ post, hasAffiliateLinks = false }: PostHeaderProps) {
   return (
     <div className="mb-8">
       <div className="flex flex-wrap items-center gap-2 mb-4">
@@ -41,6 +42,14 @@ export function PostHeader({ post }: PostHeaderProps) {
         )}
       </div>
       <h1 className="text-3xl md:text-4xl font-bold tracking-tight">{post.title}</h1>
+      {hasAffiliateLinks && (
+        <div className="mt-4 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200">
+          <Info className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>
+            <strong>Disclosure:</strong> This post contains affiliate links. We may earn a commission when you purchase through links in this article.
+          </span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a visible affiliate disclosure notice directly under the h1 title on posts that contain affiliate/referral links.

## Changes
- **PostHeader component**: Added `hasAffiliateLinks` prop to conditionally render disclosure notice
- **Post page**: Auto-detects affiliate links in content (DigitalOcean `m.do.co`, Amazon `amzn.to`, `amazon.com/.*tag=`)
- **Styling**: Amber-colored notice box with info icon for visibility

## Preview
The disclosure appears as:
> **Disclosure:** This post contains affiliate links. We may earn a commission when you purchase through links in this article.

## Why
Sponsors requested visible disclosure before affiliate links per FTC guidelines. This placement (under h1) ensures visibility before readers encounter any links.