### PR TITLE
fix: DevSecOps Roadmap report-issue floating bug (#875)

### DIFF
--- a/app/roadmap/devsecops/page.tsx
+++ b/app/roadmap/devsecops/page.tsx
@@ -914,9 +914,16 @@ export default function DevSecOpsRoadmapPage() {
       </section>
 
       {/* Report Issue */}
-      <div className="fixed bottom-4 right-4 z-50">
-        <ReportIssue />
-      </div>
+      <section className="py-8 container mx-auto px-4 max-w-4xl mb-16">
+        <div className="text-center">
+          <ReportIssue
+            title="Found an issue with this roadmap?"
+            type="page"
+            slug="roadmap/devsecops"
+            variant="default"
+          />
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #875 - The "Report Issue" component on the DevSecOps Roadmap page was floating (`fixed bottom-4 right-4`) and covering content.

## Changes

- Moved `ReportIssue` from fixed positioning to inline section at bottom of page
- Added proper props (`title`, `type`, `slug`, `variant`) consistent with other roadmap pages
- Now matches the pattern used in `/roadmap` and `/roadmap/junior` pages

## Before
Floating div covering content in bottom-right corner

## After
Inline section at bottom of page, below Additional Resources