### PR TITLE
Rewrite: Claude Code plugins post - DevOps focused

### DIFF
--- a/content/posts/best-claude-code-plugins-devops-2026.md
+++ b/content/posts/best-claude-code-plugins-devops-2026.md
@@ -1,13 +1,13 @@
 ---
 title: 'Best Claude Code Plugins for DevOps Engineers in 2026'
-excerpt: 'A practical guide to Claude Code plugins that actually help with DevOps workflows - from live documentation lookup to automated security scanning. Honest recommendations on what to install and what to skip.'
+excerpt: 'A curated guide to Claude Code plugins built for DevOps workflows - from Terraform validation and Kubernetes troubleshooting to security scanning and CI/CD pipeline optimization.'
 category:
   name: 'DevOps'
   slug: 'devops'
-date: '2026-04-11'
-publishedAt: '2026-04-11T09:00:00Z'
-updatedAt: '2026-04-11T09:00:00Z'
-readingTime: '12 min read'
+date: '2026-04-12'
+publishedAt: '2026-04-12T09:00:00Z'
+updatedAt: '2026-04-12T09:00:00Z'
+readingTime: '14 min read'
 author:
   name: 'Bobby Iliev'
   slug: 'bobby-iliev'
@@ -19,201 +19,370 @@ tags:
   - Plugins
   - Automation
   - Developer Tools
+  - Terraform
+  - Kubernetes
 ---
 
-Claude Code plugins extend what the AI coding assistant can do - from looking up live documentation to scanning for security vulnerabilities. The plugin ecosystem has grown quickly, and not all plugins are worth installing. More plugins means more context consumed per message, slower responses, and potential conflicts.
+Claude Code plugins add specialized capabilities to your AI coding assistant. For DevOps engineers, the right plugins can validate Terraform configurations, troubleshoot Kubernetes clusters, scan for security vulnerabilities, and optimize CI/CD pipelines directly from your terminal.
 
-This post covers the plugins that genuinely help with DevOps workflows, explains what each one does with real examples, and gives honest recommendations on which ones to actually install versus which ones to skip.
+This guide covers every plugin worth knowing about for DevOps work, organized by category, with installation commands and practical examples.
 
 ## TLDR
 
-- Install **Context7** (live docs lookup) and **Security Guidance** (vulnerability scanning) - these solve real problems
-- Consider **GitHub** if you manage many repos, but the `gh` CLI already works fine
-- Skip most business/marketing plugins unless you have a specific need
-- More plugins is not better - each one adds overhead to every interaction
-- The official marketplace at `claude.com/plugins` has the most reliable options
+- **Context7** and **Security Guidance** are the foundation - install these first
+- **HashiCorp Agent Skills** add Terraform and Packer expertise
+- **DevOps Skills Marketplace** has specialized tools for Kubernetes, CI/CD, monitoring, and FinOps
+- **Shipyard** handles infrastructure validation across Terraform, Ansible, Docker, and Kubernetes
+- **GitHub** plugin streamlines multi-repo PR and CI/CD management
 
 ## Prerequisites
 
-- Claude Code CLI installed and working
-- Basic familiarity with Claude Code commands and workflows
-- Active projects where you want to improve your development workflow
+- Claude Code CLI installed (`claude --version` to verify)
+- Basic familiarity with Claude Code commands
+- Active infrastructure or DevOps projects
 
-## How Claude Code Plugins Work
-
-Plugins add new capabilities to Claude Code through **skills**, **hooks**, and **MCP servers**. When you install a plugin, it registers additional tools that Claude can use during your conversations.
-
-Install a plugin from the marketplace:
+## How to Install Plugins
 
 ```bash
-/install-plugin context7
+# Install from the official marketplace
+claude plugin install context7
+
+# Add a community marketplace
+claude plugin marketplace add devops-claude-skills
+
+# Install a skill from a marketplace
+claude plugin install iac-terraform@devops-skills
+
+# List installed plugins
+claude plugin list
 ```
 
-Or from a GitHub URL:
-
-```bash
-/install-plugin https://github.com/org/plugin-name
-```
-
-List your installed plugins:
-
-```bash
-/plugins
-```
-
-Each plugin consumes context when loaded. A plugin with 10 skills adds those skill descriptions to every conversation, even when you are not using them. This is why being selective matters.
-
-## The Must-Have Plugins
+## Foundation Plugins
 
 ### Context7 - Live Documentation Lookup
 
-**What it does:** Pulls current API documentation and examples from source repositories in real time. When Claude writes code using a library, Context7 checks the actual current docs instead of relying on training data.
+**Install:** `claude plugin install context7`
 
-**Why it matters for DevOps:** DevOps tools change fast. Terraform provider arguments, Kubernetes API versions, Helm chart values, and cloud SDK methods all evolve between releases. Without Context7, Claude might generate code using deprecated flags or outdated syntax.
+Context7 pulls current API documentation and code examples from source repositories in real time. Instead of relying on training data that might be months old, Claude checks the actual docs before generating code.
 
-**Real example:** You ask Claude to write a Prisma query using the latest features. Without Context7, it might use `prisma.user.findUnique()` with Prisma 4 syntax when you are on Prisma 7 (which requires an adapter argument in the constructor). With Context7, it checks the current Prisma docs and generates correct code.
+This matters for DevOps because tooling changes fast. Terraform provider arguments get deprecated between minor versions. Kubernetes API versions evolve. Helm chart values change across releases. Without live docs, you end up debugging code that worked six months ago but fails today.
+
+**Example:** You ask Claude to write a Terraform module for an AWS ECS Fargate service. Without Context7, it might use the `launch_type` argument that was replaced by `capacity_provider_strategy` in recent versions. With Context7, it checks the current AWS provider docs and generates the correct configuration.
 
 ```bash
-# Context7 in action - Claude automatically looks up current docs
-> Write a BullMQ worker with rate limiting
+# Context7 automatically activates when Claude generates code
+> Write a Terraform module for an AWS ECS Fargate service with auto-scaling
 
-# Without Context7: might use old API (queue names with colons, deprecated options)
-# With Context7: uses current BullMQ API (no colons in names, correct limiter syntax)
+# Claude looks up current aws_ecs_service, aws_ecs_task_definition,
+# and aws_appautoscaling_target resources from the provider docs
 ```
 
-**Verdict:** Install this one. It directly prevents the most common type of AI coding error - outdated API usage.
+### Security Guidance - Infrastructure Security Scanning
 
-### Security Guidance - Vulnerability Scanning
+**Install:** `claude plugin install security-guidance`
 
-**What it does:** Scans your code for OWASP Top 10 vulnerabilities, authentication flaws, injection risks, hardcoded secrets, and insecure configurations.
+Security Guidance scans your code for OWASP Top 10 vulnerabilities, authentication flaws, injection risks, hardcoded secrets, and insecure configurations. For DevOps, this catches issues in API routes, webhook handlers, deployment configs, and infrastructure code.
 
-**Why it matters for DevOps:** Infrastructure code and API routes are security-critical. Missing rate limiting on an auth endpoint, a hardcoded secret in a config file, or an unvalidated webhook signature can all lead to real incidents.
-
-**Real example:** You are building an API with authentication. Security Guidance would flag:
+**Example:** Running a security scan on a production API:
 
 ```text
 Issues found:
-- /api/auth/forgot-password: No rate limiting (account enumeration risk)
-- /api/webhooks/ses: No signature verification (spoofing risk)
-- /lib/auth.ts: JWT maxAge not configured (sessions never expire)
-- blog.ts: sanitize: false in HTML renderer (XSS risk)
+- Dockerfile: Running as root user (use non-root USER directive)
+- terraform/main.tf: S3 bucket missing encryption configuration
+- src/api/webhook.ts: No signature verification on incoming webhooks
+- .env.example: Default secrets that could be committed accidentally
+- nginx.conf: Missing security headers (HSTS, CSP, X-Frame-Options)
 ```
 
-These are all real issues we found in a production codebase during a manual audit. An automated scan catches them earlier.
+These are the kinds of issues that slip through code review but get caught in a security incident.
 
-**Verdict:** Install this one. Security issues caught early cost nothing to fix. Security issues caught in production cost everything.
+### GitHub - Repository and CI/CD Management
 
-## The "Consider" Plugins
+**Install:** `claude plugin install github`
 
-### GitHub - PR and Issue Management
+The GitHub plugin adds direct integration with pull requests, issues, code search, and CI/CD workflows. While you can achieve similar results with the `gh` CLI, the plugin provides a more structured interface for managing multiple repositories.
 
-**What it does:** Creates PRs, manages issues, searches code across repositories, and interacts with CI/CD workflows directly from Claude Code.
-
-**Why it matters:** If you manage multiple repositories and spend time creating PRs with proper descriptions, this can save time.
-
-**The honest take:** The `gh` CLI already handles everything this plugin does. Claude Code can already run `gh pr create`, `gh issue list`, and `gh run view` through the Bash tool. The plugin wraps these into more convenient commands, but it is not solving a problem you cannot already solve.
-
-**When to install:** If you manage 5+ repos and create many PRs per day. Otherwise, `gh` CLI is fine.
-
-### Code Review - Structured Reviews
-
-**What it does:** Runs structured code reviews covering bugs, security, performance, and style. Outputs findings in a consistent format.
-
-**Why it matters:** Useful if you merge PRs without detailed manual review.
-
-**The honest take:** This adds review overhead to every interaction. If you already review your own code or have CI checks, it might slow you down more than it helps.
-
-**When to install:** If you frequently merge code without review and want an automated safety net.
-
-### Commit Commands - Git Workflow Automation
-
-**What it does:** Generates smart commit messages, creates PRs with descriptions, and generates changelogs.
-
-**The honest take:** Claude Code already writes good commit messages when you ask. This plugin formalizes the process but does not add capabilities you do not already have.
-
-**When to install:** If you want enforced commit message conventions across a team.
-
-## The Business Plugins
-
-Anthropic also has a **knowledge-work-plugins** marketplace with business-focused tools:
+**Useful for:**
+- Creating PRs across multiple repos in one session
+- Searching code patterns across your organization
+- Checking CI/CD workflow status and debugging failures
+- Managing issue backlogs with labels and milestones
 
 ```bash
-/plugin marketplace add anthropics/knowledge-work-plugins
+# Check failing CI workflow and suggest fixes
+> Why is the deploy workflow failing on the main branch?
+
+# Claude uses the GitHub plugin to fetch workflow logs,
+# identify the failing step, and suggest a fix
 ```
 
-### Brand Voice
+### Code Review - Automated PR Review
 
-**What it does:** Enforces consistent tone across all generated content. Upload your style guide once and it applies everywhere.
+**Install:** `claude plugin install code-review`
 
-**For DevOps teams:** Useful if you write documentation, blog posts, or runbooks and want consistent tone. You can achieve the same thing with a CLAUDE.md file that says "no em dashes, practical tone, no marketing speak" - but Brand Voice is more structured.
+The Code Review plugin runs structured reviews covering bugs, security issues, performance problems, and style inconsistencies. It outputs findings in a consistent format with severity levels.
 
-### Marketing
+**Useful for:**
+- Reviewing infrastructure changes before merging (Terraform plans, Kubernetes manifests)
+- Catching security issues in Dockerfiles and CI configs
+- Ensuring consistency across Helm values files and environment configs
+- Getting a second opinion on complex refactors
 
-**What it does:** SEO audits, content strategy, competitive analysis, campaign planning.
+## HashiCorp Agent Skills
 
-**For DevOps teams:** Useful if you maintain a developer blog or documentation site. Can help audit your docs for SEO and suggest improvements. Not useful for infrastructure work.
+HashiCorp maintains official Claude Code skills for Terraform and Packer. These are not generic plugins - they encode HashiCorp's best practices, naming conventions, and testing frameworks.
 
-## What to Skip
-
-**Skip these unless you have a specific, immediate need:**
-
-- **Frontend Design** - generates polished UI code. Great for frontend devs, not relevant for most DevOps work
-- **SQL Analytics** - useful for data teams, not for infrastructure
-- **Data Engineering** - Airflow and warehouse tools. Install only if you actually use these
-- **Amplitude** - analytics tracking. Very specific use case
-- **Supabase** - database management through prompts. You probably use Prisma, Terraform, or direct SQL
-- **Sales/Legal/Finance/Productivity** - business tools, not development tools
-- **Firecrawl** - web scraping. Occasionally useful for research but not worth the permanent context cost
-- **Sourcegraph** - cross-codebase search. Powerful but heavy. Use `grep` and `find` for most cases
-
-## When Plugins Help vs When They Hurt
-
-### Plugins help when:
-
-- They prevent errors you repeatedly make (Context7 for outdated APIs)
-- They catch issues you would otherwise miss (Security Guidance)
-- They automate a task you do many times per day (GitHub for heavy PR workflows)
-- The context cost is worth the capability
-
-### Plugins hurt when:
-
-- You install them "just in case" - every plugin consumes context in every conversation
-- They duplicate capabilities you already have (most Git plugins vs `gh` CLI)
-- They add review/validation steps to simple tasks (Code Review on trivial changes)
-- They conflict with your existing workflow or CLAUDE.md instructions
-
-### The context cost calculation
-
-Each plugin adds its skill descriptions to your conversation context. A plugin with 20 skills might add 2,000-5,000 tokens of context overhead. With a context window of around 200K tokens, that sounds small - but it adds up:
-
-```text
-No plugins:           ~200K tokens available for your code
-2 focused plugins:    ~195K tokens available (minimal impact)
-10 plugins:           ~170K tokens available (noticeable)
-20 plugins:           ~140K tokens available (significant)
+```bash
+# Add the HashiCorp skills marketplace
+claude plugin marketplace add hashicorp/agent-skills
 ```
 
-More plugins also means Claude spends more time deciding which tools to use, which can slow down responses.
+### Terraform Skills
 
-## My Recommended Setup
+**Install individually:**
 
-For a DevOps engineer working on infrastructure, APIs, and deployment pipelines:
-
-```text
-Must install:
-  1. Context7 (live docs - prevents outdated code)
-  2. Security Guidance (vulnerability scanning)
-
-Maybe install:
-  3. GitHub (only if managing 5+ repos daily)
-
-Skip everything else until you have a specific need.
+```bash
+claude plugin install terraform-style@hashicorp       # Style conventions
+claude plugin install terraform-testing@hashicorp      # Testing frameworks
+claude plugin install terraform-stacks@hashicorp       # Stacks orchestration
+claude plugin install terraform-providers@hashicorp    # Provider development
+claude plugin install terraform-refactoring@hashicorp  # Module refactoring
 ```
 
-This gives you the highest value with the lowest overhead. You can always add more later - but you cannot get back the context and speed you lose from plugins you do not use.
+These skills teach Claude how to write Terraform code the way HashiCorp recommends:
+
+- **Style conventions** enforce naming patterns, file organization, and documentation standards
+- **Testing** generates `terraform test` configurations and validation rules
+- **Stacks** helps orchestrate multi-layer infrastructure deployments
+- **Provider development** assists in building custom Terraform providers in Go
+- **Refactoring** breaks monolithic configurations into reusable modules
+
+**Example:** You ask Claude to refactor a 500-line `main.tf` into modules. The refactoring skill guides the process: identifying resource groups, extracting variables, setting up module interfaces, and maintaining state compatibility.
+
+```bash
+> Refactor this Terraform configuration into reusable modules
+
+# With the terraform-refactoring skill, Claude:
+# 1. Identifies logical resource groups (networking, compute, database)
+# 2. Creates module directories with proper file structure
+# 3. Extracts variables and outputs for each module
+# 4. Updates the root module to call the new modules
+# 5. Generates moved blocks for state migration
+```
+
+### Packer Skills
+
+```bash
+claude plugin install packer-aws@hashicorp        # AWS image building
+claude plugin install packer-azure@hashicorp       # Azure image building
+claude plugin install packer-windows@hashicorp     # Windows images
+claude plugin install packer-hcp@hashicorp         # HCP Packer integration
+```
+
+These cover machine image building across cloud providers:
+
+- Platform-specific builder configurations and provisioners
+- HCP Packer integration for image lifecycle management
+- Multi-platform build templates
+
+## DevOps Skills Marketplace
+
+A community-maintained collection of specialized DevOps skills. Each one focuses on a specific domain.
+
+```bash
+# Add the marketplace
+claude plugin marketplace add devops-claude-skills
+```
+
+### Terraform and IaC
+
+**Install:** `claude plugin install iac-terraform@devops-skills`
+
+Goes beyond the HashiCorp skills with Terragrunt support, state management workflows, and multi-environment patterns.
+
+**Covers:**
+- Terraform and Terragrunt configuration authoring
+- State inspection and migration strategies
+- Module development with versioning
+- Multi-environment workspace patterns (dev/staging/prod)
+
+### Kubernetes Troubleshooter
+
+**Install:** `claude plugin install k8s-troubleshooter@devops-skills`
+
+A diagnostic toolkit for Kubernetes problems. Instead of generic Kubernetes knowledge, this skill includes structured troubleshooting playbooks.
+
+**Covers:**
+- Cluster health checks (node status, resource pressure, component health)
+- Pod diagnostics (CrashLoopBackOff, OOMKilled, ImagePullBackOff)
+- Networking issues (service connectivity, DNS resolution, ingress routing)
+- Resource quota and limit analysis
+- Incident response playbooks
+
+**Example:**
+
+```bash
+> My pods keep getting OOMKilled in the production namespace
+
+# The k8s-troubleshooter skill:
+# 1. Checks current resource requests and limits
+# 2. Analyzes actual memory usage vs limits
+# 3. Reviews the application's memory profile
+# 4. Suggests right-sized limits based on usage patterns
+# 5. Generates the updated deployment manifest
+```
+
+### CI/CD Pipeline Optimization
+
+**Install:** `claude plugin install ci-cd@devops-skills`
+
+Covers pipeline design, performance optimization, security hardening, and debugging across multiple CI/CD platforms.
+
+**Covers:**
+- GitHub Actions, GitLab CI, Jenkins, CircleCI workflows
+- Pipeline performance optimization (caching, parallelization, conditional jobs)
+- Security hardening (secret management, OIDC authentication, dependency scanning)
+- Debugging failed pipelines with structured analysis
+
+**Example:**
+
+```bash
+> My GitHub Actions deploy workflow takes 12 minutes. Help me speed it up.
+
+# The ci-cd skill analyzes the workflow file and suggests:
+# - Docker layer caching for build steps
+# - Parallel test execution
+# - Conditional deployment (skip if only docs changed)
+# - Artifact caching between jobs
+```
+
+### GitOps Workflows
+
+**Install:** `claude plugin install gitops-workflows@devops-skills`
+
+Production-ready templates for ArgoCD and Flux CD, including modern secrets management.
+
+**Covers:**
+- ArgoCD Application and ApplicationSet configurations
+- Flux CD GitRepository, Kustomization, and HelmRelease resources
+- Secrets management with SOPS, Sealed Secrets, and External Secrets Operator
+- Multi-cluster deployment patterns
+- Progressive delivery with Argo Rollouts and Flagger
+
+### Monitoring and Observability
+
+**Install:** `claude plugin install monitoring-observability@devops-skills`
+
+Everything related to metrics, tracing, alerting, and SLO management.
+
+**Covers:**
+- Prometheus configuration, recording rules, and alerting rules
+- Grafana dashboard creation and templating
+- Distributed tracing with OpenTelemetry, Jaeger, and Zipkin
+- SLO definition and error budget calculations
+- Alert routing and escalation policies
+- Datadog, New Relic, and CloudWatch integration patterns
+
+### AWS Cost Optimization
+
+**Install:** `claude plugin install aws-cost-optimization@devops-skills`
+
+FinOps workflows for identifying waste and optimizing cloud spend.
+
+**Covers:**
+- Automated analysis scripts for unused resources
+- Right-sizing recommendations for EC2, RDS, and ECS
+- Reserved Instance and Savings Plan analysis
+- Cost allocation tag strategies
+- Budget alerts and anomaly detection
+
+## Infrastructure Validation with Shipyard
+
+**Install:** `claude plugin install shipyard`
+
+Shipyard is an enterprise-grade infrastructure validation plugin that covers multiple IaC tools in one package.
+
+**What it validates:**
+- Terraform configurations (syntax, best practices, security)
+- Ansible playbooks (lint, idempotency, security)
+- Docker images and Dockerfiles (security scanning, layer optimization)
+- Kubernetes manifests (resource limits, security contexts, network policies)
+- CloudFormation templates (syntax, drift detection)
+
+It includes a dedicated security auditor agent that runs focused scans on infrastructure code.
+
+```bash
+> Validate my Terraform configuration for security issues
+
+# Shipyard checks for:
+# - Overly permissive IAM policies
+# - Unencrypted storage resources
+# - Public network access where private is expected
+# - Missing logging and monitoring
+# - Non-compliant resource configurations
+```
+
+## Community Plugin: Terraform Skill by Anton Babenko
+
+**Install:** `claude plugin install https://github.com/antonbabenko/terraform-skill`
+
+Created by Anton Babenko (author of terraform-aws-modules, the most popular Terraform module collection), this skill brings deep Terraform and OpenTofu expertise.
+
+**Covers:**
+- Module design patterns from terraform-aws-modules
+- AWS architecture best practices
+- Cost-aware infrastructure design
+- Migration from Terraform to OpenTofu
+
+## Recommended Setup by Role
+
+### Platform Engineer
+
+```bash
+claude plugin install context7
+claude plugin install security-guidance
+claude plugin install shipyard
+claude plugin marketplace add hashicorp/agent-skills
+claude plugin install terraform-style@hashicorp
+claude plugin install terraform-testing@hashicorp
+claude plugin install terraform-refactoring@hashicorp
+```
+
+### SRE / Operations
+
+```bash
+claude plugin install context7
+claude plugin install security-guidance
+claude plugin marketplace add devops-claude-skills
+claude plugin install k8s-troubleshooter@devops-skills
+claude plugin install monitoring-observability@devops-skills
+claude plugin install ci-cd@devops-skills
+```
+
+### Cloud/FinOps Engineer
+
+```bash
+claude plugin install context7
+claude plugin install security-guidance
+claude plugin marketplace add devops-claude-skills
+claude plugin install aws-cost-optimization@devops-skills
+claude plugin install iac-terraform@devops-skills
+```
+
+### DevOps Generalist
+
+```bash
+claude plugin install context7
+claude plugin install security-guidance
+claude plugin install github
+claude plugin marketplace add devops-claude-skills
+claude plugin install iac-terraform@devops-skills
+claude plugin install k8s-troubleshooter@devops-skills
+claude plugin install ci-cd@devops-skills
+```
 
 ## Summary
 
-The Claude Code plugin ecosystem is growing fast, but more is not better. The best approach is to start with the two plugins that solve real, recurring problems - **Context7** for preventing outdated API usage and **Security Guidance** for catching vulnerabilities early. Add more only when you hit a specific pain point that a plugin directly addresses.
+The Claude Code plugin ecosystem now has serious depth for DevOps work. The foundation is **Context7** for live documentation and **Security Guidance** for vulnerability scanning. On top of that, the **HashiCorp Agent Skills** bring official Terraform and Packer expertise, the **DevOps Skills Marketplace** covers Kubernetes, CI/CD, monitoring, and FinOps, and **Shipyard** handles cross-tool infrastructure validation.
 
-Every plugin you install has a cost in context, speed, and complexity. Be selective, and your Claude Code experience will be faster and more reliable than if you installed everything available.
+Start with the foundation plugins, then add the role-specific ones that match your daily work. Each plugin you install makes Claude Code more capable at the infrastructure and operations tasks you handle every day.


### PR DESCRIPTION
Complete rewrite focusing only on DevOps-relevant plugins. No more "what to skip" negativity.

## What changed
- Removed all "skip these" and "plugins that hurt" sections
- Added 15+ DevOps-specific plugins across 5 categories
- Role-based recommended setups at the end

## Plugins covered
**Foundation:** Context7, Security Guidance, GitHub, Code Review
**HashiCorp:** 5 Terraform skills + 4 Packer skills (official)
**DevOps Skills:** K8s Troubleshooter, CI/CD, GitOps, Monitoring, AWS Cost Optimization, IaC Terraform
**Infrastructure:** Shipyard (multi-tool validation)
**Community:** Anton Babenko's Terraform skill

## Recommended setups by role
- Platform Engineer
- SRE / Operations
- Cloud/FinOps Engineer
- DevOps Generalist