### PR TITLE
fix: Update games page to use new simulators OG image (#915)

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     url: '/games',
     images: [
       {
-        url: '/og-image.png',
+        url: '/images/pages/simulators.png',
         width: 1200,
         height: 630,
         alt: 'DevOps Games & Interactive Tools',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
     title: 'DevOps Games & Interactive Tools - DevOps Daily',
     description:
       'Interactive games and fun simulators for DevOps professionals to learn and practice skills in a playful way. Explore our collection of DevOps-themed games designed to enhance your skills and knowledge.',
-    images: ['/og-image.png'],
+    images: ['/images/pages/simulators.png'],
   },
 };
 


### PR DESCRIPTION
Closes #915

## Summary
Updates the games page Open Graph and Twitter card metadata to use the new `simulators.png` image instead of the generic `og-image.png`.

## Changes Made
- ✅ Updated OpenGraph image in `app/games/page.tsx` from `/og-image.png` to `/images/pages/simulators.png`
- ✅ Updated Twitter card image from `/og-image.png` to `/images/pages/simulators.png`

## Impact
The games page will now show the proper simulators-themed image when shared on social media platforms instead of the generic site OG image.

## Testing
- ✅ All 4,525 tests pass
- ✅ Metadata dimensions remain 1200x630 (correct for OG images)

## Files Changed
- `app/games/page.tsx` - Updated metadata configuration