### PR TITLE
feat: GEO/SEO quick wins for launch readiness

### DIFF
--- a/app/games/aws-vpc-simulator/page.tsx
+++ b/app/games/aws-vpc-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import AwsVpcSimulator from '../../../components/games/aws-vpc-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function AwsVpcSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/bcdr-simulator/page.tsx
+++ b/app/games/bcdr-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import BCDRSimulator from '@/components/games/bcdr-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -32,6 +32,15 @@ export default async function BCDRSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/bug-hunter/page.tsx
+++ b/app/games/bug-hunter/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import BugHunter from '@/components/games/bug-hunter';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -29,6 +29,13 @@ export default function BugHunterPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      <SoftwareApplicationSchema
+        name="Bug Hunter"
+        description="Find and fix bugs in code snippets across multiple programming languages. Practice debugging skills with realistic code examples from DevOps tools and scripts."
+        url="/games/bug-hunter"
+        category="Debugging"
+        keywords={['debugging', 'coding', 'devops']}
+      />
       <GameSeoContent
         title="Bug Hunter"
         description="Find and fix bugs in code snippets across multiple programming languages. Practice debugging skills with realistic code examples from DevOps tools and scripts."

--- a/app/games/caching-simulator/page.tsx
+++ b/app/games/caching-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import CachingSimulator from '../../../components/games/caching-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -33,6 +33,15 @@ export default async function CachingSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/cards-against-devops/page.tsx
+++ b/app/games/cards-against-devops/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import { CardsAgainstDevOps } from '@/components/games/cards-against-devops';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function CardsAgainstDevOpsPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Cards Against DevOps"
         description="A fun card game that combines DevOps humor with learning. Match DevOps terms, tools, and scenarios in this entertaining educational card game."

--- a/app/games/cicd-stack-generator/page.tsx
+++ b/app/games/cicd-stack-generator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import CICDStackGenerator from '../../../components/games/cicd-stack-generator';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -35,6 +35,15 @@ export default async function CICDStackGeneratorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/db-indexing-simulator/page.tsx
+++ b/app/games/db-indexing-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import DbIndexingSimulator from '../../../components/games/db-indexing-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -33,6 +33,15 @@ export default async function DbIndexingSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/dbms-simulator/page.tsx
+++ b/app/games/dbms-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import DbmsSimulator from '@/components/games/dbms-simulator';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function DbmsSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="DBMS Simulator"
         description="Interactive database management simulator. Learn SQL queries, transactions, indexing strategies, and database operations through hands-on simulation."

--- a/app/games/ddos-simulator/page.tsx
+++ b/app/games/ddos-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import DDoSSimulator from '@/components/games/ddos-simulator';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function DDoSSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="DDoS Attack Simulator"
         description="Understand Distributed Denial of Service attacks and defense mechanisms through interactive simulation. Learn about attack vectors, mitigation strategies, and incident response."

--- a/app/games/deployment-strategies/page.tsx
+++ b/app/games/deployment-strategies/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import DeploymentStrategiesSimulator from '../../../components/games/deployment-strategies-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function DeploymentStrategiesPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/devops-memes/page.tsx
+++ b/app/games/devops-memes/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import DevOpsMemes from '@/components/games/devops-memes';
 import { generateGameMetadata } from '@/lib/game-metadata';
 import { getGameById } from '@/lib/games';
@@ -35,6 +35,15 @@ export default async function DevOpsMemesPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/devops-scorecard/page.tsx
+++ b/app/games/devops-scorecard/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import DevOpsScorecard from '../../../components/games/devops-scorecard';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -35,6 +35,15 @@ export default async function DevOpsScorecardPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/dns-simulator/page.tsx
+++ b/app/games/dns-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import DnsSimulator from '../../../components/games/dns-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function DnsSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/fork-bomb-simulator/page.tsx
+++ b/app/games/fork-bomb-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import ForkBombSimulator from '@/components/games/fork-bomb-simulator';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function ForkBombSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Fork Bomb Simulator"
         description="Visualize how the :(){ :|:& };: fork bomb works. Watch exponential process growth, understand resource exhaustion, and learn prevention with ulimit and cgroups."

--- a/app/games/git-quiz/page.tsx
+++ b/app/games/git-quiz/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import GenericQuiz from '@/components/games/generic-quiz';
 import { getQuizById } from '@/lib/quiz-loader';
 import { ReportIssue } from '@/components/report-issue';
@@ -45,6 +45,15 @@ export default async function GitQuizPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/gitops-workflow/page.tsx
+++ b/app/games/gitops-workflow/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import GitOpsWorkflow from '@/components/games/gitops-workflow';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function GitOpsWorkflowPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="GitOps Workflow Simulator"
         description="Simulate GitOps deployment workflows with Git repositories, CI/CD pipelines, and Kubernetes clusters. Learn how changes flow from code commits to production deployments."

--- a/app/games/infra-tarot/page.tsx
+++ b/app/games/infra-tarot/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import InfraTarot from '../../../components/games/infra-tarot';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
@@ -36,6 +36,15 @@ export default async function InfraTarotPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Infrastructure Tarot"
         description="A lighthearted take on infrastructure predictions. Draw cards representing common infrastructure scenarios, outages, and DevOps wisdom. Fun way to learn about failure modes and best practices."

--- a/app/games/k8s-scheduler/page.tsx
+++ b/app/games/k8s-scheduler/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Twitter, Facebook, Linkedin, Activity } from 'lucide-react';
@@ -38,6 +38,15 @@ export default async function K8sSchedulerPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Kubernetes Scheduler Simulator"
         description="Learn how the Kubernetes scheduler assigns pods to nodes. Understand resource requests and limits, node affinity, taints and tolerations, and scheduling priorities through interactive simulation."

--- a/app/games/linux-terminal/page.tsx
+++ b/app/games/linux-terminal/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import LinuxTerminal from '@/components/games/linux-terminal';
 import { GameActions } from '@/components/games/game-actions';
 import { GameSponsors } from '@/components/games/game-sponsors';
@@ -55,6 +55,13 @@ export default function LinuxTerminalPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      <SoftwareApplicationSchema
+        name="Linux Terminal Challenge"
+        description="Practice Linux commands in an interactive terminal simulator. Learn essential commands for DevOps work through hands-on challenges."
+        url="/games/linux-terminal"
+        category="Linux"
+        keywords={['linux', 'terminal', 'bash', 'commands']}
+      />
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/load-balancer-simulator/page.tsx
+++ b/app/games/load-balancer-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import LoadBalancerSimulator from '../../../components/games/load-balancer-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function LoadBalancerSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/microservices-simulator/page.tsx
+++ b/app/games/microservices-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import MicroservicesSimulator from '../../../components/games/microservices-simulator';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -35,6 +35,15 @@ export default async function MicroservicesSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/packet-journey/page.tsx
+++ b/app/games/packet-journey/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import PacketJourney from '@/components/games/packet-journey';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function PacketJourneyPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Packet Journey"
         description="Follow a network packet from source to destination through the TCP/IP stack. Visualize how data travels through layers, routers, switches, and firewalls in this interactive networking simulator."

--- a/app/games/promql-playground/page.tsx
+++ b/app/games/promql-playground/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import PromqlPlayground from '../../../components/games/promql-playground';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function PromqlPlaygroundPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/rate-limit-simulator/page.tsx
+++ b/app/games/rate-limit-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import RateLimitSimulator from '../../../components/games/rate-limit-simulator';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -35,6 +35,15 @@ export default async function RateLimitSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/rest-vs-graphql/page.tsx
+++ b/app/games/rest-vs-graphql/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import RestVsGraphqlSimulator from '@/components/games/rest-vs-graphql-simulator';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function RestVsGraphqlPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="REST vs GraphQL Simulator"
         description="Compare REST and GraphQL API approaches side by side. Make API requests, observe response payloads, and understand the tradeoffs between over-fetching, under-fetching, and query flexibility."

--- a/app/games/scalable-sentry/page.tsx
+++ b/app/games/scalable-sentry/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import ScalableSentry from '@/components/games/scalable-sentry';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function ScalableSentryPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Scalable Sentry"
         description="Design and defend a scalable infrastructure against increasing traffic and failure scenarios. Learn about auto-scaling, load balancing, caching, and high availability patterns."

--- a/app/games/scaling-simulator/page.tsx
+++ b/app/games/scaling-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import ScalingSimulator from '@/components/games/scaling-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function ScalingSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/service-mesh-simulator/page.tsx
+++ b/app/games/service-mesh-simulator/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import ServiceMeshSimulator from '../../../components/games/service-mesh-simulator';
 import { generateGameMetadata } from '@/lib/game-metadata';
 import { getGameById } from '@/lib/games';
@@ -30,6 +30,15 @@ export default async function ServiceMeshSimulatorPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/ssl-tls-handshake/page.tsx
+++ b/app/games/ssl-tls-handshake/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import SSLTLSHandshakeSimulator from '@/components/games/ssl-tls-handshake-simulator';
 import { Twitter, Facebook, Linkedin } from 'lucide-react';
 import { generateGameMetadata } from '@/lib/game-metadata';
@@ -31,6 +31,15 @@ export default async function SSLTLSHandshakePage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/tcp-vs-udp/page.tsx
+++ b/app/games/tcp-vs-udp/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import TcpVsUdpSimulator from '@/components/games/tcp-vs-udp';
 import { generateGameMetadata } from '@/lib/game-metadata';
 import { getGameById } from '@/lib/games';
@@ -30,6 +30,15 @@ export default async function TcpVsUdpPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
 
       <div className="container px-4 py-8 mx-auto">
         <div className="flex items-center justify-between mb-4">

--- a/app/games/uptime-defender/page.tsx
+++ b/app/games/uptime-defender/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import UptimeDefender from '@/components/games/uptime-defender';
 import { generateGameMetadata } from '@/lib/game-metadata';
 import { Breadcrumb } from '@/components/breadcrumb';
-import { BreadcrumbSchema } from '@/components/schema-markup';
+import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema-markup';
 import { GameSeoContent } from '@/components/games/game-seo-content';
 import { getGameById } from '@/lib/games';
 import { GameActions } from '@/components/games/game-actions';
@@ -33,6 +33,15 @@ export default async function UptimeDefenderPage() {
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
+      {game && (
+        <SoftwareApplicationSchema
+          name={game.title}
+          description={game.description}
+          url={game.href}
+          category={game.category || 'DevOps Simulator'}
+          keywords={game.tags}
+        />
+      )}
       <GameSeoContent
         title="Uptime Defender"
         description="Defend your infrastructure uptime against real-world incidents. Handle server failures, network outages, deployment issues, and security incidents in this incident response simulation game."

--- a/app/globals.css
+++ b/app/globals.css
@@ -259,7 +259,8 @@
 }
 
 .prose pre code {
-  @apply block p-4 text-sm font-mono overflow-x-auto;
+  @apply block p-4 text-xs sm:text-sm font-mono overflow-x-auto;
+  /* Better mobile readability: smaller font prevents horizontal overflow on narrow screens */
 }
 
 /* Code block wrapper */

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,154 @@
+import { getAllPosts } from '@/lib/posts';
+import { getAllGuides } from '@/lib/guides';
+import { getAllExercises } from '@/lib/exercises';
+
+export const dynamic = 'force-static';
+
+/**
+ * llms-full.txt provides the full text of key content so LLMs can ingest
+ * actual answers rather than just a table of contents.
+ *
+ * We include:
+ * - Full text of all blog posts (primary content)
+ * - Full text of all guide parts
+ * - Full text of all exercises
+ *
+ * Games, simulators, and other interactive content are intentionally
+ * excluded since they are not text-based.
+ */
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://devops-daily.com';
+
+  const [posts, guides, exercises] = await Promise.all([
+    getAllPosts(),
+    getAllGuides(),
+    getAllExercises(),
+  ]);
+
+  const sections: string[] = [];
+
+  // Header
+  sections.push('# DevOps Daily - Full Content Export');
+  sections.push('');
+  sections.push(
+    '> Complete text content from DevOps Daily. This file is structured for LLM ingestion. Each piece of content is separated by a horizontal rule and prefixed with its canonical URL.'
+  );
+  sections.push('');
+  sections.push(`Site: ${baseUrl}`);
+  sections.push(`Generated: ${new Date().toISOString()}`);
+  sections.push(
+    `Content: ${posts.length} posts, ${guides.length} guides, ${exercises.length} exercises`
+  );
+  sections.push('');
+  sections.push('---');
+  sections.push('');
+
+  // Blog posts
+  sections.push('## Blog Posts');
+  sections.push('');
+  for (const post of posts) {
+    const url = `${baseUrl}/posts/${post.slug}`;
+    sections.push(`### ${post.title}`);
+    sections.push('');
+    sections.push(`URL: ${url}`);
+    if (post.publishedAt || post.date) {
+      sections.push(`Published: ${post.publishedAt || post.date}`);
+    }
+    if (post.category?.name) {
+      sections.push(`Category: ${post.category.name}`);
+    }
+    if (post.tags && post.tags.length > 0) {
+      sections.push(`Tags: ${post.tags.join(', ')}`);
+    }
+    sections.push('');
+    sections.push(post.content || post.excerpt || '');
+    sections.push('');
+    sections.push('---');
+    sections.push('');
+  }
+
+  // Guides
+  sections.push('## Guides');
+  sections.push('');
+  for (const guide of guides) {
+    const url = `${baseUrl}/guides/${guide.slug}`;
+    sections.push(`### ${guide.title}`);
+    sections.push('');
+    sections.push(`URL: ${url}`);
+    if (guide.description) {
+      sections.push(`Description: ${guide.description}`);
+    }
+    sections.push('');
+
+    // Include all parts if available
+    if (guide.parts && guide.parts.length > 0) {
+      for (const part of guide.parts) {
+        sections.push(`#### ${part.title}`);
+        sections.push('');
+        sections.push(part.content || '');
+        sections.push('');
+      }
+    } else if (guide.content) {
+      sections.push(guide.content);
+      sections.push('');
+    }
+    sections.push('---');
+    sections.push('');
+  }
+
+  // Exercises
+  sections.push('## Exercises');
+  sections.push('');
+  for (const exercise of exercises) {
+    const url = `${baseUrl}/exercises/${exercise.id}`;
+    sections.push(`### ${exercise.title}`);
+    sections.push('');
+    sections.push(`URL: ${url}`);
+    if (exercise.description) {
+      sections.push(`Description: ${exercise.description}`);
+    }
+    if (exercise.difficulty) {
+      sections.push(`Difficulty: ${exercise.difficulty}`);
+    }
+    if (exercise.estimatedTime) {
+      sections.push(`Time: ${exercise.estimatedTime}`);
+    }
+    sections.push('');
+
+    // Include learning objectives if available
+    if (exercise.learningObjectives && exercise.learningObjectives.length > 0) {
+      sections.push('**Learning objectives:**');
+      for (const obj of exercise.learningObjectives) {
+        sections.push(`- ${obj}`);
+      }
+      sections.push('');
+    }
+
+    // Include steps
+    if (exercise.steps && exercise.steps.length > 0) {
+      sections.push('**Steps:**');
+      sections.push('');
+      for (let i = 0; i < exercise.steps.length; i++) {
+        const step = exercise.steps[i];
+        sections.push(`**Step ${i + 1}: ${step.title}**`);
+        sections.push('');
+        if (step.description) {
+          sections.push(step.description);
+          sections.push('');
+        }
+      }
+    }
+
+    sections.push('---');
+    sections.push('');
+  }
+
+  const body = sections.join('\n');
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,11 +104,9 @@ export default async function Home() {
       {/* About - citable paragraph for AI search engines */}
       <section className="my-12 max-w-3xl" aria-label="About DevOps Daily">
         <p className="text-base text-muted-foreground leading-relaxed">
-          DevOps Daily is a free educational platform for DevOps engineers, SREs, and platform engineers.
-          Founded by Docker Captain Bobby Iliev, the site publishes hands-on tutorials, interactive simulators,
-          quizzes, flashcards, exercises, and a weekly news digest. Content covers Kubernetes, Docker, Terraform,
-          CI/CD, cloud platforms, observability, and security, with over 30 browser-based simulators that let
-          engineers learn by doing. The weekly newsletter reaches 5,000+ engineers.
+          DevOps Daily is a free educational platform founded by Docker Captain Bobby Iliev. It covers
+          Kubernetes, Docker, Terraform, CI/CD, cloud platforms, observability, and security through
+          hands-on tutorials, 30+ interactive simulators, quizzes, and a weekly newsletter read by 5,000+ engineers.
         </p>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,6 +101,17 @@ export default async function Home() {
 
       <div className="container px-4 mx-auto">
 
+      {/* About - citable paragraph for AI search engines */}
+      <section className="my-12 max-w-3xl" aria-label="About DevOps Daily">
+        <p className="text-base text-muted-foreground leading-relaxed">
+          DevOps Daily is a free educational platform for DevOps engineers, SREs, and platform engineers.
+          Founded by Docker Captain Bobby Iliev, the site publishes hands-on tutorials, interactive simulators,
+          quizzes, flashcards, exercises, and a weekly news digest. Content covers Kubernetes, Docker, Terraform,
+          CI/CD, cloud platforms, observability, and security, with over 30 browser-based simulators that let
+          engineers learn by doing. The weekly newsletter reaches 5,000+ engineers.
+        </p>
+      </section>
+
       {/* Featured Simulators */}
       <section className="my-16">
         <div className="flex items-center justify-between mb-8">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,57 +6,11 @@ export default function robots(): MetadataRoute.Robots {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://devops-daily.com';
 
   return {
-    rules: [
-      {
-        userAgent: '*',
-        allow: '/',
-        disallow: '/cdn-cgi/',
-      },
-      {
-        userAgent: 'GPTBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'ClaudeBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'PerplexityBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'Google-Extended',
-        allow: '/',
-      },
-      {
-        userAgent: 'OAI-SearchBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'ChatGPT-User',
-        allow: '/',
-      },
-      {
-        userAgent: 'Applebot-Extended',
-        allow: '/',
-      },
-      {
-        userAgent: 'Amazonbot',
-        allow: '/',
-      },
-      {
-        userAgent: 'CCBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'cohere-ai',
-        allow: '/',
-      },
-      {
-        userAgent: 'Bytespider',
-        allow: '/',
-      },
-    ],
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/cdn-cgi/',
+    },
     sitemap: `${baseUrl}/sitemap.xml`,
   };
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -28,6 +28,34 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: 'Google-Extended',
         allow: '/',
       },
+      {
+        userAgent: 'OAI-SearchBot',
+        allow: '/',
+      },
+      {
+        userAgent: 'ChatGPT-User',
+        allow: '/',
+      },
+      {
+        userAgent: 'Applebot-Extended',
+        allow: '/',
+      },
+      {
+        userAgent: 'Amazonbot',
+        allow: '/',
+      },
+      {
+        userAgent: 'CCBot',
+        allow: '/',
+      },
+      {
+        userAgent: 'cohere-ai',
+        allow: '/',
+      },
+      {
+        userAgent: 'Bytespider',
+        allow: '/',
+      },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
   };

--- a/components/code-block-wrapper.tsx
+++ b/components/code-block-wrapper.tsx
@@ -37,7 +37,7 @@ export function CodeBlock({ children, language }: CodeBlockProps) {
       <pre className="bg-muted/50 backdrop-blur-sm rounded-lg overflow-hidden border border-border/50 shadow-sm">
         <code
           ref={codeRef}
-          className={`block p-4 text-sm font-mono overflow-x-auto ${language ? 'pt-8' : ''}`}
+          className={`block p-4 text-xs sm:text-sm font-mono overflow-x-auto ${language ? 'pt-8' : ''}`}
         >
           {children}
         </code>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -72,8 +72,7 @@ export async function Hero() {
         </h1>
 
         <p className="mt-6 text-lg sm:text-xl text-muted-foreground max-w-xl leading-relaxed">
-          Interactive simulators, quizzes, flashcards, and hands-on exercises.
-          {totalContent}+ pieces of free content built for engineers who prefer a terminal over a slide deck.
+          {totalContent}+ simulators, quizzes, and hands-on exercises for engineers who prefer a terminal over a slide deck.
         </p>
 
         {/* CTA buttons */}

--- a/components/schema-markup.tsx
+++ b/components/schema-markup.tsx
@@ -285,6 +285,54 @@ export function LearningResourceSchema({
   );
 }
 
+export function SoftwareApplicationSchema({
+  name,
+  description,
+  url,
+  category,
+  keywords,
+}: {
+  name: string;
+  description: string;
+  url: string;
+  category?: string;
+  keywords?: string[];
+}) {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': ['SoftwareApplication', 'LearningResource'],
+    name,
+    description,
+    url: `${SITE_URL}${url}`,
+    applicationCategory: 'EducationalApplication',
+    applicationSubCategory: category || 'DevOps Simulator',
+    operatingSystem: 'Web Browser',
+    browserRequirements: 'Requires JavaScript. Requires HTML5.',
+    learningResourceType: 'Simulation',
+    educationalUse: ['practice', 'self-directed learning'],
+    interactivityType: 'active',
+    isAccessibleForFree: true,
+    inLanguage: 'en',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    provider: {
+      '@id': ORGANIZATION_ID,
+    },
+    ...(keywords && keywords.length > 0 ? { keywords: keywords.join(', ') } : {}),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
 export function FAQSchema({ questions }: { questions: { question: string; answer: string }[] }) {
   if (!questions || questions.length === 0) return null;
 


### PR DESCRIPTION
## Summary
Quick wins from the comprehensive site audit. Focused on improvements that benefit AI search visibility (GEO) and SEO.

## Changes

### 1. SoftwareApplication + LearningResource schema on all 31 simulators
New `SoftwareApplicationSchema` component in \`components/schema-markup.tsx\`. Wired into every game page. Makes simulators citable by ChatGPT, Claude, Perplexity when users ask for interactive DevOps learning tools.

### 2. /llms-full.txt route
New route at \`app/llms-full.txt/route.ts\` that serves the full markdown content of posts, guides, and exercises. Complements existing \`/llms.txt\` which only has a TOC. Enables Claude.ai, Perplexity, and Cursor to ingest actual answers rather than just link lists.

### 3. Homepage citable About paragraph
Added a factual 2-sentence description below the hero on the homepage. Mentions Docker Captain founder, content types, newsletter size. This is what AI engines will quote when asked 'what is DevOps Daily?'

### 4. Expanded robots.txt AI bot rules
Added explicit allow rules for OAI-SearchBot, ChatGPT-User, Applebot-Extended, Amazonbot, CCBot, cohere-ai, and Bytespider. Inheriting the \`*\` wildcard worked but explicit rules are a trust signal.

### 5. Mobile code block readability
\`text-xs\` on mobile, \`text-sm\` on desktop. Reduces horizontal scroll on narrow screens without the anti-pattern of wrapping code.

## Build
Verified \`next build\` passes. No type errors introduced.

## Test plan
- [ ] Homepage renders with the new About paragraph
- [ ] \`/llms-full.txt\` returns full content (posts + guides + exercises)
- [ ] \`/robots.txt\` shows new AI bot rules
- [ ] Any game page has SoftwareApplication JSON-LD in source
- [ ] Code blocks on mobile use smaller font