### PR TITLE
Fix: Add embed endpoints for PromQL Playground and Service Mesh Simulator

### DIFF
--- a/app/games/[slug]/embed/page.tsx
+++ b/app/games/[slug]/embed/page.tsx
@@ -32,6 +32,8 @@ import InfraTarot from '@/components/games/infra-tarot';
 import DevOpsMemes from '@/components/games/devops-memes';
 import BCDRSimulator from '@/components/games/bcdr-simulator';
 import SslTlsHandshakeSimulator from '@/components/games/ssl-tls-handshake-simulator';
+import PromqlPlayground from '@/components/games/promql-playground';
+import ServiceMeshSimulator from '@/components/games/service-mesh-simulator';
 
 // Map of game slugs to their components
 const GAME_COMPONENTS: Record<string, React.ComponentType> = {
@@ -63,6 +65,8 @@ const GAME_COMPONENTS: Record<string, React.ComponentType> = {
   'devops-memes': DevOpsMemes,
   'bcdr-simulator': BCDRSimulator,
   'ssl-tls-handshake': SslTlsHandshakeSimulator,
+  'promql-playground': PromqlPlayground,
+  'service-mesh-simulator': ServiceMeshSimulator,
 };
 
 interface PageProps {


### PR DESCRIPTION
Fixes #936

Adds missing embed endpoint support for:
- `/games/promql-playground/embed`
- `/games/service-mesh-simulator/embed`

Both games are now registered in the `GAME_COMPONENTS` map in `app/games/[slug]/embed/page.tsx`.

**Testing:**
- ✅ All 4,525 tests passing
- Build Test workflow will verify embed endpoints work correctly