### PR TITLE
Update DigitalOcean referral link to CJ Affiliate URL

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -90,7 +90,8 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
   // Check if post content contains affiliate links
   const affiliatePatterns = [
-    'm.do.co',           // DigitalOcean referral
+    'm.do.co',           // DigitalOcean referral (old)
+    'jdoqocy.com',       // DigitalOcean referral (CJ Affiliate)
     'amzn.to',           // Amazon short links
     'amazon.com/.*tag=', // Amazon affiliate tags
   ];

--- a/app/toolbox/page.tsx
+++ b/app/toolbox/page.tsx
@@ -98,7 +98,7 @@ const tools: Tool[] = [
   {
     name: 'DigitalOcean',
     description: 'Cloud infrastructure provider offering scalable compute and storage solutions.',
-    href: 'https://m.do.co/c/2a9bba940f39',
+    href: 'https://www.jdoqocy.com/click-101674709-15836238',
     category: 'cloud',
     icon: CloudCog,
     isPopular: true,

--- a/components/inline-sponsors.tsx
+++ b/components/inline-sponsors.tsx
@@ -9,7 +9,7 @@ const sponsors = [
   {
     name: 'DigitalOcean',
     logo: 'https://web-platforms.sfo2.cdn.digitaloceanspaces.com/WWW/Badge%202.svg',
-    url: 'https://m.do.co/c/2a9bba940f39',
+    url: 'https://www.jdoqocy.com/click-101674709-15836238',
     tagline: 'Cloud infrastructure for developers',
     description: 'Simple, reliable cloud computing designed for developers',
   },

--- a/components/sponsor-sidebar.tsx
+++ b/components/sponsor-sidebar.tsx
@@ -8,7 +8,7 @@ const sponsors = [
   {
     name: 'DigitalOcean',
     logo: 'https://web-platforms.sfo2.cdn.digitaloceanspaces.com/WWW/Badge%202.svg',
-    url: 'https://m.do.co/c/2a9bba940f39',
+    url: 'https://www.jdoqocy.com/click-101674709-15836238',
     tagline: 'Cloud infrastructure for developers',
   },
   {

--- a/content/guides/introduction-to-bash/03-working-with-files.md
+++ b/content/guides/introduction-to-bash/03-working-with-files.md
@@ -191,7 +191,7 @@ rsync -av source_directory/ destination_directory/
 rsync -avz -e ssh source_directory/ username@remote_host:/path/to/destination/
 ```
 
-> **Need a server to practice file operations?** If you want to experiment with remote file operations, consider setting up a DigitalOcean Droplet. Their basic plans start at just $4/month, and you can get $200 in credits to start with using this link: [https://m.do.co/c/2a9bba940f39](https://m.do.co/c/2a9bba940f39)
+> **Need a server to practice file operations?** If you want to experiment with remote file operations, consider setting up a DigitalOcean Droplet. Their basic plans start at just $4/month, and you can get $200 in credits to start with using this link: [https://www.jdoqocy.com/click-101674709-15836238](https://www.jdoqocy.com/click-101674709-15836238)
 
 ## Advanced File Operations
 

--- a/content/guides/introduction-to-bash/06-functions.md
+++ b/content/guides/introduction-to-bash/06-functions.md
@@ -404,7 +404,7 @@ retry() {
 retry "ping -c 1 google.com" 5 2
 ```
 
-> **Need a server to practice your Bash scripts?** If you're looking for a reliable, affordable environment to test your Bash scripts, consider using a DigitalOcean Droplet. You can get $200 in free credits to start with by signing up at [https://m.do.co/c/2a9bba940f39](https://m.do.co/c/2a9bba940f39)
+> **Need a server to practice your Bash scripts?** If you're looking for a reliable, affordable environment to test your Bash scripts, consider using a DigitalOcean Droplet. You can get $200 in free credits to start with by signing up at [https://www.jdoqocy.com/click-101674709-15836238](https://www.jdoqocy.com/click-101674709-15836238)
 
 ### Backup Function
 

--- a/content/guides/introduction-to-bash/09-bash-tools.md
+++ b/content/guides/introduction-to-bash/09-bash-tools.md
@@ -691,7 +691,7 @@ tmux ls
 tmux attach -t [session_id]
 ```
 
-> **Need a server to practice these Bash tools?** If you want a dedicated environment to experiment with these tools, consider setting up a DigitalOcean Droplet. Their basic plans start at just $4/month, and you can get $200 in credits using this link: [https://m.do.co/c/2a9bba940f39](https://m.do.co/c/2a9bba940f39)
+> **Need a server to practice these Bash tools?** If you want a dedicated environment to experiment with these tools, consider setting up a DigitalOcean Droplet. Their basic plans start at just $4/month, and you can get $200 in credits using this link: [https://www.jdoqocy.com/click-101674709-15836238](https://www.jdoqocy.com/click-101674709-15836238)
 
 ## Putting Tools Together: Practical Examples
 

--- a/content/guides/introduction-to-docker/02-docker-installation.md
+++ b/content/guides/introduction-to-docker/02-docker-installation.md
@@ -89,7 +89,7 @@ After running this command, log out and back in for the changes to take effect.
 
 If you don't want to install Docker locally, you can use a cloud-based development environment. DigitalOcean's Droplets provide an excellent platform for running Docker.
 
-You can quickly spin up a Droplet with Docker pre-installed using their One-Click Docker application. [Get $200 in free credits when you sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to test your Docker applications in the cloud.
+You can quickly spin up a Droplet with Docker pre-installed using their One-Click Docker application. [Get $200 in free credits when you sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to test your Docker applications in the cloud.
 
 ## Verifying Your Installation
 

--- a/content/guides/introduction-to-docker/03-working-with-docker-images.md
+++ b/content/guides/introduction-to-docker/03-working-with-docker-images.md
@@ -213,7 +213,7 @@ This is useful for transferring images to air-gapped environments or for backup 
 
 For team environments or production workloads, consider using a private registry like DigitalOcean Container Registry to store and share your custom images securely.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) and get $200 in free credits to try their Container Registry service.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) and get $200 in free credits to try their Container Registry service.
 
 ## Next Steps
 

--- a/content/guides/introduction-to-docker/04-creating-your-first-container.md
+++ b/content/guides/introduction-to-docker/04-creating-your-first-container.md
@@ -288,6 +288,6 @@ After running these commands, you can access your WordPress site at http://local
 
 For development teams, running Docker containers in the cloud provides a consistent environment accessible to everyone. DigitalOcean offers an excellent platform for this with fast SSD-based Droplets optimized for container workloads.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and deploy your containerized applications to the cloud.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and deploy your containerized applications to the cloud.
 
 In the next section, we'll learn how to build your own custom Docker images with Dockerfiles.

--- a/content/guides/introduction-to-docker/05-building-custom-docker-images.md
+++ b/content/guides/introduction-to-docker/05-building-custom-docker-images.md
@@ -346,7 +346,7 @@ docker build -t registry.example.com/myapp:1.0.0 .
 docker push registry.example.com/myapp:1.0.0
 ```
 
-For cloud-based container registries, DigitalOcean Container Registry offers a secure, private place to store your Docker images. [Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) and get $200 in free credits to try their Container Registry service.
+For cloud-based container registries, DigitalOcean Container Registry offers a secure, private place to store your Docker images. [Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) and get $200 in free credits to try their Container Registry service.
 
 ## Real-World Example: Building a Full-Stack Application
 

--- a/content/guides/introduction-to-docker/06-working-with-docker-volumes.md
+++ b/content/guides/introduction-to-docker/06-working-with-docker-volumes.md
@@ -315,7 +315,7 @@ Both containers have access to the same data in the volume.
 
 When running containers in the cloud, you can use platform-specific volume solutions. DigitalOcean's Block Storage provides SSD-based volumes that can be attached to your Droplets running Docker.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and try their Block Storage service with your containerized applications.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and try their Block Storage service with your containerized applications.
 
 ## tmpfs Mounts for Sensitive Data
 

--- a/content/guides/introduction-to-docker/07-networking-in-docker.md
+++ b/content/guides/introduction-to-docker/07-networking-in-docker.md
@@ -363,7 +363,7 @@ For applications where network performance is critical:
 
 When deploying containerized applications to the cloud, networking is a crucial consideration. DigitalOcean provides robust networking features for container-based applications, including private networks between Droplets.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and deploy your networked container applications in a production-ready environment.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and deploy your networked container applications in a production-ready environment.
 
 ## Network Troubleshooting Tools
 

--- a/content/guides/introduction-to-docker/08-docker-compose.md
+++ b/content/guides/introduction-to-docker/08-docker-compose.md
@@ -509,7 +509,7 @@ secrets:
 
 Docker Compose files work excellently when deploying to cloud providers like DigitalOcean. You can set up a Droplet with Docker installed and use your Compose file to deploy your application.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) and get $200 in free credits to deploy your Compose-based applications.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) and get $200 in free credits to deploy your Compose-based applications.
 
 Steps to deploy:
 

--- a/content/guides/introduction-to-docker/09-docker-best-practices.md
+++ b/content/guides/introduction-to-docker/09-docker-best-practices.md
@@ -564,7 +564,7 @@ For common components like databases, message queues, and caches, consider using
 
 ### Use DigitalOcean for Simplified Container Deployment
 
-DigitalOcean provides simplified container deployment options that implement many of these best practices automatically. [Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and deploy your containerized applications following best practices.
+DigitalOcean provides simplified container deployment options that implement many of these best practices automatically. [Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and deploy your containerized applications following best practices.
 
 ## Performance and Efficiency Best Practices
 

--- a/content/guides/introduction-to-docker/10-docker-in-production.md
+++ b/content/guides/introduction-to-docker/10-docker-in-production.md
@@ -551,7 +551,7 @@ DigitalOcean provides a user-friendly platform for running container workloads i
 - **DigitalOcean App Platform**: PaaS for containerized applications
 - **Droplets with Docker**: Self-managed Docker hosts
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and deploy your Docker applications to production with confidence.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and deploy your Docker applications to production with confidence.
 
 ## Disaster Recovery Planning
 

--- a/content/guides/introduction-to-kubernetes/02-setting-up-a-kubernetes-cluster.md
+++ b/content/guides/introduction-to-kubernetes/02-setting-up-a-kubernetes-cluster.md
@@ -233,7 +233,7 @@ Managed services offload the control plane management to cloud providers, allowi
 
 ### DigitalOcean Kubernetes (DOKS)
 
-DigitalOcean offers a managed Kubernetes service that simplifies setup and maintenance. [Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits to try DOKS.
+DigitalOcean offers a managed Kubernetes service that simplifies setup and maintenance. [Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits to try DOKS.
 
 You can create a cluster through the web UI or using their CLI tool, doctl:
 
@@ -512,6 +512,6 @@ When selecting a Kubernetes solution, consider these factors:
 - **Scalability**: All solutions can scale, but with different levels of effort
 - **Integration**: Consider how well it integrates with your existing tools
 
-For many teams, starting with a managed service like DigitalOcean Kubernetes ([Get $200 in free credits](https://m.do.co/c/2a9bba940f39)) provides a good balance of simplicity and capability while learning.
+For many teams, starting with a managed service like DigitalOcean Kubernetes ([Get $200 in free credits](https://www.jdoqocy.com/click-101674709-15836238)) provides a good balance of simplicity and capability while learning.
 
 In the next section, we'll explore how to work with pods and containers, the fundamental units of deployment in Kubernetes.

--- a/content/guides/introduction-to-kubernetes/03-pods-and-containers-in-kubernetes.md
+++ b/content/guides/introduction-to-kubernetes/03-pods-and-containers-in-kubernetes.md
@@ -505,6 +505,6 @@ DigitalOcean Kubernetes provides an optimized platform for running your pods wit
 - Block storage for persistent volumes
 - Container registry for your images
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and start deploying your pods on a production-ready Kubernetes platform.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and start deploying your pods on a production-ready Kubernetes platform.
 
 In the next section, we'll explore Deployments and ReplicaSets, which help you manage multiple pod instances and handle updates gracefully.

--- a/content/guides/introduction-to-kubernetes/04-deployments-and-replicasets.md
+++ b/content/guides/introduction-to-kubernetes/04-deployments-and-replicasets.md
@@ -651,6 +651,6 @@ DigitalOcean Kubernetes provides a reliable platform for running your Deployment
 - Load balancer integration for services
 - Container Registry for storing your images securely
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) and get $200 in free credits to deploy your applications on a production-ready Kubernetes platform.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) and get $200 in free credits to deploy your applications on a production-ready Kubernetes platform.
 
 In the next section, we'll explore Kubernetes Services and Networking, which enable communication between your applications and the outside world.

--- a/content/guides/introduction-to-kubernetes/05-services-and-networking.md
+++ b/content/guides/introduction-to-kubernetes/05-services-and-networking.md
@@ -566,7 +566,7 @@ spec:
       targetPort: 8080
 ```
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and easily provision load balancers for your Kubernetes services.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and easily provision load balancers for your Kubernetes services.
 
 ## Best Practices for Services and Networking
 

--- a/content/guides/introduction-to-kubernetes/06-configmaps-and-secrets.md
+++ b/content/guides/introduction-to-kubernetes/06-configmaps-and-secrets.md
@@ -736,6 +736,6 @@ When running Kubernetes in a production environment, properly managing configura
 - Support for external secret management systems
 - Encrypted etcd for secure storage
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and leverage these features for your applications.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and leverage these features for your applications.
 
 In the next section, we'll explore persistent storage in Kubernetes, which allows your applications to store data beyond the container lifecycle.

--- a/content/guides/introduction-to-kubernetes/07-persistent-storage-in-kubernetes.md
+++ b/content/guides/introduction-to-kubernetes/07-persistent-storage-in-kubernetes.md
@@ -376,7 +376,7 @@ spec:
       storage: 5Gi
 ```
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and try this Block Storage integration with Kubernetes.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and try this Block Storage integration with Kubernetes.
 
 ## StatefulSets with Persistent Storage
 
@@ -697,6 +697,6 @@ DigitalOcean makes it easy to provision and manage persistent storage for your K
 - Automated volume snapshots
 - Seamless Kubernetes integration through CSI driver
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and try their storage solutions with your Kubernetes applications.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and try their storage solutions with your Kubernetes applications.
 
 In the next section, we'll explore Kubernetes resource management, covering how to optimize your cluster's compute resources and implement effective scaling strategies.

--- a/content/guides/introduction-to-kubernetes/08-resource-management-and-scaling.md
+++ b/content/guides/introduction-to-kubernetes/08-resource-management-and-scaling.md
@@ -370,7 +370,7 @@ Cluster Autoscaler works with many cloud providers:
 
 On DigitalOcean, you can enable autoscaling when creating a cluster or by modifying existing node pools. Specify the minimum and maximum node count, and the cluster will automatically scale based on resource demands.
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and try out their autoscaling features for Kubernetes clusters.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and try out their autoscaling features for Kubernetes clusters.
 
 ## Analyzing Resource Usage
 
@@ -840,6 +840,6 @@ DigitalOcean Kubernetes provides a cost-effective platform with built-in autosca
 - Prometheus-compatible metrics API
 - Integration with DOKS metrics to Datadog, Prometheus, and other monitoring tools
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and efficiently manage resources on your Kubernetes clusters.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and efficiently manage resources on your Kubernetes clusters.
 
 In the next section, we'll explore monitoring and logging in Kubernetes, which are essential for maintaining visibility into your applications and infrastructure.

--- a/content/guides/introduction-to-kubernetes/09-monitoring-and-logging-in-kubernetes.md
+++ b/content/guides/introduction-to-kubernetes/09-monitoring-and-logging-in-kubernetes.md
@@ -911,7 +911,7 @@ DigitalOcean Kubernetes makes monitoring easy with:
 - Managed Prometheus and Grafana offered as add-ons
 - Simple log aggregation with existing tools
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and implement effective monitoring for your Kubernetes applications.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and implement effective monitoring for your Kubernetes applications.
 
 ## Best Practices for Kubernetes Monitoring and Logging
 

--- a/content/guides/introduction-to-kubernetes/10-best-practices-in-kubernetes.md
+++ b/content/guides/introduction-to-kubernetes/10-best-practices-in-kubernetes.md
@@ -791,7 +791,7 @@ DigitalOcean Kubernetes Service (DOKS) provides several security features:
    - Private networking
    - VPC integration
 
-[Sign up with DigitalOcean](https://m.do.co/c/2a9bba940f39) to get $200 in free credits and deploy your applications on a secure Kubernetes platform.
+[Sign up with DigitalOcean](https://www.jdoqocy.com/click-101674709-15836238) to get $200 in free credits and deploy your applications on a secure Kubernetes platform.
 
 ## Securing the CI/CD Pipeline
 

--- a/content/guides/introduction-to-linux/02-getting-started.md
+++ b/content/guides/introduction-to-linux/02-getting-started.md
@@ -120,7 +120,7 @@ Cloud providers let you create Linux servers in minutes without needing physical
 
 DigitalOcean provides one of the simplest ways to get started with a Linux server:
 
-1. Sign up for a DigitalOcean account (use [this link](https://m.do.co/c/2a9bba940f39) to receive $200 in credits for 60 days)
+1. Sign up for a DigitalOcean account (use [this link](https://www.jdoqocy.com/click-101674709-15836238) to receive $200 in credits for 60 days)
 2. Create a new Droplet (DigitalOcean's term for a virtual server)
 3. Select Ubuntu as the operating system
 4. Choose the smallest plan for learning ($4-5/month, or free with credits)

--- a/content/guides/introduction-to-linux/05-package-management.md
+++ b/content/guides/introduction-to-linux/05-package-management.md
@@ -746,7 +746,7 @@ When working with cloud servers, you'll often use package management to set up a
 
 DigitalOcean makes it easy to create a Linux server with various distributions. Here's a quick way to get started:
 
-1. Sign up for a DigitalOcean account (use [this link](https://m.do.co/c/2a9bba940f39) to receive $200 in credits for 60 days)
+1. Sign up for a DigitalOcean account (use [this link](https://www.jdoqocy.com/click-101674709-15836238) to receive $200 in credits for 60 days)
 2. Create a Droplet (virtual server) with your preferred Linux distribution
 3. Connect via SSH and update your system:
 

--- a/content/guides/introduction-to-linux/06-user-management.md
+++ b/content/guides/introduction-to-linux/06-user-management.md
@@ -734,7 +734,7 @@ sudo quota -u username
 
 When working with cloud servers, you'll often need to set up users. Here's how to do it on a DigitalOcean Droplet:
 
-1. Create a new Droplet (use [this link](https://m.do.co/c/2a9bba940f39) for $200 in credits)
+1. Create a new Droplet (use [this link](https://www.jdoqocy.com/click-101674709-15836238) for $200 in credits)
 2. Connect as root
 3. Create a non-root user with sudo privileges:
 

--- a/content/guides/introduction-to-linux/07-process-management.md
+++ b/content/guides/introduction-to-linux/07-process-management.md
@@ -826,7 +826,7 @@ When running Linux in cloud environments, efficient process management is crucia
 
 ### Cloud Process Management Example
 
-For example, on a DigitalOcean Droplet (use [this link](https://m.do.co/c/2a9bba940f39) for $200 in credits):
+For example, on a DigitalOcean Droplet (use [this link](https://www.jdoqocy.com/click-101674709-15836238) for $200 in credits):
 
 1. Choose a Droplet size appropriate for your workload
 2. Monitor resource usage to avoid over-provisioning

--- a/content/guides/introduction-to-linux/08-networking.md
+++ b/content/guides/introduction-to-linux/08-networking.md
@@ -771,7 +771,7 @@ When running Linux in the cloud, network configuration is often handled differen
 
 ### Example: DigitalOcean Droplet
 
-When you create a Droplet on DigitalOcean (use [this link](https://m.do.co/c/2a9bba940f39) to receive $200 in credits), networking is pre-configured, but you may need to make changes:
+When you create a Droplet on DigitalOcean (use [this link](https://www.jdoqocy.com/click-101674709-15836238) to receive $200 in credits), networking is pre-configured, but you may need to make changes:
 
 1. Configure Private Networking:
 

--- a/content/guides/introduction-to-linux/09-shell-scripting.md
+++ b/content/guides/introduction-to-linux/09-shell-scripting.md
@@ -1135,7 +1135,7 @@ main "${ARGS[@]}"
 
 Shell scripts are extremely valuable for cloud automation. Here's an example of how you might use shell scripting on a DigitalOcean Droplet:
 
-1. Sign up for a DigitalOcean account (use [this link](https://m.do.co/c/2a9bba940f39) to receive $200 in credits for 60 days)
+1. Sign up for a DigitalOcean account (use [this link](https://www.jdoqocy.com/click-101674709-15836238) to receive $200 in credits for 60 days)
 2. Create a new Droplet
 3. Create this automation script:
 

--- a/content/guides/introduction-to-linux/10-system-administration.md
+++ b/content/guides/introduction-to-linux/10-system-administration.md
@@ -1086,7 +1086,7 @@ Running Linux in the cloud requires specific considerations:
 
 Managing a Linux server on DigitalOcean:
 
-1. Create a Droplet (use [this link](https://m.do.co/c/2a9bba940f39) to receive $200 in credits for 60 days)
+1. Create a Droplet (use [this link](https://www.jdoqocy.com/click-101674709-15836238) to receive $200 in credits for 60 days)
 
 2. Secure and optimize a cloud server:
 

--- a/content/posts/heroku-alternatives-2026.md
+++ b/content/posts/heroku-alternatives-2026.md
@@ -26,7 +26,7 @@ If you've been relying on Heroku for its simplicity and developer experience, no
 
 ## 1. DigitalOcean App Platform (Recommended)
 
-[DigitalOcean App Platform](https://m.do.co/c/2a9bba940f39) is probably the closest experience to Heroku you'll find. It offers the same git-push-to-deploy workflow that made Heroku famous, with competitive pricing and excellent documentation.
+[DigitalOcean App Platform](https://www.jdoqocy.com/click-101674709-15836238) is probably the closest experience to Heroku you'll find. It offers the same git-push-to-deploy workflow that made Heroku famous, with competitive pricing and excellent documentation.
 
 **Why it's great:**
 - **Heroku-like simplicity** — Connect your GitHub repo and deploy
@@ -51,7 +51,7 @@ services:
     instance_size_slug: basic-xxs
 ```
 
-[Get started with DigitalOcean App Platform →](https://m.do.co/c/2a9bba940f39)
+[Get started with DigitalOcean App Platform →](https://www.jdoqocy.com/click-101674709-15836238)
 
 ---
 
@@ -144,7 +144,7 @@ Before you migrate, here's what to prepare:
 
 Heroku's move to maintenance mode marks the end of an era. The platform that pioneered "git push to deploy" is stepping back, but its legacy lives on in the alternatives that followed.
 
-**Our recommendation:** Start with [DigitalOcean App Platform](https://m.do.co/c/2a9bba940f39) if you want the smoothest transition. It's the closest to the Heroku experience with transparent pricing and solid documentation.
+**Our recommendation:** Start with [DigitalOcean App Platform](https://www.jdoqocy.com/click-101674709-15836238) if you want the smoothest transition. It's the closest to the Heroku experience with transparent pricing and solid documentation.
 
 Whatever you choose, the good news is that in 2026, there are more options than ever for deploying applications without managing infrastructure.
 


### PR DESCRIPTION
## Summary
Updates the DigitalOcean referral link from the old `m.do.co` URL to the new CJ Affiliate URL.

## Changes
- **All content files**: Replaced `https://m.do.co/c/2a9bba940f39` with `https://www.jdoqocy.com/click-101674709-15836238`
- **Sponsor components**: Updated referral URL in `inline-sponsors.tsx`, `sponsor-sidebar.tsx`, `toolbox/page.tsx`
- **Guide content**: Updated 30+ guide files across bash, docker, kubernetes, and linux guides
- **Blog posts**: Updated Heroku alternatives post
- **Affiliate detection**: Added `jdoqocy.com` to `affiliatePatterns` in posts page for proper disclosure detection

## Files Changed
- `app/posts/[slug]/page.tsx` - Added jdoqocy.com to affiliate patterns
- `app/toolbox/page.tsx` - Updated DO referral link
- `components/inline-sponsors.tsx` - Updated DO referral link
- `components/sponsor-sidebar.tsx` - Updated DO referral link
- `content/guides/introduction-to-bash/*.md` - Updated referral links
- `content/guides/introduction-to-docker/*.md` - Updated referral links
- `content/guides/introduction-to-kubernetes/*.md` - Updated referral links
- `content/guides/introduction-to-linux/*.md` - Updated referral links
- `content/posts/heroku-alternatives-2026.md` - Updated referral link