### PR TITLE
Roadmap links + Hacktoberfest sweep + Advent 2026 rebrand

### DIFF
--- a/app/advent-of-devops/page.tsx
+++ b/app/advent-of-devops/page.tsx
@@ -3,37 +3,38 @@ import { PostContent } from '@/components/post-content';
 import { InlineSponsors } from '@/components/inline-sponsors';
 import { AdventLandingClient } from '@/components/advent-landing-client';
 import { AdventHeroProgress } from '@/components/advent-hero-progress';
-import { Calendar, Trophy, Star, Sparkles, Target, Gift, ChevronRight } from 'lucide-react';
+import { SectionSeparator } from '@/components/section-separator';
+import { Calendar, Trophy, Target, ChevronRight, Github } from 'lucide-react';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Advent of DevOps - 25 Day Challenge | DevOps Daily',
+  title: 'Advent of DevOps 2026 - 25 Day Challenge | DevOps Daily',
   description:
-    'Join the Advent of DevOps challenge! 25 days of hands-on DevOps tasks covering Docker, Kubernetes, CI/CD, security, monitoring, and more. Level up your DevOps skills this December.',
+    'Join the Advent of DevOps 2026 challenge! 25 days of hands-on DevOps tasks covering Docker, Kubernetes, CI/CD, security, monitoring, and more. Level up your DevOps skills this December.',
   alternates: {
     canonical: '/advent-of-devops',
   },
   openGraph: {
     type: 'website',
-    title: 'Advent of DevOps - 25 Day Challenge',
+    title: 'Advent of DevOps 2026 - 25 Day Challenge',
     description:
-      'Join 25 days of hands-on DevOps challenges covering Docker, Kubernetes, CI/CD, and more!',
+      'Join 25 days of hands-on DevOps challenges covering Docker, Kubernetes, CI/CD, and more.',
     url: '/advent-of-devops',
     images: [
       {
         url: '/images/advent/advent-of-devops.png',
         width: 1200,
         height: 630,
-        alt: 'Advent of DevOps - 25 Day Challenge',
+        alt: 'Advent of DevOps 2026 - 25 Day Challenge',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Advent of DevOps - 25 Day Challenge',
+    title: 'Advent of DevOps 2026 - 25 Day Challenge',
     description:
-      'Join 25 days of hands-on DevOps challenges covering Docker, Kubernetes, CI/CD, and more!',
+      'Join 25 days of hands-on DevOps challenges covering Docker, Kubernetes, CI/CD, and more.',
     images: ['/images/advent/advent-of-devops.png'],
   },
 };
@@ -44,90 +45,87 @@ export default async function AdventOfDevOpsPage() {
 
   return (
     <>
-      {/* Hero Section with Gradient Background */}
+      {/* Hero */}
       <div className="relative overflow-hidden">
-        {/* Animated Background */}
-        <div className="absolute inset-0 bg-linear-to-br from-primary/5 via-background to-green-500/5" />
-        <div className="absolute inset-0">
-          <div className="absolute top-20 left-10 w-72 h-72 bg-primary/10 rounded-full blur-3xl animate-pulse" />
-          <div className="absolute bottom-20 right-10 w-96 h-96 bg-green-500/10 rounded-full blur-3xl animate-pulse delay-1000" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-red-500/5 rounded-full blur-3xl animate-pulse delay-500" />
-        </div>
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 -z-10 opacity-[0.07] dark:opacity-[0.09]"
+          style={{
+            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+            maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+            WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+          }}
+        />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/[0.04] via-transparent to-transparent" />
 
-        {/* Snowflakes Effect */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          {[...Array(20)].map((_, i) => (
-            <div
-              key={i}
-              className="absolute animate-fall"
-              style={{
-                left: `${Math.random() * 100}%`,
-                animationDelay: `${Math.random() * 5}s`,
-                animationDuration: `${10 + Math.random() * 10}s`,
-              }}
-            >
-              <Star
-                className="text-primary/20"
-                size={8 + Math.random() * 8}
-                fill="currentColor"
-              />
-            </div>
-          ))}
-        </div>
-
-        <div className="container relative mx-auto px-4 py-16 md:py-24">
-          {/* Hero Content */}
+        <div className="container relative mx-auto px-4 py-16 md:py-20">
           <div className="max-w-4xl mx-auto text-center">
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-linear-to-r from-red-500/20 to-green-500/20 border border-primary/30 mb-6 animate-fade-in">
-              <Gift className="h-4 w-4 text-primary" />
-              <span className="text-sm font-medium">25 Days of DevOps Challenges</span>
+            <p className="text-xs font-mono text-muted-foreground mb-3">// advent-of-devops</p>
+
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-primary/20 bg-primary/5 text-xs font-mono text-primary mb-6 tabular-nums">
+              <Calendar className="w-3.5 h-3.5" strokeWidth={1.5} />
+              December 1-25, 2026
             </div>
 
-            <h1 className="text-5xl md:text-7xl font-bold mb-6 animate-fade-in-up">
-              <span className="bg-linear-to-r from-red-500 via-primary to-green-500 bg-clip-text text-transparent">
-                Advent of DevOps
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-6">
+              Advent of DevOps{' '}
+              <span className="text-primary relative inline-block">
+                2026
+                <svg
+                  className="absolute -bottom-2 left-0 w-full h-3 text-primary/40"
+                  viewBox="0 0 120 12"
+                  preserveAspectRatio="none"
+                >
+                  <path
+                    d="M2 9 Q15 2 30 8 Q45 1 60 7 Q75 2 90 9 Q105 4 118 7"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    fill="none"
+                    strokeLinecap="round"
+                  />
+                </svg>
               </span>
             </h1>
 
-            <p className="text-xl md:text-2xl text-muted-foreground mb-8 animate-fade-in-up delay-100">
-              Level up your DevOps skills with 25 days of hands-on challenges
+            <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
+              Level up your DevOps skills with 25 days of hands-on challenges. One task a day
+              through December, covering Docker, Kubernetes, CI/CD, security, monitoring, and more.
             </p>
 
-            <div className="flex flex-wrap items-center justify-center gap-4 mb-12 animate-fade-in-up delay-200">
-              <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card/50 backdrop-blur border border-border">
-                <Calendar className="h-5 w-5 text-primary" />
-                <span className="font-medium">25 Days</span>
-              </div>
-              <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card/50 backdrop-blur border border-border">
-                <Trophy className="h-5 w-5 text-yellow-500" />
-                <span className="font-medium">Hands-on Challenges</span>
-              </div>
-              <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card/50 backdrop-blur border border-border">
-                <Target className="h-5 w-5 text-green-500" />
-                <span className="font-medium">Real-world Skills</span>
-              </div>
+            <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 mb-10 font-mono text-sm text-muted-foreground tabular-nums">
+              <span className="inline-flex items-center gap-1.5">
+                <Calendar className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                25 days
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Trophy className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                Hands-on tasks
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Target className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                Real-world skills
+              </span>
             </div>
 
-            <div className="flex flex-wrap items-center justify-center gap-4 animate-fade-in-up delay-300">
+            <div className="flex flex-wrap justify-center gap-3">
               <Link
                 href="#challenges"
                 className="group inline-flex items-center gap-2 px-6 py-3 rounded-md bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
               >
-                <Sparkles className="h-5 w-5" />
                 Start Challenge
-                <ChevronRight className="h-5 w-5 group-hover:translate-x-1 transition-transform" />
+                <ChevronRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
               </Link>
               <a
                 href="https://x.com/thedevopsdaily"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-border hover:border-primary hover:bg-primary/5 font-medium transition-all"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-md border border-border hover:border-primary/50 hover:bg-muted/30 font-medium transition-colors"
               >
                 Follow @thedevopsdaily
               </a>
             </div>
 
-            {/* Progress Bar - Client Component */}
             <AdventHeroProgress />
           </div>
         </div>
@@ -135,7 +133,8 @@ export default async function AdventOfDevOpsPage() {
 
       {/* Introduction Section */}
       {indexContent && (
-        <div className="container mx-auto px-4 py-12">
+        <div className="container mx-auto px-4 py-8">
+          <SectionSeparator command="cat intro.md" />
           <div className="max-w-4xl mx-auto prose dark:prose-invert">
             <PostContent content={indexContent.content} />
           </div>
@@ -144,49 +143,50 @@ export default async function AdventOfDevOpsPage() {
 
       {/* Challenges Grid with Progress Tracking */}
       <div id="challenges">
+        <div className="container mx-auto px-4">
+          <SectionSeparator command="ls /advent-of-devops/days" />
+        </div>
         <AdventLandingClient days={days} />
       </div>
 
-      {/* Sponsors Section */}
-      <div className="container mx-auto px-4 py-12">
+      {/* Sponsors */}
+      <div className="container mx-auto px-4 py-8">
         <InlineSponsors variant="banner" />
       </div>
 
-      {/* CTA Section */}
-      <div className="container mx-auto px-4 py-16">
+      {/* CTA */}
+      <div className="container mx-auto px-4 py-12">
         <div className="max-w-4xl mx-auto">
-          <div className="relative rounded-2xl overflow-hidden">
-            <div className="absolute inset-0 bg-linear-to-br from-primary/20 via-blue-500/20 to-green-500/20" />
-            <div className="relative px-8 py-12 text-center">
-              <h2 className="text-3xl font-bold mb-4">Ready to Start Your Journey?</h2>
-              <p className="text-lg text-muted-foreground mb-8">
-                Join the community and share your progress with{' '}
-                <a
-                  href="https://x.com/thedevopsdaily"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline font-medium"
-                >
-                  @thedevopsdaily
-                </a>
-              </p>
-              <div className="flex flex-wrap items-center justify-center gap-4">
-                <Link
-                  href="/advent-of-devops/day-1"
-                  className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
-                >
-                  <Trophy className="h-5 w-5" />
-                  Start Day 1
-                </Link>
-                <a
-                  href="https://github.com/The-DevOps-Daily/devops-daily"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-border hover:border-primary hover:bg-primary/5 font-medium transition-all"
-                >
-                  View on GitHub
-                </a>
-              </div>
+          <div className="rounded-md border bg-primary/5 px-8 py-10 text-center">
+            <h2 className="text-2xl sm:text-3xl font-bold mb-3">Ready to Start Your Journey?</h2>
+            <p className="text-muted-foreground mb-6">
+              Join the community and share your progress with{' '}
+              <a
+                href="https://x.com/thedevopsdaily"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline font-medium"
+              >
+                @thedevopsdaily
+              </a>
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/advent-of-devops/day-1"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-primary text-primary-foreground font-medium hover:bg-primary/90 transition-colors"
+              >
+                <Trophy className="h-4 w-4" strokeWidth={1.5} />
+                Start Day 1
+              </Link>
+              <a
+                href="https://github.com/The-DevOps-Daily/devops-daily"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-6 py-3 rounded-md border border-border hover:border-primary/50 hover:bg-muted/30 font-medium transition-colors"
+              >
+                <Github className="h-4 w-4" strokeWidth={1.5} />
+                View on GitHub
+              </a>
             </div>
           </div>
         </div>

--- a/app/hacktoberfest/page.tsx
+++ b/app/hacktoberfest/page.tsx
@@ -1,9 +1,28 @@
-import { Calendar, GitPullRequest, Users, Star, Github, ArrowRight, CheckCircle2, ExternalLink, Trophy, Zap, BookOpen, Heart, FileCode, Clock, Award, Megaphone, Mail } from 'lucide-react';
+import {
+  Calendar,
+  GitPullRequest,
+  Users,
+  Star,
+  Github,
+  ArrowRight,
+  CheckCircle2,
+  Trophy,
+  Zap,
+  BookOpen,
+  Heart,
+  FileCode,
+  Clock,
+  Award,
+  Megaphone,
+  type LucideIcon,
+} from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { BreadcrumbSchema, FAQSchema } from '@/components/schema-markup';
 import { InlineSponsors } from '@/components/inline-sponsors';
 import { HacktoberfestCountdown } from '@/components/hacktoberfest/countdown';
+import { SectionHeader } from '@/components/section-header';
+import { SectionSeparator } from '@/components/section-separator';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -37,94 +56,87 @@ export const metadata: Metadata = {
   },
 };
 
-const CHALLENGE_DAYS = [
+interface ChallengeDay {
+  day: number;
+  title: string;
+  description: string;
+  difficulty: 'Beginner' | 'Intermediate' | 'Advanced';
+  time: string;
+  icon: LucideIcon;
+  bonus?: boolean;
+}
+
+const CHALLENGE_DAYS: ChallengeDay[] = [
   {
     day: 1,
     title: 'Add Yourself',
-    description: 'Add your profile to the DevOps Experts directory. Get a profile page with a backlink to your site.',
-    share: 'Share your new expert profile on X and tag @thedevopsdaily!',
+    description:
+      'Add your profile to the DevOps Experts directory. Get a profile page with a backlink to your site.',
     difficulty: 'Beginner',
     time: '5 min',
     icon: Users,
-    color: 'text-emerald-500',
-    bg: 'bg-emerald-500/10',
   },
   {
     day: 2,
     title: 'Add Your Favorite Tool',
-    description: 'Add a DevOps tool you love to the Toolbox page. Name, description, link, and category.',
-    share: 'Tell everyone about your favorite tool - post your PR and tag @thedevopsdaily!',
+    description:
+      'Add a DevOps tool you love to the Toolbox page. Name, description, link, and category.',
     difficulty: 'Beginner',
     time: '5 min',
     icon: Zap,
-    color: 'text-blue-500',
-    bg: 'bg-blue-500/10',
   },
   {
     day: 3,
     title: 'Add a Quiz Question',
-    description: 'Add 1 multiple-choice question to an existing quiz. Include an explanation for the answer.',
-    share: 'Challenge your followers with your quiz question - share it with #DevOpsDaily!',
+    description:
+      'Add 1 multiple-choice question to an existing quiz. Include an explanation for the answer.',
     difficulty: 'Beginner',
     time: '5 min',
     icon: Trophy,
-    color: 'text-purple-500',
-    bg: 'bg-purple-500/10',
   },
   {
     day: 4,
     title: 'Add a Flashcard',
     description: 'Add 1-2 flashcards to an existing flashcard set. Front/back format in JSON.',
-    share: 'Share a DevOps concept you think everyone should know - tag @thedevopsdaily!',
     difficulty: 'Beginner',
     time: '5 min',
     icon: BookOpen,
-    color: 'text-cyan-500',
-    bg: 'bg-cyan-500/10',
   },
   {
     day: 5,
     title: 'Share a Tip',
-    description: 'Add a practical tip or gotcha to an existing blog post or guide. Something you learned the hard way.',
-    share: 'Share your hard-earned DevOps tip on LinkedIn and tag DevOps Daily!',
+    description:
+      'Add a practical tip or gotcha to an existing blog post or guide. Something you learned the hard way.',
     difficulty: 'Beginner',
     time: '10 min',
     icon: Star,
-    color: 'text-orange-500',
-    bg: 'bg-orange-500/10',
   },
   {
     day: 6,
     title: 'Find & Fix Something',
-    description: 'Browse the site and fix a typo, broken link, outdated info, or formatting issue you spot.',
-    share: 'Found and fixed a bug in an open source project! Share your detective work with #Hacktoberfest!',
+    description:
+      'Browse the site and fix a typo, broken link, outdated info, or formatting issue you spot.',
     difficulty: 'Intermediate',
     time: '10 min',
     icon: CheckCircle2,
-    color: 'text-amber-500',
-    bg: 'bg-amber-500/10',
   },
   {
     day: 7,
     title: 'Share Your Stack',
-    description: 'Write a short profile of your DevOps setup. What tools you use, how they fit together, and why.',
-    share: 'Show off your DevOps stack! Post it on X/LinkedIn and tag @thedevopsdaily!',
+    description:
+      'Write a short profile of your DevOps setup. What tools you use, how they fit together, and why.',
     difficulty: 'Intermediate',
     time: '15 min',
     icon: Heart,
-    color: 'text-pink-500',
-    bg: 'bg-pink-500/10',
   },
   {
     day: 8,
     title: 'Bonus: Build Something',
-    description: 'Go big! Create a new quiz, write a tool comparison, build a checklist, or contribute a game/simulator.',
-    share: 'Completed all 8 days of the DevOps Daily Hacktoberfest challenge! #DevOpsDaily #Hacktoberfest',
+    description:
+      'Go big! Create a new quiz, write a tool comparison, build a checklist, or contribute a game/simulator.',
     difficulty: 'Advanced',
     time: '30+ min',
     icon: Trophy,
-    color: 'text-yellow-500',
-    bg: 'bg-yellow-500/10',
     bonus: true,
   },
 ];
@@ -132,7 +144,8 @@ const CHALLENGE_DAYS = [
 const FAQ_ITEMS = [
   {
     question: 'Do I need to know React or Next.js to participate?',
-    answer: 'No! Most contributions are JSON or Markdown files. You just need to know how to fork a repo and submit a pull request.',
+    answer:
+      'No! Most contributions are JSON or Markdown files. You just need to know how to fork a repo and submit a pull request.',
   },
   {
     question: 'Do I have to complete all 7 days?',
@@ -140,19 +153,23 @@ const FAQ_ITEMS = [
   },
   {
     question: 'Do these PRs count toward Hacktoberfest?',
-    answer: 'Yes! As long as the PRs are accepted and the repo has the hacktoberfest topic, they count toward your Hacktoberfest total.',
+    answer:
+      'Yes! As long as the PRs are accepted and the repo has the hacktoberfest topic, they count toward your Hacktoberfest total.',
   },
   {
     question: 'When does the challenge start?',
-    answer: 'October 1, 2026. But you can start exploring the repo and setting up your environment anytime before that.',
+    answer:
+      'October 1, 2026. But you can start exploring the repo and setting up your environment anytime before that.',
   },
   {
     question: 'What is the Experts Directory?',
-    answer: 'A page on DevOps Daily where you can list yourself as a DevOps expert with your bio, skills, and links. It gives you a public profile with a backlink to your own site.',
+    answer:
+      'A page on DevOps Daily where you can list yourself as a DevOps expert with your bio, skills, and links. It gives you a public profile with a backlink to your own site.',
   },
   {
     question: 'Can I contribute outside of the 7-day challenge?',
-    answer: 'Absolutely! The challenge is just a structured starting point. We welcome all contributions year-round.',
+    answer:
+      'Absolutely! The challenge is just a structured starting point. We welcome all contributions year-round.',
   },
 ];
 
@@ -220,41 +237,26 @@ export default function HacktoberfestPage() {
       <BreadcrumbSchema items={breadcrumbItems} />
       <FAQSchema questions={FAQ_ITEMS} />
 
-      {/* Hero Section */}
+      {/* Hero */}
       <div className="relative overflow-hidden">
-        {/* Background effects */}
-        <div className="absolute inset-0 bg-gradient-to-br from-[#183d5d]/20 via-background to-[#93c2db]/10" />
-        <div className="absolute inset-0">
-          <div className="absolute top-20 left-10 w-72 h-72 bg-[#183d5d]/15 rounded-full blur-3xl animate-pulse" />
-          <div className="absolute bottom-20 right-10 w-96 h-96 bg-[#93c2db]/10 rounded-full blur-3xl animate-pulse" />
-        </div>
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 -z-10 opacity-[0.07] dark:opacity-[0.09]"
+          style={{
+            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+            maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+            WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+          }}
+        />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/[0.04] via-transparent to-transparent" />
 
-        {/* Floating git icons */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <div
-              key={i}
-              className="absolute animate-float"
-              style={{
-                left: `${8 + (i * 8) % 84}%`,
-                top: `${10 + Math.sin(i * 1.5) * 30 + 30}%`,
-                animationDelay: `${i * 0.7}s`,
-                animationDuration: `${6 + (i % 3) * 2}s`,
-              }}
-            >
-              <GitPullRequest
-                className="text-primary/[0.06]"
-                size={14 + (i % 4) * 4}
-              />
-            </div>
-          ))}
-        </div>
-
-        <div className="container relative mx-auto px-4 py-16 md:py-24">
+        <div className="container relative mx-auto px-4 py-16 md:py-20">
           <div className="max-w-4xl mx-auto text-center">
-            {/* Badge */}
-            <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-primary/20 bg-primary/5 text-sm font-medium text-primary mb-8">
-              <Calendar className="w-4 h-4" />
+            <p className="text-xs font-mono text-muted-foreground mb-3">// hacktoberfest</p>
+
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-primary/20 bg-primary/5 text-xs font-mono text-primary mb-6 tabular-nums">
+              <Calendar className="w-3.5 h-3.5" strokeWidth={1.5} />
               October 1-7, 2026
             </div>
 
@@ -263,52 +265,59 @@ export default function HacktoberfestPage() {
               <br />
               <span className="text-primary relative inline-block">
                 DevOps Challenge
-                <svg className="absolute -bottom-2 left-0 w-full h-3 text-primary/40" viewBox="0 0 200 12" preserveAspectRatio="none">
-                  <path d="M2 9 Q25 2 50 8 Q75 1 100 7 Q125 2 150 9 Q175 4 198 7" stroke="currentColor" strokeWidth="2.5" fill="none" strokeLinecap="round" />
+                <svg
+                  className="absolute -bottom-2 left-0 w-full h-3 text-primary/40"
+                  viewBox="0 0 200 12"
+                  preserveAspectRatio="none"
+                >
+                  <path
+                    d="M2 9 Q25 2 50 8 Q75 1 100 7 Q125 2 150 9 Q175 4 198 7"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    fill="none"
+                    strokeLinecap="round"
+                  />
                 </svg>
               </span>
             </h1>
 
             <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
-              Contribute to open source in 7 days. No coding required - just JSON and Markdown.
+              Contribute to open source in 7 days. No coding required, just JSON and Markdown.
               Each day takes 5-15 minutes and earns you a Hacktoberfest PR.
             </p>
 
-            {/* Hero stats */}
-            <div className="flex flex-wrap justify-center gap-6 mb-10">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Calendar className="w-4 h-4 text-primary" />
-                <span>7 days + bonus</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <GitPullRequest className="w-4 h-4 text-primary" />
-                <span>8 PRs</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Star className="w-4 h-4 text-primary" />
-                <span>No coding needed</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Users className="w-4 h-4 text-primary" />
-                <span>Beginner friendly</span>
-              </div>
+            <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 mb-10 font-mono text-sm text-muted-foreground tabular-nums">
+              <span className="inline-flex items-center gap-1.5">
+                <Calendar className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                7 days + bonus
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <GitPullRequest className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                8 PRs
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Star className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                No coding needed
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Users className="w-3.5 h-3.5 text-primary" strokeWidth={1.5} />
+                Beginner friendly
+              </span>
             </div>
 
-            {/* Countdown */}
             <div className="flex justify-center mb-10">
               <HacktoberfestCountdown />
             </div>
 
-            {/* CTA buttons */}
             <div className="flex flex-wrap justify-center gap-3">
-              <Button asChild size="lg" className="shadow-md shadow-primary/10">
+              <Button asChild size="lg">
                 <a
                   href="https://github.com/The-DevOps-Daily/devops-daily"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="group"
                 >
-                  <Github className="w-5 h-5 mr-2" />
+                  <Github className="w-5 h-5 mr-2" strokeWidth={1.5} />
                   Star & Fork the Repo
                   <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
                 </a>
@@ -322,40 +331,43 @@ export default function HacktoberfestPage() {
       </div>
 
       <div className="container mx-auto px-4">
+        <SectionSeparator command="ls /hacktoberfest/requirements" />
+
         {/* What You'll Need */}
-        <section className="my-16 max-w-3xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-8">
-            What You Need
-          </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div className="rounded-lg border bg-card p-4 text-center">
-              <Github className="w-6 h-6 mx-auto mb-2 text-muted-foreground" />
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader label="what you need" title="What You Need" />
+          <div className="grid gap-px sm:grid-cols-3 bg-border border rounded-md overflow-hidden">
+            <div className="bg-card p-5">
+              <Github className="w-5 h-5 text-primary mb-3" strokeWidth={1.5} />
               <h3 className="font-semibold text-sm mb-1">GitHub Account</h3>
-              <p className="text-xs text-muted-foreground">Free account to fork repos and submit PRs</p>
+              <p className="text-xs text-muted-foreground">
+                Free account to fork repos and submit PRs
+              </p>
             </div>
-            <div className="rounded-lg border bg-card p-4 text-center">
-              <FileCode className="w-6 h-6 mx-auto mb-2 text-muted-foreground" />
+            <div className="bg-card p-5">
+              <FileCode className="w-5 h-5 text-primary mb-3" strokeWidth={1.5} />
               <h3 className="font-semibold text-sm mb-1">Text Editor</h3>
-              <p className="text-xs text-muted-foreground">VS Code, Vim, or any editor for JSON/Markdown</p>
+              <p className="text-xs text-muted-foreground">
+                VS Code, Vim, or any editor for JSON/Markdown
+              </p>
             </div>
-            <div className="rounded-lg border bg-card p-4 text-center">
-              <Clock className="w-6 h-6 mx-auto mb-2 text-muted-foreground" />
-              <h3 className="font-semibold text-sm mb-1">5-15 min/day</h3>
+            <div className="bg-card p-5">
+              <Clock className="w-5 h-5 text-primary mb-3" strokeWidth={1.5} />
+              <h3 className="font-semibold text-sm mb-1 font-mono tabular-nums">5-15 min/day</h3>
               <p className="text-xs text-muted-foreground">Each challenge is quick and focused</p>
             </div>
           </div>
         </section>
 
+        <SectionSeparator command="cat how-it-works.md" />
+
         {/* How It Works */}
-        <section className="my-16 max-w-4xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-10">
-            How It Works
-          </h2>
-          {/* Mobile: vertical list */}
-          <div className="flex flex-col gap-4 sm:hidden">
+        <section className="my-12 max-w-4xl mx-auto">
+          <SectionHeader label="how it works" title="How It Works" />
+          <div className="flex flex-col gap-3 sm:hidden">
             {STEPS.map((s) => (
               <div key={s.step} className="flex items-center gap-4">
-                <div className="w-10 h-10 rounded-full bg-primary text-primary-foreground font-bold flex items-center justify-center flex-shrink-0">
+                <div className="w-9 h-9 rounded-md bg-primary/10 border border-primary/20 text-primary font-mono font-semibold flex items-center justify-center flex-shrink-0 tabular-nums">
                   {s.step}
                 </div>
                 <div>
@@ -365,15 +377,13 @@ export default function HacktoberfestPage() {
               </div>
             ))}
           </div>
-          {/* Desktop: horizontal with connecting line */}
           <div className="hidden sm:block">
             <div className="relative">
-              {/* Connecting line */}
-              <div className="absolute top-5 left-[10%] right-[10%] h-0.5 bg-primary/15" />
+              <div className="absolute top-[18px] left-[10%] right-[10%] h-px bg-border" />
               <div className="grid grid-cols-5 gap-4">
                 {STEPS.map((s) => (
                   <div key={s.step} className="text-center relative">
-                    <div className="w-10 h-10 rounded-full bg-primary text-primary-foreground font-bold flex items-center justify-center mx-auto mb-3 relative z-10">
+                    <div className="w-9 h-9 rounded-md bg-primary/10 border border-primary/20 text-primary font-mono font-semibold flex items-center justify-center mx-auto mb-3 relative z-10 tabular-nums bg-background">
                       {s.step}
                     </div>
                     <h3 className="font-semibold text-sm mb-1">{s.title}</h3>
@@ -385,39 +395,43 @@ export default function HacktoberfestPage() {
           </div>
         </section>
 
-        {/* Challenge Cards */}
-        <section id="challenges" className="my-16 max-w-5xl mx-auto scroll-mt-20">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-4">
-            The Challenge
-          </h2>
-          <p className="text-center text-muted-foreground mb-10 max-w-xl mx-auto">
-            One task per day, each building on your familiarity with the project. All contributions are JSON or Markdown edits.
-          </p>
+        <SectionSeparator command="ls /hacktoberfest/challenges" />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Challenge Cards */}
+        <section id="challenges" className="my-12 max-w-5xl mx-auto scroll-mt-20">
+          <SectionHeader
+            label="challenges"
+            title="The Challenge"
+            description="One task per day, each building on your familiarity with the project. All contributions are JSON or Markdown edits."
+          />
+
+          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
             {CHALLENGE_DAYS.map((day) => {
               const Icon = day.icon;
               return (
                 <Link
                   key={day.day}
                   href={`/hacktoberfest/day-${day.day}`}
-                  className={`group rounded-lg border bg-card p-5 transition-all hover:border-primary/30 hover:shadow-sm ${day.bonus ? 'md:col-span-2 border-yellow-500/20 bg-yellow-500/[0.02]' : ''}`}
+                  className={`group bg-card p-5 transition-colors hover:bg-muted/40 ${
+                    day.bonus ? 'sm:col-span-2' : ''
+                  }`}
                 >
                   <div className="flex items-start gap-4">
-                    <div className={`flex-shrink-0 w-10 h-10 rounded-lg ${day.bg} flex items-center justify-center`}>
-                      <Icon className={`w-5 h-5 ${day.color}`} />
+                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
+                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
                     </div>
                     <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs font-mono text-muted-foreground">Day {day.day}</span>
-                        <span className="text-xs px-1.5 py-0.5 rounded-full bg-secondary text-muted-foreground">
-                          {day.difficulty}
-                        </span>
-                        <span className="text-xs text-muted-foreground/60">{day.time}</span>
+                      <div className="flex items-center gap-2 mb-1 font-mono text-xs text-muted-foreground tabular-nums">
+                        <span>Day {day.day}</span>
+                        <span className="text-muted-foreground/60">·</span>
+                        <span>{day.difficulty}</span>
+                        <span className="text-muted-foreground/60">·</span>
+                        <span>{day.time}</span>
                         {day.bonus && (
-                          <span className="text-xs px-1.5 py-0.5 rounded-full bg-yellow-500/20 text-yellow-600 font-medium">
-                            Bonus
-                          </span>
+                          <>
+                            <span className="text-muted-foreground/60">·</span>
+                            <span className="text-primary">bonus</span>
+                          </>
                         )}
                       </div>
                       <h3 className="font-semibold mb-1 group-hover:text-primary transition-colors">
@@ -426,7 +440,7 @@ export default function HacktoberfestPage() {
                       <p className="text-sm text-muted-foreground leading-relaxed">
                         {day.description}
                       </p>
-                      <div className="flex items-center gap-1 mt-2 text-xs text-primary/70">
+                      <div className="flex items-center gap-1 mt-2 text-xs text-primary/80">
                         <span>View full instructions</span>
                         <ArrowRight className="w-3 h-3 transition-transform group-hover:translate-x-1" />
                       </div>
@@ -438,78 +452,94 @@ export default function HacktoberfestPage() {
           </div>
         </section>
 
+        <SectionSeparator command="cat rewards.md" />
+
         {/* Rewards */}
-        <section className="my-16 max-w-4xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-4">
-            Rewards
-          </h2>
-          <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">
-            Every contribution earns you something. Complete all 8 days for a chance to win prizes.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="rounded-lg border bg-card p-5 flex items-start gap-4">
-              <div className="w-10 h-10 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
-                <GitPullRequest className="w-5 h-5 text-emerald-500" />
+        <section className="my-12 max-w-4xl mx-auto">
+          <SectionHeader
+            label="rewards"
+            title="Rewards"
+            description="Every contribution earns you something. Complete all 8 days for a chance to win prizes."
+          />
+          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
+            <div className="bg-card p-5 flex items-start gap-4">
+              <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
+                <GitPullRequest className="w-5 h-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
                 <h3 className="font-semibold text-sm mb-1">Hacktoberfest PRs</h3>
-                <p className="text-xs text-muted-foreground">Each day counts toward your Hacktoberfest badge or tree.</p>
+                <p className="text-xs text-muted-foreground">
+                  Each day counts toward your Hacktoberfest badge or tree.
+                </p>
               </div>
             </div>
-            <div className="rounded-lg border bg-card p-5 flex items-start gap-4">
-              <div className="w-10 h-10 rounded-lg bg-blue-500/10 flex items-center justify-center flex-shrink-0">
-                <Users className="w-5 h-5 text-blue-500" />
+            <div className="bg-card p-5 flex items-start gap-4">
+              <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
+                <Users className="w-5 h-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
                 <h3 className="font-semibold text-sm mb-1">Expert Profile + Backlink</h3>
-                <p className="text-xs text-muted-foreground">Day 1 gives you a public profile on our <Link href="/experts" className="text-primary hover:underline">Experts Directory</Link>.</p>
+                <p className="text-xs text-muted-foreground">
+                  Day 1 gives you a public profile on our{' '}
+                  <Link href="/experts" className="text-primary hover:underline">
+                    Experts Directory
+                  </Link>
+                  .
+                </p>
               </div>
             </div>
-            <div className="rounded-lg border bg-card p-5 flex items-start gap-4">
-              <div className="w-10 h-10 rounded-lg bg-purple-500/10 flex items-center justify-center flex-shrink-0">
-                <Award className="w-5 h-5 text-purple-500" />
+            <div className="bg-card p-5 flex items-start gap-4">
+              <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
+                <Award className="w-5 h-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
                 <h3 className="font-semibold text-sm mb-1">Featured Profile</h3>
-                <p className="text-xs text-muted-foreground">Top 3 contributors get a highlighted profile on the experts page for a month.</p>
+                <p className="text-xs text-muted-foreground">
+                  Top 3 contributors get a highlighted profile on the experts page for a month.
+                </p>
               </div>
             </div>
-            <div className="rounded-lg border bg-card p-5 flex items-start gap-4">
-              <div className="w-10 h-10 rounded-lg bg-orange-500/10 flex items-center justify-center flex-shrink-0">
-                <Megaphone className="w-5 h-5 text-orange-500" />
+            <div className="bg-card p-5 flex items-start gap-4">
+              <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
+                <Megaphone className="w-5 h-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
                 <h3 className="font-semibold text-sm mb-1">Newsletter Shoutout</h3>
-                <p className="text-xs text-muted-foreground">Contributors get featured in the DevOps Daily weekly newsletter.</p>
+                <p className="text-xs text-muted-foreground">
+                  Contributors get featured in the DevOps Daily weekly newsletter.
+                </p>
               </div>
             </div>
-            <div className="rounded-lg border bg-card p-5 flex items-start gap-4 md:col-span-2 border-yellow-500/20 bg-yellow-500/[0.02]">
-              <div className="w-10 h-10 rounded-lg bg-yellow-500/10 flex items-center justify-center flex-shrink-0">
-                <Trophy className="w-5 h-5 text-yellow-500" />
+            <div className="sm:col-span-2 bg-primary/5 border-t border-primary/20 p-5 flex items-start gap-4">
+              <div className="w-10 h-10 rounded-md bg-primary/15 flex items-center justify-center flex-shrink-0">
+                <Trophy className="w-5 h-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
                 <h3 className="font-semibold text-sm mb-1">Complete All 8 Days</h3>
-                <p className="text-xs text-muted-foreground">Everyone who finishes all 8 days gets DevOps Daily stickers shipped to them, plus a chance to win DigitalOcean credit in our raffle.</p>
+                <p className="text-xs text-muted-foreground">
+                  Everyone who finishes all 8 days gets DevOps Daily stickers shipped to them, plus
+                  a chance to win DigitalOcean credit in our raffle.
+                </p>
               </div>
             </div>
           </div>
         </section>
 
+        <SectionSeparator command="cd /local-setup" />
+
         {/* Get Set Up */}
-        <section className="my-16 max-w-3xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-8">
-            Get Your Environment Ready
-          </h2>
-          <div className="rounded-lg border bg-card overflow-hidden">
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader label="setup" title="Get Your Environment Ready" />
+          <div className="rounded-md border bg-card overflow-hidden font-mono text-sm">
             <div className="flex items-center gap-2 px-4 py-2.5 bg-muted/60 border-b border-border/80">
               <div className="flex gap-1.5">
                 <div className="w-3 h-3 rounded-full bg-red-400/70" />
                 <div className="w-3 h-3 rounded-full bg-yellow-400/70" />
                 <div className="w-3 h-3 rounded-full bg-green-400/70" />
               </div>
-              <span className="text-xs text-muted-foreground font-mono ml-2">terminal</span>
+              <span className="text-xs text-muted-foreground ml-2">terminal</span>
             </div>
-            <div className="p-4 font-mono text-sm space-y-2">
+            <div className="p-4 space-y-2">
               <div>
                 <span className="text-muted-foreground"># Fork the repo on GitHub, then:</span>
               </div>
@@ -527,7 +557,9 @@ export default function HacktoberfestPage() {
                 <span className="text-green-500">$</span> <span>pnpm dev</span>
               </div>
               <div className="pt-2">
-                <span className="text-muted-foreground"># Open http://localhost:3000 and start contributing!</span>
+                <span className="text-muted-foreground">
+                  # Open http://localhost:3000 and start contributing
+                </span>
               </div>
             </div>
           </div>
@@ -545,106 +577,60 @@ export default function HacktoberfestPage() {
           </p>
         </section>
 
+        <SectionSeparator command="ls /share-templates" />
+
         {/* Share Your Progress */}
-        <section className="my-16 max-w-3xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-4">
-            Share Your Progress
-          </h2>
-          <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">
-            Each day you contribute, share your PR on social media. Tag us and use <span className="font-mono text-primary">#DevOpsDaily</span> - we repost the best ones!
-          </p>
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader
+            label="share"
+            title="Share Your Progress"
+            description={`Each day you contribute, share your PR on social media. Tag us and use #DevOpsDaily, we repost the best ones.`}
+          />
           <div className="space-y-3">
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-xs text-muted-foreground mb-2 font-semibold">Copy-paste for X / Twitter:</p>
-              <p className="text-sm text-foreground font-mono bg-muted/50 rounded p-3 leading-relaxed">
-                {"I just completed Day [X] of the @thedevopsdaily Hacktoberfest challenge! 🎃\n\n[What you did]\n\nJoin the challenge: devops-daily.com/hacktoberfest\n\n#Hacktoberfest #DevOpsDaily #OpenSource"}
+            <div className="rounded-md border bg-card p-4">
+              <p className="text-xs text-muted-foreground mb-2 font-mono">// x / twitter</p>
+              <p className="text-sm text-foreground font-mono bg-muted/50 rounded-md p-3 leading-relaxed whitespace-pre-wrap">
+                {`I just completed Day [X] of the @thedevopsdaily Hacktoberfest challenge!
+
+[What you did]
+
+Join the challenge: devops-daily.com/hacktoberfest
+
+#Hacktoberfest #DevOpsDaily #OpenSource`}
               </p>
             </div>
-            <div className="rounded-lg border bg-card p-4">
-              <p className="text-xs text-muted-foreground mb-2 font-semibold">Copy-paste for LinkedIn:</p>
-              <p className="text-sm text-foreground font-mono bg-muted/50 rounded p-3 leading-relaxed">
-                {"Day [X] of the DevOps Daily Hacktoberfest challenge done! ✅\n\n[What you contributed and what you learned]\n\nIt's beginner-friendly and takes just 5-15 minutes per day. Check it out: devops-daily.com/hacktoberfest\n\n#Hacktoberfest #DevOps #OpenSource"}
+            <div className="rounded-md border bg-card p-4">
+              <p className="text-xs text-muted-foreground mb-2 font-mono">// linkedin</p>
+              <p className="text-sm text-foreground font-mono bg-muted/50 rounded-md p-3 leading-relaxed whitespace-pre-wrap">
+                {`Day [X] of the DevOps Daily Hacktoberfest challenge done!
+
+[What you contributed and what you learned]
+
+It's beginner-friendly and takes just 5-15 minutes per day. Check it out: devops-daily.com/hacktoberfest
+
+#Hacktoberfest #DevOps #OpenSource`}
               </p>
             </div>
           </div>
         </section>
 
-        {/* Follow Us */}
-        <section className="my-16 max-w-2xl mx-auto text-center">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight mb-4">
-            Stay Updated
-          </h2>
-          <p className="text-muted-foreground mb-6">
-            Follow us for daily challenge reminders, contributor highlights, and DevOps tips.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <a
-              href="https://x.com/thedevopsdaily"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-card hover:border-primary/30 transition-colors text-sm"
-            >
-              <ExternalLink className="w-4 h-4" />
-              X / Twitter
-            </a>
-            <a
-              href="https://www.linkedin.com/company/thedevopsdaily"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-card hover:border-primary/30 transition-colors text-sm"
-            >
-              <ExternalLink className="w-4 h-4" />
-              LinkedIn
-            </a>
-            <a
-              href="https://www.instagram.com/thedailydevops"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-card hover:border-primary/30 transition-colors text-sm"
-            >
-              <ExternalLink className="w-4 h-4" />
-              Instagram
-            </a>
-            <a
-              href="https://github.com/The-DevOps-Daily"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-card hover:border-primary/30 transition-colors text-sm"
-            >
-              <Github className="w-4 h-4" />
-              GitHub
-            </a>
-          </div>
-          <div className="mt-6">
-            <Link
-              href="/newsletters"
-              className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-            >
-              Subscribe to the newsletter for weekly reminders
-              <ArrowRight className="w-3 h-3" />
-            </Link>
-          </div>
-        </section>
+        <SectionSeparator command="ls /templates" />
 
-        {/* Sponsors */}
-        <div className="my-16">
-          <InlineSponsors variant="compact" />
-        </div>
-
-        {/* Contribution Templates */}
-        <section className="my-16 max-w-4xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-4">
-            Contribution Templates
-          </h2>
-          <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">
-            Copy these templates to get started. Each one shows the exact JSON structure you need.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Templates */}
+        <section className="my-12 max-w-5xl mx-auto">
+          <SectionHeader
+            label="templates"
+            title="Contribution Templates"
+            description="Copy these templates to get started. Each one shows the exact JSON structure you need."
+          />
+          <div className="grid gap-px md:grid-cols-3 bg-border border rounded-md overflow-hidden">
             {TEMPLATES.map((tmpl) => (
-              <div key={tmpl.day} className="rounded-lg border bg-card overflow-hidden">
-                <div className="flex items-center justify-between px-4 py-2.5 bg-muted/60 border-b border-border/80">
-                  <span className="text-xs font-semibold">{tmpl.day}: {tmpl.title}</span>
-                  <FileCode className="w-3.5 h-3.5 text-muted-foreground" />
+              <div key={tmpl.day} className="bg-card">
+                <div className="flex items-center justify-between px-4 py-2.5 bg-muted/60 border-b border-border/60">
+                  <span className="text-xs font-semibold font-mono">
+                    {tmpl.day}: {tmpl.title}
+                  </span>
+                  <FileCode className="w-3.5 h-3.5 text-muted-foreground" strokeWidth={1.5} />
                 </div>
                 <div className="p-3">
                   <p className="text-[10px] text-muted-foreground font-mono mb-2">{tmpl.file}</p>
@@ -657,14 +643,14 @@ export default function HacktoberfestPage() {
           </div>
         </section>
 
+        <SectionSeparator command="cat faq.md" />
+
         {/* FAQ */}
-        <section className="my-16 max-w-3xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-center mb-8">
-            Frequently Asked Questions
-          </h2>
-          <div className="space-y-4">
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader label="faq" title="Frequently Asked Questions" />
+          <div className="space-y-3">
             {FAQ_ITEMS.map((faq) => (
-              <div key={faq.question} className="rounded-lg border bg-card p-5">
+              <div key={faq.question} className="rounded-md border bg-card p-5">
                 <h3 className="font-semibold mb-2">{faq.question}</h3>
                 <p className="text-sm text-muted-foreground">{faq.answer}</p>
               </div>
@@ -672,20 +658,25 @@ export default function HacktoberfestPage() {
           </div>
         </section>
 
+        {/* Sponsors */}
+        <div className="my-12">
+          <InlineSponsors variant="compact" />
+        </div>
+
         {/* Final CTA */}
         <section className="my-16 max-w-2xl mx-auto text-center">
           <h2 className="text-2xl font-bold mb-4">Ready to contribute?</h2>
           <p className="text-muted-foreground mb-6">
-            Star the repo, fork it, and pick your first challenge. See you in October!
+            Star the repo, fork it, and pick your first challenge. See you in October.
           </p>
-          <Button asChild size="lg" className="shadow-md shadow-primary/10">
+          <Button asChild size="lg">
             <a
               href="https://github.com/The-DevOps-Daily/devops-daily"
               target="_blank"
               rel="noopener noreferrer"
               className="group"
             >
-              <Github className="w-5 h-5 mr-2" />
+              <Github className="w-5 h-5 mr-2" strokeWidth={1.5} />
               Get Started on GitHub
               <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
             </a>

--- a/app/hacktoberfest/page.tsx
+++ b/app/hacktoberfest/page.tsx
@@ -218,12 +218,37 @@ const TEMPLATES = [
   },
 ];
 
-const STEPS = [
-  { step: 1, title: 'Star the repo', description: 'Star the DevOps Daily repository on GitHub' },
-  { step: 2, title: 'Fork it', description: 'Fork the repo to your own GitHub account' },
-  { step: 3, title: 'Pick a day', description: 'Choose a challenge and follow the instructions' },
-  { step: 4, title: 'Submit a PR', description: 'Open a pull request with your contribution' },
-  { step: 5, title: 'Share it', description: 'Share your PR on social media with #DevOpsDaily' },
+const STEPS: { step: number; title: string; description: string; icon: LucideIcon }[] = [
+  {
+    step: 1,
+    title: 'Star the repo',
+    description: 'Star the DevOps Daily repository on GitHub',
+    icon: Star,
+  },
+  {
+    step: 2,
+    title: 'Fork it',
+    description: 'Fork the repo to your own GitHub account',
+    icon: GitPullRequest,
+  },
+  {
+    step: 3,
+    title: 'Pick a day',
+    description: 'Choose a challenge and follow the instructions',
+    icon: Calendar,
+  },
+  {
+    step: 4,
+    title: 'Submit a PR',
+    description: 'Open a pull request with your contribution',
+    icon: CheckCircle2,
+  },
+  {
+    step: 5,
+    title: 'Share it',
+    description: 'Share your PR on social media with #DevOpsDaily',
+    icon: Megaphone,
+  },
 ];
 
 export default function HacktoberfestPage() {
@@ -365,31 +390,43 @@ export default function HacktoberfestPage() {
         <section className="my-12 max-w-4xl mx-auto">
           <SectionHeader label="how it works" title="How It Works" />
           <div className="flex flex-col gap-3 sm:hidden">
-            {STEPS.map((s) => (
-              <div key={s.step} className="flex items-center gap-4">
-                <div className="w-9 h-9 rounded-md bg-primary/10 border border-primary/20 text-primary font-mono font-semibold flex items-center justify-center flex-shrink-0 tabular-nums">
-                  {s.step}
+            {STEPS.map((s) => {
+              const Icon = s.icon;
+              return (
+                <div key={s.step} className="flex items-center gap-4">
+                  <div className="relative flex-shrink-0 w-12 h-12 rounded-md bg-primary/10 border border-primary/20 flex items-center justify-center">
+                    <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
+                    <span className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-background border border-primary/30 text-primary text-[10px] font-mono tabular-nums font-semibold flex items-center justify-center">
+                      {s.step}
+                    </span>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-sm">{s.title}</h3>
+                    <p className="text-xs text-muted-foreground">{s.description}</p>
+                  </div>
                 </div>
-                <div>
-                  <h3 className="font-semibold text-sm">{s.title}</h3>
-                  <p className="text-xs text-muted-foreground">{s.description}</p>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
           <div className="hidden sm:block">
             <div className="relative">
-              <div className="absolute top-[18px] left-[10%] right-[10%] h-px bg-border" />
+              <div className="absolute top-6 left-[10%] right-[10%] h-px bg-border" />
               <div className="grid grid-cols-5 gap-4">
-                {STEPS.map((s) => (
-                  <div key={s.step} className="text-center relative">
-                    <div className="w-9 h-9 rounded-md bg-primary/10 border border-primary/20 text-primary font-mono font-semibold flex items-center justify-center mx-auto mb-3 relative z-10 tabular-nums bg-background">
-                      {s.step}
+                {STEPS.map((s) => {
+                  const Icon = s.icon;
+                  return (
+                    <div key={s.step} className="text-center relative">
+                      <div className="relative w-12 h-12 rounded-md bg-primary/10 border border-primary/20 flex items-center justify-center mx-auto mb-3 z-10 bg-background">
+                        <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
+                        <span className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-background border border-primary/30 text-primary text-[10px] font-mono tabular-nums font-semibold flex items-center justify-center">
+                          {s.step}
+                        </span>
+                      </div>
+                      <h3 className="font-semibold text-sm mb-1">{s.title}</h3>
+                      <p className="text-xs text-muted-foreground">{s.description}</p>
                     </div>
-                    <h3 className="font-semibold text-sm mb-1">{s.title}</h3>
-                    <p className="text-xs text-muted-foreground">{s.description}</p>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           </div>
@@ -405,51 +442,88 @@ export default function HacktoberfestPage() {
             description="One task per day, each building on your familiarity with the project. All contributions are JSON or Markdown edits."
           />
 
-          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
-            {CHALLENGE_DAYS.map((day) => {
-              const Icon = day.icon;
-              return (
-                <Link
-                  key={day.day}
-                  href={`/hacktoberfest/day-${day.day}`}
-                  className={`group bg-card p-5 transition-colors hover:bg-muted/40 ${
-                    day.bonus ? 'sm:col-span-2' : ''
-                  }`}
-                >
-                  <div className="flex items-start gap-4">
-                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
-                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1 font-mono text-xs text-muted-foreground tabular-nums">
-                        <span>Day {day.day}</span>
-                        <span className="text-muted-foreground/60">·</span>
-                        <span>{day.difficulty}</span>
-                        <span className="text-muted-foreground/60">·</span>
-                        <span>{day.time}</span>
-                        {day.bonus && (
-                          <>
-                            <span className="text-muted-foreground/60">·</span>
-                            <span className="text-primary">bonus</span>
-                          </>
-                        )}
+          {(() => {
+            const regularDays = CHALLENGE_DAYS.filter((d) => !d.bonus);
+            const bonusDay = CHALLENGE_DAYS.find((d) => d.bonus);
+            const regularRemainder = regularDays.length % 2;
+            return (
+              <>
+                <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
+                  {regularDays.map((day) => {
+                    const Icon = day.icon;
+                    return (
+                      <Link
+                        key={day.day}
+                        href={`/hacktoberfest/day-${day.day}`}
+                        className="group bg-card p-5 transition-colors hover:bg-muted/40"
+                      >
+                        <div className="flex items-start gap-4">
+                          <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
+                            <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 mb-1 font-mono text-xs text-muted-foreground tabular-nums">
+                              <span>Day {day.day}</span>
+                              <span className="text-muted-foreground/60">·</span>
+                              <span>{day.difficulty}</span>
+                              <span className="text-muted-foreground/60">·</span>
+                              <span>{day.time}</span>
+                            </div>
+                            <h3 className="font-semibold mb-1 group-hover:text-primary transition-colors">
+                              {day.title}
+                            </h3>
+                            <p className="text-sm text-muted-foreground leading-relaxed">
+                              {day.description}
+                            </p>
+                            <div className="flex items-center gap-1 mt-2 text-xs text-primary/80">
+                              <span>View full instructions</span>
+                              <ArrowRight className="w-3 h-3 transition-transform group-hover:translate-x-1" />
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                  {regularRemainder === 1 && (
+                    <div aria-hidden="true" className="bg-card hidden sm:block" />
+                  )}
+                </div>
+                {bonusDay && (
+                  <Link
+                    href={`/hacktoberfest/day-${bonusDay.day}`}
+                    className="group block mt-px rounded-md border bg-primary/5 p-5 transition-colors hover:bg-primary/10"
+                  >
+                    <div className="flex items-start gap-4">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/15 flex items-center justify-center">
+                        <bonusDay.icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
                       </div>
-                      <h3 className="font-semibold mb-1 group-hover:text-primary transition-colors">
-                        {day.title}
-                      </h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">
-                        {day.description}
-                      </p>
-                      <div className="flex items-center gap-1 mt-2 text-xs text-primary/80">
-                        <span>View full instructions</span>
-                        <ArrowRight className="w-3 h-3 transition-transform group-hover:translate-x-1" />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1 font-mono text-xs text-muted-foreground tabular-nums">
+                          <span>Day {bonusDay.day}</span>
+                          <span className="text-muted-foreground/60">·</span>
+                          <span>{bonusDay.difficulty}</span>
+                          <span className="text-muted-foreground/60">·</span>
+                          <span>{bonusDay.time}</span>
+                          <span className="text-muted-foreground/60">·</span>
+                          <span className="text-primary font-semibold">bonus</span>
+                        </div>
+                        <h3 className="font-semibold mb-1 group-hover:text-primary transition-colors">
+                          {bonusDay.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {bonusDay.description}
+                        </p>
+                        <div className="flex items-center gap-1 mt-2 text-xs text-primary/80">
+                          <span>View full instructions</span>
+                          <ArrowRight className="w-3 h-3 transition-transform group-hover:translate-x-1" />
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
+                  </Link>
+                )}
+              </>
+            );
+          })()}
         </section>
 
         <SectionSeparator command="cat rewards.md" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -152,7 +152,7 @@ export default async function Home() {
         limit={8}
         showHeader
         showViewAll
-        gridClassName="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4"
+        gridClassName="lg:grid-cols-4"
       />
 
       <SectionSeparator command="ls /exercises --recent" />

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -108,9 +108,9 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
     {
       title: 'Introduction to Linux',
       url: 'https://leanpub.com/introduction-to-linux',
-      type: 'tutorial',
+      type: 'book',
       external: true,
-      description: 'Free ebook covering Linux fundamentals end-to-end',
+      description: 'Comprehensive Linux fundamentals ebook on Leanpub',
     },
   ],
   'Shell Scripting (Bash)': [

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -1,20 +1,34 @@
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Target, TrendingUp, Award, CheckCircle, Mail, Sparkles, BarChart } from 'lucide-react';
+import {
+  Target,
+  TrendingUp,
+  Award,
+  CheckCircle2,
+  Mail,
+  BarChart,
+  Users,
+  Newspaper,
+  Gamepad2,
+  BookOpen,
+  Rocket,
+  ArrowRight,
+} from 'lucide-react';
+import { SectionHeader } from '@/components/section-header';
+import { SectionSeparator } from '@/components/section-separator';
+import { BreadcrumbSchema } from '@/components/schema-markup';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Sponsorship',
+  title: 'Sponsorship - Reach 25,000+ DevOps Engineers | DevOps Daily',
   description:
-    'Partner with DevOps Daily to reach thousands of DevOps professionals and decision-makers.',
+    'Partner with DevOps Daily to reach 25,000+ monthly readers, 5,000+ newsletter subscribers, and a highly engaged audience of DevOps engineers, SREs, and technical decision-makers.',
   alternates: {
     canonical: '/sponsorship',
   },
   openGraph: {
-    title: 'Sponsor DevOps Daily',
+    title: 'Sponsor DevOps Daily - Reach 25,000+ DevOps Engineers',
     description:
-      'Partner with DevOps Daily to reach thousands of DevOps professionals and decision-makers.',
+      'Partner with DevOps Daily to connect with 25,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
     url: '/sponsorship',
     type: 'website',
     images: [
@@ -28,293 +42,458 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Sponsor DevOps Daily',
+    title: 'Sponsor DevOps Daily - Reach 25,000+ DevOps Engineers',
     description:
-      'Partner with DevOps Daily to reach thousands of DevOps professionals and decision-makers.',
+      'Partner with DevOps Daily to reach 25,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
     images: ['/og-image.png'],
   },
 };
 
+const STATS = [
+  { value: '25,000+', label: 'Monthly readers', detail: 'organic + newsletter' },
+  { value: '5,000+', label: 'Newsletter subs', detail: 'weekly digest' },
+  { value: '600+', label: 'Content pieces', detail: 'posts, guides, labs' },
+  { value: '85%', label: 'Senior engineers', detail: 'mid-to-staff level' },
+];
+
+const AUDIENCE = [
+  { label: 'DevOps / Platform engineers', share: '42%' },
+  { label: 'Site reliability engineers (SRE)', share: '18%' },
+  { label: 'Cloud / infra architects', share: '14%' },
+  { label: 'Backend / fullstack engineers', share: '16%' },
+  { label: 'Engineering managers / leadership', share: '10%' },
+];
+
+const CHANNELS = [
+  {
+    title: 'Weekly Newsletter',
+    description:
+      '5,000+ engineers get a curated DevOps digest every Monday. Sponsored slot with copy you control.',
+    icon: Newspaper,
+    metric: '45%+ open rate',
+  },
+  {
+    title: 'Interactive Simulators',
+    description:
+      '30+ simulators pulling 10k+ sessions/month. Inline sponsor mention on the most popular ones.',
+    icon: Gamepad2,
+    metric: '10k+ sessions/mo',
+  },
+  {
+    title: 'Long-form Guides & Posts',
+    description:
+      '550+ indexed articles drawing AI-search and SEO traffic from engineers actively solving problems.',
+    icon: BookOpen,
+    metric: '500k+ pageviews/yr',
+  },
+  {
+    title: 'Roadmap & Toolbox',
+    description:
+      'Career roadmap and curated tool directory reached by engineers evaluating stacks and skills.',
+    icon: Target,
+    metric: 'Evergreen traffic',
+  },
+];
+
+const WHY = [
+  {
+    title: 'Engineers who decide',
+    description:
+      '65% of our audience influences tooling, vendor, or platform purchase decisions at their org.',
+    icon: TrendingUp,
+  },
+  {
+    title: 'Trust, not ads',
+    description:
+      'Your brand appears inside practical tutorials and interactive learning, not as a banner. Credibility transfers.',
+    icon: Award,
+  },
+  {
+    title: 'Focused, not fragmented',
+    description:
+      'No generic reach. Every visitor is here for DevOps, containers, cloud, CI/CD, SRE, or infra. Zero waste.',
+    icon: Target,
+  },
+  {
+    title: 'Measurable lift',
+    description:
+      'UTM tracking, click reports, share-of-voice against the relevant article, shared monthly with you.',
+    icon: BarChart,
+  },
+];
+
+const PACKAGES = [
+  {
+    name: 'Starter',
+    price: '$500',
+    cadence: '/month',
+    description: 'Awareness across the site',
+    features: [
+      'Logo + tagline on all post pages',
+      'One newsletter mention / month',
+      'Social shoutout at start of sponsorship',
+      'Monthly report (impressions, clicks)',
+    ],
+    popular: false,
+  },
+  {
+    name: 'Professional',
+    price: '$1,500',
+    cadence: '/month',
+    description: 'Our most popular — prominent reach',
+    features: [
+      'Everything in Starter',
+      'Homepage + roadmap placement',
+      'Dedicated newsletter slot (weekly)',
+      'One sponsored tutorial or tool spotlight post',
+      'Simulator/game inline mention on 3 pages',
+      'Priority response + monthly call',
+    ],
+    popular: true,
+  },
+  {
+    name: 'Enterprise',
+    price: 'Custom',
+    cadence: '',
+    description: 'Category ownership + custom content',
+    features: [
+      'Everything in Professional',
+      'Exclusive category sponsorship (K8s, cloud, CI/CD)',
+      'Custom content series (4+ pieces)',
+      'Co-branded webinar or live workshop',
+      'First look at new simulator slots',
+      'Quarterly strategy session',
+    ],
+    popular: false,
+  },
+];
+
+const FAQ = [
+  {
+    q: 'Who reads DevOps Daily?',
+    a: 'Mostly practicing DevOps/Platform engineers, SREs, and cloud architects, 2+ years in. 85% are mid-to-staff level, 65% influence tooling decisions at their org.',
+  },
+  {
+    q: 'Do you accept non-DevOps sponsors?',
+    a: "Only if there's a clear fit with our audience (e.g. developer tools, cloud infra, observability, security). We don't run general tech or consumer ads.",
+  },
+  {
+    q: "What kind of copy / creative do you need?",
+    a: 'For newsletter: 1-2 short paragraphs + a CTA link. For site placements: logo + tagline. For sponsored posts: we can write it based on your brief, or you provide the draft and we edit for house voice.',
+  },
+  {
+    q: 'Is there a minimum commitment?',
+    a: 'Starter and Professional are month-to-month. Enterprise is typically quarterly. Cancel anytime with 30 days notice.',
+  },
+  {
+    q: 'How do I start?',
+    a: (
+      <>
+        Email{' '}
+        <a
+          href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry"
+          className="text-primary hover:underline"
+        >
+          info@devops-daily.com
+        </a>{' '}
+        with a sentence about your product and the audience you want to reach. We respond within
+        24h and send a media kit + available slots.
+      </>
+    ),
+  },
+];
+
 export default function SponsorshipPage() {
+  const breadcrumbItems = [
+    { name: 'Home', url: '/' },
+    { name: 'Sponsorship', url: '/sponsorship' },
+  ];
+
   return (
-    <div className="min-h-screen">
-      {/* Hero Section */}
-      <section className="relative overflow-hidden bg-background py-20">
-        {/* Background decoration */}
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute inset-0 bg-linear-to-br from-primary/10 via-background to-background" />
-          <div className="absolute top-20 right-20 w-96 h-96 bg-primary/10 rounded-full blur-[120px]" />
-          <div className="absolute bottom-20 left-20 w-72 h-72 bg-primary/10 rounded-full blur-[100px]" />
-        </div>
+    <>
+      <BreadcrumbSchema items={breadcrumbItems} />
 
-        <div className="container mx-auto px-4">
+      {/* Hero */}
+      <div className="relative overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 -z-10 opacity-[0.07] dark:opacity-[0.09]"
+          style={{
+            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+            maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+            WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
+          }}
+        />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/[0.04] via-transparent to-transparent" />
+
+        <div className="container relative mx-auto px-4 py-16 md:py-20">
           <div className="max-w-4xl mx-auto text-center">
-            <Badge variant="outline" className="mb-6 px-4 py-1.5 border-primary/50 bg-primary/5">
-              <Sparkles className="w-3.5 h-3.5 mr-2" />
-              Limited Sponsorship Spots Available
-            </Badge>
+            <p className="text-xs font-mono text-muted-foreground mb-3">// sponsorship</p>
 
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-primary/20 bg-primary/5 text-xs font-mono text-primary mb-6">
+              <Rocket className="w-3.5 h-3.5" strokeWidth={1.5} />
+              Limited slots available
+            </div>
+
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-6">
               Reach{' '}
-              <span className="text-primary">
-                10,000+
+              <span className="text-primary relative inline-block">
+                25,000+
+                <svg
+                  className="absolute -bottom-2 left-0 w-full h-3 text-primary/40"
+                  viewBox="0 0 200 12"
+                  preserveAspectRatio="none"
+                >
+                  <path
+                    d="M2 9 Q25 2 50 8 Q75 1 100 7 Q125 2 150 9 Q175 4 198 7"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    fill="none"
+                    strokeLinecap="round"
+                  />
+                </svg>
               </span>{' '}
-              DevOps Professionals
+              DevOps engineers
+              <br />
+              who decide what to buy.
             </h1>
 
-            <p className="text-xl text-muted-foreground mb-8">
-              Partner with DevOps Daily to connect with a highly engaged audience of DevOps
-              engineers, SREs, and technical decision-makers
+            <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
+              DevOps Daily is where practicing platform engineers, SREs, and cloud architects come
+              to learn by doing. Your product lives inside real tutorials and interactive labs, not
+              next to cat videos.
             </p>
 
-            <div className="flex gap-4 justify-center flex-wrap">
-              <Button asChild size="lg" className="shadow-lg shadow-primary/20">
-                <a href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry">
-                  <Mail className="mr-2 h-4 w-4" />
-                  Contact Us
+            <div className="flex flex-wrap justify-center gap-3">
+              <Button asChild size="lg">
+                <a
+                  href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry"
+                  className="group"
+                >
+                  <Mail className="mr-2 h-4 w-4" strokeWidth={1.5} />
+                  Get the media kit
+                  <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
                 </a>
               </Button>
               <Button asChild variant="outline" size="lg">
-                <a href="#packages">View Packages</a>
+                <a href="#packages">See packages</a>
               </Button>
             </div>
           </div>
         </div>
-      </section>
+      </div>
 
-      {/* Stats Section */}
-      <section className="py-16 bg-muted/50">
-        <div className="container mx-auto px-4">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-            <div className="text-center">
-              <div className="text-4xl font-bold text-primary mb-2">10k+</div>
-              <div className="text-muted-foreground">Monthly Readers</div>
-            </div>
-            <div className="text-center">
-              <div className="text-4xl font-bold text-primary mb-2">85%</div>
-              <div className="text-muted-foreground">Senior Engineers</div>
-            </div>
-            <div className="text-center">
-              <div className="text-4xl font-bold text-primary mb-2">65%</div>
-              <div className="text-muted-foreground">Decision Makers</div>
-            </div>
-            <div className="text-center">
-              <div className="text-4xl font-bold text-primary mb-2">92%</div>
-              <div className="text-muted-foreground">Engagement Rate</div>
-            </div>
-          </div>
-        </div>
-      </section>
+      <div className="container mx-auto px-4">
+        <SectionSeparator command="cat audience.csv" />
 
-      {/* Why Sponsor Section */}
-      <section className="py-20">
-        <div className="container mx-auto px-4">
-          <div className="max-w-4xl mx-auto">
-            <h2 className="text-3xl md:text-4xl font-bold text-center mb-4">
-              Why Sponsor DevOps Daily?
-            </h2>
-            <p className="text-xl text-center text-muted-foreground mb-12">
-              Connect with the professionals shaping the future of DevOps
-            </p>
+        {/* Stats */}
+        <section className="my-12 max-w-5xl mx-auto">
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-px bg-border border rounded-md overflow-hidden">
+            {STATS.map((s) => (
+              <div key={s.label} className="bg-card p-5">
+                <dt className="text-[11px] uppercase tracking-wider text-muted-foreground font-mono">
+                  {s.label}
+                </dt>
+                <dd className="text-2xl sm:text-3xl font-bold tabular-nums mt-1 text-foreground">
+                  {s.value}
+                </dd>
+                <dd className="text-xs text-muted-foreground/80 mt-0.5 font-mono">{s.detail}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <Card className="group hover:shadow-lg transition-all duration-300 border-border/50">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-blue-500/10 text-blue-600">
-                      <Target className="h-6 w-6" />
+        {/* Audience breakdown */}
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader
+            label="audience"
+            title="Who you're reaching"
+            description="Breakdown of who visits, based on reader surveys and subscription sign-ups."
+          />
+          <ul className="space-y-2 font-mono text-sm">
+            {AUDIENCE.map((a) => (
+              <li
+                key={a.label}
+                className="flex items-center justify-between gap-4 rounded-md border bg-card px-4 py-3"
+              >
+                <span className="text-foreground">{a.label}</span>
+                <span className="text-primary tabular-nums font-semibold">{a.share}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <SectionSeparator command="ls /placement-channels" />
+
+        {/* Channels */}
+        <section className="my-12 max-w-5xl mx-auto">
+          <SectionHeader
+            label="channels"
+            title="Where your brand shows up"
+            description="Four distinct surfaces, each with its own audience and format."
+          />
+          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
+            {CHANNELS.map((c) => {
+              const Icon = c.icon;
+              return (
+                <div key={c.title} className="bg-card p-5">
+                  <div className="flex items-start gap-3 mb-2">
+                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
+                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
                     </div>
-                    <CardTitle>Targeted Audience</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">
-                    Reach DevOps engineers, SREs, cloud architects, and technical leadership
-                    actively seeking tools and solutions
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="group hover:shadow-lg transition-all duration-300 border-border/50">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-purple-500/10 text-purple-600">
-                      <TrendingUp className="h-6 w-6" />
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between gap-2 mb-0.5">
+                        <h3 className="font-semibold">{c.title}</h3>
+                        <span className="text-[11px] font-mono tabular-nums text-primary shrink-0">
+                          {c.metric}
+                        </span>
+                      </div>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {c.description}
+                      </p>
                     </div>
-                    <CardTitle>Growing Community</CardTitle>
                   </div>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">
-                    Our readership grows 30% month-over-month, with highly engaged professionals
-                    from Fortune 500 companies
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="group hover:shadow-lg transition-all duration-300 border-border/50">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-green-500/10 text-green-600">
-                      <Award className="h-6 w-6" />
-                    </div>
-                    <CardTitle>Premium Content</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">
-                    Your brand alongside expert-written tutorials, guides, and industry insights
-                    that developers trust
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="group hover:shadow-lg transition-all duration-300 border-border/50">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-orange-500/10 text-orange-600">
-                      <BarChart className="h-6 w-6" />
-                    </div>
-                    <CardTitle>Authentic Exposure</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">
-                    Get your message in front of a focused audience without the noise or
-                    distractions of traditional ads.
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Sponsorship Packages */}
-      <section id="packages" className="py-20 bg-muted/50">
-        <div className="container mx-auto px-4">
-          <div className="max-w-5xl mx-auto">
-            <h2 className="text-3xl md:text-4xl font-bold text-center mb-4">
-              Sponsorship Packages
-            </h2>
-            <p className="text-xl text-center text-muted-foreground mb-12">
-              Choose the package that best fits your goals
-            </p>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-              {/* Starter Package */}
-              <Card className="relative overflow-hidden border-2 hover:border-primary/50 transition-all">
-                <CardHeader>
-                  <CardTitle className="text-2xl">Starter</CardTitle>
-                  <CardDescription>Perfect for emerging companies</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="mb-6">
-                    <span className="text-3xl font-bold">$500</span>
-                    <span className="text-muted-foreground">/month</span>
-                  </div>
-                  <ul className="space-y-3">
-                    {[
-                      'Logo on all article pages',
-                      'Monthly newsletter mention',
-                      'Social media shoutout',
-                    ].map((feature) => (
-                      <li key={feature} className="flex items-start gap-2">
-                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                        <span className="text-sm">{feature}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-
-              {/* Professional Package */}
-              <Card className="relative overflow-hidden border-2 border-primary shadow-lg shadow-primary/10">
-                <div className="absolute top-0 right-0 bg-primary text-primary-foreground px-3 py-1 text-sm rounded-bl-lg">
-                  Popular
                 </div>
-                <CardHeader>
-                  <CardTitle className="text-2xl">Professional</CardTitle>
-                  <CardDescription>Our most popular option</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="mb-6">
-                    <span className="text-3xl font-bold">$1,500</span>
-                    <span className="text-muted-foreground">/month</span>
-                  </div>
-                  <ul className="space-y-3">
-                    {['Everything in Starter', 'Homepage placement', 'Dedicated blog post'].map(
-                      (feature) => (
-                        <li key={feature} className="flex items-start gap-2">
-                          <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                          <span className="text-sm">{feature}</span>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                </CardContent>
-              </Card>
-
-              {/* Enterprise Package */}
-              <Card className="relative overflow-hidden border-2 hover:border-primary/50 transition-all">
-                <CardHeader>
-                  <CardTitle className="text-2xl">Enterprise</CardTitle>
-                  <CardDescription>Maximum visibility & impact</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="mb-6">
-                    <span className="text-3xl font-bold">Custom</span>
-                  </div>
-                  <ul className="space-y-3">
-                    {[
-                      'Everything in Professional',
-                      'Exclusive partnerships',
-                      'Custom content series',
-                    ].map((feature) => (
-                      <li key={feature} className="flex items-start gap-2">
-                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                        <span className="text-sm">{feature}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </div>
+              );
+            })}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* CTA Section */}
-      <section className="py-20 relative overflow-hidden">
-        {/* Background decoration */}
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute inset-0 bg-linear-to-br from-primary/5 via-background to-background" />
-        </div>
+        <SectionSeparator command="cat why-sponsor.md" />
 
-        <div className="container mx-auto px-4">
-          <div className="max-w-3xl mx-auto text-center">
-            <h2 className="text-3xl md:text-4xl font-bold mb-6">
-              Ready to Reach Your Target Audience?
+        {/* Why Sponsor */}
+        <section className="my-12 max-w-4xl mx-auto">
+          <SectionHeader label="why sponsor" title="Why sponsor DevOps Daily" />
+          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
+            {WHY.map((w) => {
+              const Icon = w.icon;
+              return (
+                <div key={w.title} className="bg-card p-5">
+                  <div className="flex items-start gap-3">
+                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
+                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold mb-1">{w.title}</h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {w.description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <SectionSeparator command="ls /packages" />
+
+        {/* Packages */}
+        <section id="packages" className="my-12 max-w-5xl mx-auto scroll-mt-20">
+          <SectionHeader
+            label="packages"
+            title="Sponsorship packages"
+            description="Start with awareness, scale to category ownership. Cancel anytime."
+          />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {PACKAGES.map((pkg) => (
+              <div
+                key={pkg.name}
+                className={`relative rounded-md border bg-card p-6 flex flex-col ${
+                  pkg.popular
+                    ? 'border-primary/50 bg-primary/[0.03] ring-1 ring-primary/20'
+                    : 'border-border'
+                }`}
+              >
+                {pkg.popular && (
+                  <span className="absolute -top-2.5 right-4 px-2 py-0.5 text-[10px] font-mono tabular-nums uppercase tracking-wider text-primary bg-background border border-primary/40 rounded">
+                    most popular
+                  </span>
+                )}
+                <p className="text-xs font-mono text-muted-foreground mb-1">// {pkg.name.toLowerCase()}</p>
+                <h3 className="text-xl font-bold mb-1">{pkg.name}</h3>
+                <p className="text-sm text-muted-foreground mb-4">{pkg.description}</p>
+                <div className="mb-5 font-mono tabular-nums">
+                  <span className="text-3xl font-bold text-foreground">{pkg.price}</span>
+                  {pkg.cadence && (
+                    <span className="text-sm text-muted-foreground">{pkg.cadence}</span>
+                  )}
+                </div>
+                <ul className="space-y-2 flex-1 mb-6">
+                  {pkg.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm">
+                      <CheckCircle2
+                        className="h-4 w-4 text-primary mt-0.5 shrink-0"
+                        strokeWidth={1.5}
+                      />
+                      <span className="text-foreground">{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Button
+                  asChild
+                  variant={pkg.popular ? 'default' : 'outline'}
+                  className="w-full"
+                >
+                  <a
+                    href={`mailto:info@devops-daily.com?subject=Sponsorship Inquiry - ${pkg.name}`}
+                  >
+                    {pkg.price === 'Custom' ? 'Get a quote' : `Start with ${pkg.name}`}
+                  </a>
+                </Button>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground text-center mt-6 font-mono">
+            All packages include monthly reporting with impressions, clicks, and top-referring content.
+          </p>
+        </section>
+
+        <SectionSeparator command="cat faq.md" />
+
+        {/* FAQ */}
+        <section className="my-12 max-w-3xl mx-auto">
+          <SectionHeader label="faq" title="Frequently asked" />
+          <div className="space-y-3">
+            {FAQ.map((f) => (
+              <div key={f.q} className="rounded-md border bg-card p-5">
+                <h3 className="font-semibold mb-2">{f.q}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Final CTA */}
+        <section className="my-16 max-w-3xl mx-auto">
+          <div className="rounded-md border bg-primary/5 p-8 text-center">
+            <div className="inline-flex items-center gap-2 mb-4">
+              <Users className="w-5 h-5 text-primary" strokeWidth={1.5} />
+              <p className="text-xs font-mono text-primary uppercase tracking-wider">
+                Let&apos;s talk
+              </p>
+            </div>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-3">
+              Ready to reach engineers who build?
             </h2>
-            <p className="text-xl text-muted-foreground mb-8">
-              Join industry leaders who trust DevOps Daily to connect with the DevOps community
+            <p className="text-muted-foreground mb-6">
+              Tell us about your product and who you want to reach. We respond within 24 hours with
+              a media kit and available slots.
             </p>
-
-            <div className="flex gap-4 justify-center flex-wrap">
-              <Button asChild size="lg" className="shadow-lg shadow-primary/20">
-                <a href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry">
-                  <Mail className="mr-2 h-4 w-4" />
-                  Email: info@devops-daily.com
-                </a>
-              </Button>
-            </div>
-
-            <p className="mt-6 text-sm text-muted-foreground">
-              We typically respond within 24 hours
-            </p>
+            <Button asChild size="lg">
+              <a
+                href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry"
+                className="group"
+              >
+                <Mail className="mr-2 h-4 w-4" strokeWidth={1.5} />
+                info@devops-daily.com
+                <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+              </a>
+            </Button>
           </div>
-        </div>
-      </section>
-    </div>
+        </section>
+      </div>
+    </>
   );
 }

--- a/components/advent-landing-client.tsx
+++ b/components/advent-landing-client.tsx
@@ -28,9 +28,10 @@ export function AdventLandingClient({ days }: AdventLandingClientProps) {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
           {/* Main content */}
           <div className="lg:col-span-9">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl md:text-4xl font-bold mb-4">Daily Challenges</h2>
-              <p className="text-lg text-muted-foreground">
+            <div className="mb-8">
+              <p className="text-xs font-mono text-muted-foreground mb-1">// daily challenges</p>
+              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">Daily Challenges</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
                 Choose any day to start your DevOps learning journey
               </p>
             </div>

--- a/components/category-grid.tsx
+++ b/components/category-grid.tsx
@@ -97,6 +97,21 @@ export async function CategoryGrid({
     gridClassName
   );
 
+  // Pad the grid with empty `bg-card` cells so the last row doesn't show
+  // gapped strips of the outer bg-border. We pad to the max column count
+  // implied by the gridClassName (defaulting to 3), and pad up to `maxCols - 1`
+  // cells which is enough to cover any single incomplete row.
+  const maxCols = gridClassName?.includes('lg:grid-cols-4')
+    ? 4
+    : gridClassName?.includes('lg:grid-cols-3') ||
+      !gridClassName
+    ? 3
+    : gridClassName?.includes('lg:grid-cols-2')
+    ? 2
+    : 3;
+  const remainder = displayCategories.length % maxCols;
+  const fillerCount = remainder === 0 ? 0 : maxCols - remainder;
+
   return (
     <section className={cn('', className)}>
       {showHeader && (
@@ -136,6 +151,10 @@ export async function CategoryGrid({
             </Link>
           );
         })}
+
+        {Array.from({ length: fillerCount }).map((_, i) => (
+          <div key={`filler-${i}`} aria-hidden="true" className="bg-card hidden lg:block" />
+        ))}
 
         {displayCategories.length === 0 && (
           <div className="py-12 text-center col-span-full bg-card">

--- a/components/easter-egg-terminal.tsx
+++ b/components/easter-egg-terminal.tsx
@@ -263,12 +263,12 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
         </div>
 
         {/* Pipeline Stages */}
-        <div className="p-4 sm:p-6 border-b border-slate-700 overflow-x-auto">
-          <div className="flex justify-between items-center min-w-max sm:min-w-0">
+        <div className="px-3 sm:px-4 py-3 border-b border-slate-800">
+          <div className="flex items-center justify-between gap-1 sm:gap-1.5">
             {stages.map((s, i) => (
-              <div key={i} className="flex items-center">
+              <div key={i} className="flex items-center flex-1 min-w-0">
                 <div
-                  className={`flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 rounded-md border transition-all font-mono ${
+                  className={`flex items-center gap-1 sm:gap-1.5 px-1.5 sm:px-2.5 py-1 sm:py-1.5 rounded border transition-all font-mono text-[10px] sm:text-xs flex-1 min-w-0 justify-center ${
                     i < stage
                       ? 'bg-green-500/10 border-green-500/40 text-green-400'
                       : i === stage
@@ -276,19 +276,19 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
                         : 'bg-slate-800 border-slate-700 text-slate-500'
                   }`}
                 >
-                  <span className="text-base sm:text-xl" aria-hidden="true">
+                  <span className="text-sm sm:text-base leading-none" aria-hidden="true">
                     {s.icon}
                   </span>
-                  <span className="text-xs sm:text-sm font-medium">
+                  <span className="font-medium truncate">
                     {s.name.replace(s.icon, '').trim()}
                   </span>
                   {i < stage && (
-                    <CheckCircle className="w-3 h-3 sm:w-4 sm:h-4" aria-label="Complete" />
+                    <CheckCircle className="w-3 h-3 shrink-0" aria-label="Complete" />
                   )}
                 </div>
                 {i < stages.length - 1 && (
                   <div
-                    className={`w-2 sm:w-4 h-px mx-0.5 sm:mx-1 transition-all ${
+                    className={`w-2 sm:w-3 h-px mx-0.5 transition-all shrink-0 ${
                       i < stage ? 'bg-green-500/60' : 'bg-slate-700'
                     }`}
                   />

--- a/components/easter-egg-terminal.tsx
+++ b/components/easter-egg-terminal.tsx
@@ -234,22 +234,23 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
       aria-labelledby="deployment-title"
       aria-describedby="deployment-description"
     >
-      <div className="w-full max-w-4xl bg-slate-900 rounded-lg border-2 border-blue-500 shadow-2xl overflow-hidden my-4">
+      <div className="w-full max-w-4xl bg-slate-950 rounded-md border border-primary/40 shadow-2xl overflow-hidden my-4">
         {/* Header */}
-        <div className="bg-linear-to-r from-blue-600 to-purple-600 p-4">
+        <div className="bg-slate-900 border-b border-primary/30 p-4">
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <Rocket
-                className="w-5 h-5 sm:w-6 sm:h-6 text-white animate-pulse"
+                className="w-5 h-5 sm:w-6 sm:h-6 text-primary animate-pulse"
+                strokeWidth={1.5}
                 aria-hidden="true"
               />
-              <h2 id="deployment-title" className="text-lg sm:text-xl font-bold text-white">
+              <h2 id="deployment-title" className="text-lg sm:text-xl font-semibold text-slate-100">
                 Production Deployment Pipeline
               </h2>
             </div>
             <button
               onClick={onComplete}
-              className="text-white hover:text-gray-200 transition-colors p-2"
+              className="text-slate-400 hover:text-slate-100 transition-colors p-2"
               aria-label="Close deployment"
             >
               <X className="w-5 h-5" />
@@ -267,12 +268,12 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
             {stages.map((s, i) => (
               <div key={i} className="flex items-center">
                 <div
-                  className={`flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 rounded-full transition-all ${
+                  className={`flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 rounded-md border transition-all font-mono ${
                     i < stage
-                      ? 'bg-green-600 text-white'
+                      ? 'bg-green-500/10 border-green-500/40 text-green-400'
                       : i === stage
-                        ? 'bg-blue-600 text-white animate-pulse'
-                        : 'bg-slate-700 text-slate-400'
+                        ? 'bg-primary/10 border-primary/50 text-primary animate-pulse'
+                        : 'bg-slate-800 border-slate-700 text-slate-500'
                   }`}
                 >
                   <span className="text-base sm:text-xl" aria-hidden="true">
@@ -287,8 +288,8 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
                 </div>
                 {i < stages.length - 1 && (
                   <div
-                    className={`w-2 sm:w-4 h-1 mx-0.5 sm:mx-1 transition-all ${
-                      i < stage ? 'bg-green-600' : 'bg-slate-700'
+                    className={`w-2 sm:w-4 h-px mx-0.5 sm:mx-1 transition-all ${
+                      i < stage ? 'bg-green-500/60' : 'bg-slate-700'
                     }`}
                   />
                 )}
@@ -309,11 +310,11 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
                 log?.startsWith('✓')
                   ? 'text-green-400'
                   : log?.startsWith('→')
-                    ? 'text-blue-400'
+                    ? 'text-primary'
                     : log?.startsWith('🎉')
-                      ? 'text-yellow-400 font-bold text-lg'
+                      ? 'text-primary font-bold text-lg'
                       : log?.startsWith('🚀') || log?.startsWith('📊') || log?.startsWith('📈')
-                        ? 'text-purple-400'
+                        ? 'text-primary/80'
                         : 'text-slate-300'
               }`}
             >
@@ -324,17 +325,17 @@ const DeploymentAnimation = ({ onComplete }: { onComplete: () => void }) => {
         </div>
 
         {/* Progress Bar */}
-        <div className="p-4 bg-slate-900">
-          <div className="w-full bg-slate-700 rounded-full h-3 overflow-hidden">
+        <div className="p-4 bg-slate-900 border-t border-slate-800">
+          <div className="w-full bg-slate-800 rounded-full h-2 overflow-hidden">
             <div
-              className="bg-linear-to-r from-blue-500 to-purple-500 h-full transition-all duration-500 ease-out"
+              className="bg-primary h-full transition-all duration-500 ease-out"
               style={{ width: `${((stage + 1) / stages.length) * 100}%` }}
             />
           </div>
-          <p className="text-center text-slate-400 text-sm mt-2">
+          <p className="text-center text-slate-400 text-xs mt-2 font-mono tabular-nums">
             {stage < stages.length
-              ? `Stage ${stage + 1} of ${stages.length}`
-              : 'Deployment Complete!'}
+              ? `stage ${stage + 1} / ${stages.length}`
+              : 'deployment complete'}
           </p>
         </div>
       </div>
@@ -355,13 +356,16 @@ const AchievementModal = ({ open, onClose }: { open: boolean; onClose: () => voi
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-4" id="achievement-description">
-          <div className="bg-linear-to-r from-yellow-500/20 to-orange-500/20 border-2 border-yellow-500 rounded-lg p-6 text-center">
+          <div className="bg-primary/10 border border-primary/40 rounded-md p-6 text-center">
             <div className="text-6xl mb-4" aria-hidden="true">
               🚀
             </div>
             <h3 className="text-2xl font-bold mb-2">DevOps Master</h3>
             <p className="text-muted-foreground mb-4">You successfully deployed to production!</p>
-            <Badge variant="secondary" className="text-lg px-4 py-2">
+            <Badge
+              variant="secondary"
+              className="text-sm px-3 py-1 font-mono bg-primary/10 border border-primary/20 text-primary"
+            >
               Easter Egg Found
             </Badge>
           </div>

--- a/components/games/bug-hunter.tsx
+++ b/components/games/bug-hunter.tsx
@@ -508,7 +508,7 @@ return (
                         className={cn(
                           'w-full h-full rounded shadow-lg flex items-center justify-center',
                           index === 0
-                            ? 'bg-gradient-to-br from-red-500 to-orange-600 animate-glitch'
+                            ? 'bg-gradient-to-br from-red-500 to-orange-600'
                             : 'bg-gradient-to-br from-red-600 to-orange-700'
                         )}
                       >
@@ -536,11 +536,7 @@ return (
                             <p>• Speed increases as you infect more servers</p>
                             <p>• Unlock achievements as you progress</p>
                           </div>
-                          <Button
-                            onClick={startGame}
-                            size="lg"
-                            className="bg-gradient-to-r from-red-500 to-orange-600 hover:from-red-600 hover:to-orange-700"
-                          >
+                          <Button onClick={startGame} size="lg">
                             Start Game
                           </Button>
                         </div>
@@ -764,18 +760,6 @@ return (
           background-image: linear-gradient(to right, rgba(100, 100, 100, 0.1) 1px, transparent 1px),
             linear-gradient(to bottom, rgba(100, 100, 100, 0.1) 1px, transparent 1px);
           background-size: ${CELL_SIZE}px ${CELL_SIZE}px;
-        }
-
-        @keyframes glitch {
-          0%, 100% { transform: translate(0); }
-          20% { transform: translate(-2px, 2px); }
-          40% { transform: translate(2px, -2px); }
-          60% { transform: translate(-2px, -2px); }
-          80% { transform: translate(2px, 2px); }
-        }
-
-        .animate-glitch {
-          animation: glitch 0.3s ease-in-out infinite;
         }
       `}</style>
     </div>

--- a/components/games/cicd-stack-generator-impl.tsx
+++ b/components/games/cicd-stack-generator-impl.tsx
@@ -379,48 +379,50 @@ export default function CICDStackGenerator() {
 
   return (
     <div className="flex flex-col items-center w-full max-w-4xl mx-auto my-8">
-      <h1 className="text-3xl md:text-4xl font-bold mb-4 text-center">
-        <span className="text-transparent bg-clip-text bg-linear-to-r from-green-500 via-blue-500 to-purple-500">
-          CI/CD Stack Generator
-        </span>
+      <h1 className="text-3xl md:text-4xl font-bold mb-4 text-center text-primary">
+        CI/CD Stack Generator
       </h1>
 
       <p className="text-center text-muted-foreground mb-8 max-w-2xl">
         Spin the wheels to get your perfect (or perfectly cursed) DevOps stack!
       </p>
 
-      {/* Slot Machine */}
-      <div className="relative w-full max-w-2xl bg-linear-to-b from-slate-800 to-slate-950 rounded-xl shadow-2xl border border-slate-700 p-6 mb-6">
-        {/* Top decoration */}
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-3 w-32 h-6 bg-slate-700 rounded-full flex items-center justify-center">
-          <div className="w-24 h-4 bg-linear-to-r from-red-500 via-amber-500 to-green-500 rounded-full animate-pulse"></div>
+      {/* Slot Machine (terminal-styled) */}
+      <div className="relative w-full max-w-2xl rounded-md border bg-card overflow-hidden font-mono text-sm p-6 mb-6">
+        {/* Terminal traffic-light header */}
+        <div className="absolute top-0 left-0 right-0 h-7 bg-muted/50 border-b flex items-center gap-1.5 px-3">
+          <span className="w-2.5 h-2.5 rounded-full bg-red-400/70"></span>
+          <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/70"></span>
+          <span className="w-2.5 h-2.5 rounded-full bg-green-400/70"></span>
+          <span className="ml-3 text-xs text-muted-foreground">$ generate stack</span>
         </div>
+        <div className="h-4" />
 
         {/* Reels Container */}
-        <div className="relative bg-slate-900 rounded-lg p-4 mb-6 overflow-hidden min-h-[200px]">
+        <div className="relative bg-muted/40 border rounded-md p-4 mb-6 overflow-hidden min-h-[200px]">
           {/* Selection highlight */}
           <div className="absolute left-0 right-0 top-1/2 h-16 -translate-y-1/2 bg-primary/20 border-y-2 border-primary/50 z-10 pointer-events-none rounded"></div>
 
           {/* Column separators */}
-          <div className="absolute left-1/3 top-0 bottom-0 w-px bg-slate-700 z-10"></div>
-          <div className="absolute left-2/3 top-0 bottom-0 w-px bg-slate-700 z-10"></div>
+          <div className="absolute left-1/3 top-0 bottom-0 w-px bg-border z-10"></div>
+          <div className="absolute left-2/3 top-0 bottom-0 w-px bg-border z-10"></div>
 
           {/* Column Headers */}
           <div className="grid grid-cols-3 gap-0 mb-2">
-            <div className="text-center text-xs font-medium text-slate-400 uppercase tracking-wider">
+            <div className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider">
               CI/CD Tool
             </div>
-            <div className="text-center text-xs font-medium text-slate-400 uppercase tracking-wider">
+            <div className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider">
               Infrastructure
             </div>
-            <div className="text-center text-xs font-medium text-slate-400 uppercase tracking-wider">
+            <div className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider">
               Platform
             </div>
           </div>
 
           <div className="grid grid-cols-3 gap-0">
             {reels.map((reel, index) => (
-              <div key={index} className="h-48 overflow-hidden bg-slate-800 relative">
+              <div key={index} className="h-48 overflow-hidden bg-background/60 relative">
                 <AnimatePresence mode="wait">
                   {reel.spinning ? (
                     <motion.div
@@ -437,7 +439,7 @@ export default function CICDStackGenerator() {
                       {reel.displayItems.map((item, itemIndex) => (
                         <div
                           key={itemIndex}
-                          className="h-12 flex items-center justify-center px-2 text-center font-medium text-white/90 text-sm leading-tight shrink-0 border-b border-slate-700/50"
+                          className="h-12 flex items-center justify-center px-2 text-center font-medium text-foreground/90 text-sm leading-tight shrink-0 border-b border-border/50"
                         >
                           {item}
                         </div>
@@ -460,8 +462,8 @@ export default function CICDStackGenerator() {
                   )}
                 </AnimatePresence>
 
-                {/* Subtle gradient overlay to create depth */}
-                <div className="absolute inset-0 bg-linear-to-b from-slate-800/20 via-transparent to-slate-800/20 pointer-events-none" />
+                {/* Subtle overlay to create depth */}
+                <div className="absolute inset-0 bg-linear-to-b from-background/30 via-transparent to-background/30 pointer-events-none" />
               </div>
             ))}
           </div>
@@ -474,7 +476,7 @@ export default function CICDStackGenerator() {
             disabled={isSpinning}
             size="lg"
             className={cn(
-              'px-8 font-bold text-lg bg-linear-to-r from-amber-500 to-red-500 hover:from-amber-400 hover:to-red-400 shadow-lg',
+              'px-8 font-bold text-lg',
               isSpinning && 'opacity-50 cursor-not-allowed'
             )}
           >
@@ -498,10 +500,7 @@ export default function CICDStackGenerator() {
             size="lg"
             disabled={!rating}
             onClick={shareResult}
-            className={cn(
-              'border-slate-600 hover:bg-slate-800',
-              !rating && 'opacity-50 cursor-not-allowed'
-            )}
+            className={cn(!rating && 'opacity-50 cursor-not-allowed')}
           >
             <Share2 className="h-4 w-4 mr-2" />
             Share
@@ -509,32 +508,49 @@ export default function CICDStackGenerator() {
         </div>
       </div>
 
-      {/* Results */}
+      {/* Results - terminal-styled output */}
       <AnimatePresence mode="wait">
         {rating && (
           <motion.div
-            initial={{ opacity: 0, y: 20, scale: 0.9 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -20, scale: 0.9 }}
-            transition={{ duration: 0.5, ease: 'easeOut' }}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
             className="w-full max-w-2xl"
           >
-            <div
-              className={cn(
-                'rounded-xl p-8 text-white text-center shadow-xl border border-white/20',
-                rating.color
-              )}
-            >
-              <motion.div
-                className="text-6xl mb-4"
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
-              >
-                {rating.emoji}
-              </motion.div>
-              <h3 className="text-2xl font-bold mb-3">Your Stack Rating</h3>
-              <p className="text-lg leading-relaxed">{rating.text}</p>
+            <div className="rounded-md border bg-card overflow-hidden font-mono text-sm">
+              {/* Terminal header with traffic lights */}
+              <div className="h-7 bg-muted/50 border-b flex items-center gap-1.5 px-3">
+                <span className="w-2.5 h-2.5 rounded-full bg-red-400/70"></span>
+                <span className="w-2.5 h-2.5 rounded-full bg-yellow-400/70"></span>
+                <span className="w-2.5 h-2.5 rounded-full bg-green-400/70"></span>
+                <span className="ml-3 text-xs text-muted-foreground">stack.yml</span>
+              </div>
+              <div className="p-5 space-y-1 leading-relaxed">
+                <div className="text-muted-foreground"># Generated DevOps Stack</div>
+                <div>
+                  <span className="text-primary">ci_cd</span>
+                  <span className="text-muted-foreground">:</span>{' '}
+                  <span className="text-foreground">{reels[0].value}</span>
+                </div>
+                <div>
+                  <span className="text-primary">infrastructure</span>
+                  <span className="text-muted-foreground">:</span>{' '}
+                  <span className="text-foreground">{reels[1].value}</span>
+                </div>
+                <div>
+                  <span className="text-primary">platform</span>
+                  <span className="text-muted-foreground">:</span>{' '}
+                  <span className="text-foreground">{reels[2].value}</span>
+                </div>
+                <div className="pt-3 border-t mt-3">
+                  <div className="text-muted-foreground"># verdict</div>
+                  <div className="flex items-start gap-2 mt-1">
+                    <span className="text-xl leading-none mt-0.5">{rating.emoji}</span>
+                    <span className="text-foreground font-sans">{rating.text}</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </motion.div>
         )}

--- a/components/games/ddos-simulator.tsx
+++ b/components/games/ddos-simulator.tsx
@@ -552,12 +552,7 @@ export default function DDoSSimulator() {
   }
 
   return (
-    <div className={cn(
-      "min-h-screen",
-      isDark
-        ? "bg-linear-to-br from-slate-950 via-slate-900 to-slate-950"
-        : "bg-gradient-to-br from-gray-50 via-blue-50 to-gray-50"
-    )}>
+    <div className="bg-background text-foreground">
       <div className={cn("container mx-auto px-4 py-6 sm:py-8 transition-transform duration-200", screenShake && "animate-shake")}>
         {/* Achievement Notification */}
         <AnimatePresence>
@@ -566,7 +561,7 @@ export default function DDoSSimulator() {
               initial={{ opacity: 0, y: -50, x: '-50%' }}
               animate={{ opacity: 1, y: 0, x: '-50%' }}
               exit={{ opacity: 0, y: -50, x: '-50%' }}
-              className="fixed top-20 left-1/2 z-50 bg-linear-to-r from-yellow-500/90 to-orange-500/90 backdrop-blur-sm px-6 py-4 rounded-xl shadow-2xl border-2 border-yellow-400"
+              className="fixed top-20 left-1/2 z-50 bg-amber-500/90 backdrop-blur-sm px-6 py-4 rounded-md border border-amber-400"
             >
               <div className="flex items-center gap-3">
                 <Award className="w-6 h-6 text-white" />
@@ -589,10 +584,10 @@ export default function DDoSSimulator() {
           className="text-center mb-8"
         >
           <div className="flex items-center justify-center gap-3 mb-4">
-            <div className="w-12 h-12 rounded-xl bg-linear-to-br from-red-500 to-orange-600 flex items-center justify-center shadow-lg shadow-red-500/50">
+            <div className="w-12 h-12 rounded-md bg-red-500 flex items-center justify-center">
               <Shield className="w-6 h-6 text-white" />
             </div>
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold bg-linear-to-r from-red-500 via-orange-500 to-yellow-500 bg-clip-text text-transparent">
+            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-primary">
               DDoS Attack Simulator
             </h1>
           </div>
@@ -989,9 +984,7 @@ export default function DDoSSimulator() {
                     onClick={toggleSimulation}
                     className={cn(
                       'flex-1',
-                      isRunning
-                        ? 'bg-red-500 hover:bg-red-600'
-                        : 'bg-linear-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600'
+                      isRunning && 'bg-red-500 hover:bg-red-600 text-white'
                     )}
                     disabled={gameOver}
                   >
@@ -1173,14 +1166,14 @@ export default function DDoSSimulator() {
                   >
                     <div
                       className={cn(
-                        'relative w-24 h-24 rounded-2xl flex items-center justify-center transition-all duration-300',
+                        'relative w-24 h-24 rounded-md flex items-center justify-center transition-all duration-300 border',
                         serverHealth > 70
-                          ? 'bg-linear-to-br from-green-500/20 to-emerald-500/20 border-2 border-green-500/50'
+                          ? 'bg-green-500/10 border-green-500/50'
                           : serverHealth > 40
-                            ? 'bg-linear-to-br from-yellow-500/20 to-orange-500/20 border-2 border-yellow-500/50'
+                            ? 'bg-yellow-500/10 border-yellow-500/50'
                             : serverHealth > 0
-                              ? 'bg-linear-to-br from-red-500/20 to-rose-500/20 border-2 border-red-500/50'
-                              : 'bg-linear-to-br from-gray-500/20 to-slate-500/20 border-2 border-gray-500/50'
+                              ? 'bg-red-500/10 border-red-500/50'
+                              : 'bg-gray-500/10 border-gray-500/50'
                       )}
                     >
                       <Server
@@ -1269,7 +1262,7 @@ export default function DDoSSimulator() {
 
                       {/* Offline icon when down */}
                       {serverHealth <= 0 && (
-                        <div className="absolute inset-0 flex items-center justify-center bg-slate-900/80 rounded-2xl">
+                        <div className="absolute inset-0 flex items-center justify-center bg-slate-900/80 rounded-md">
                           <WifiOff className="w-12 h-12 text-gray-500" />
                         </div>
                       )}
@@ -1286,7 +1279,7 @@ export default function DDoSSimulator() {
                         className="absolute inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center"
                       >
                         <div className={cn(
-                          "text-center p-8 rounded-2xl border-2 border-red-500/50 shadow-2xl max-w-md",
+                          "text-center p-8 rounded-md border border-red-500/50 max-w-md",
                           isDark ? "bg-slate-900/90" : "bg-white/95"
                         )}>
                           <WifiOff className="w-16 h-16 text-red-500 mx-auto mb-4" />
@@ -1327,14 +1320,11 @@ export default function DDoSSimulator() {
                             </div>
                           </div>
                           {survivalTime === highScore && highScore > 0 && (
-                            <Badge className="mb-4 bg-linear-to-r from-yellow-500 to-orange-500">
+                            <Badge className="mb-4 bg-amber-500 text-white">
                               🏆 New High Score!
                             </Badge>
                           )}
-                          <Button
-                            onClick={resetGame}
-                            className="bg-linear-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600"
-                          >
+                          <Button onClick={resetGame}>
                             <RotateCcw className="w-4 h-4 mr-2" />
                             Try Again
                           </Button>
@@ -1426,7 +1416,7 @@ export default function DDoSSimulator() {
                   </div>
                   <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-linear-to-r from-green-500 to-emerald-500"
+                      className="h-full bg-green-500"
                       style={{ width: `${(blockedRequests / totalRequests) * 100}%` }}
                     />
                   </div>
@@ -1461,7 +1451,7 @@ export default function DDoSSimulator() {
                     className={cn(
                       'p-3 rounded-lg border transition-all',
                       achievement.unlocked
-                        ? 'bg-linear-to-r from-yellow-500/10 to-orange-500/10 border-yellow-500/30'
+                        ? 'bg-amber-500/10 border-amber-500/30'
                         : isDark
                           ? 'bg-slate-800/30 border-slate-700/30 opacity-50'
                           : 'bg-gray-100 border-gray-300 opacity-50'
@@ -1494,12 +1484,7 @@ export default function DDoSSimulator() {
         </div>
 
         {/* Educational Tips */}
-        <Card className={cn(
-          "border backdrop-blur",
-          isDark 
-            ? "bg-linear-to-br from-blue-500/10 to-purple-500/10 border-blue-500/20" 
-            : "bg-linear-to-br from-blue-50 to-purple-50 border-blue-200"
-        )}>
+        <Card className="border bg-muted/30">
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
               <div className={cn(

--- a/components/games/load-balancer-simulator.tsx
+++ b/components/games/load-balancer-simulator.tsx
@@ -416,7 +416,7 @@ export default function LoadBalancerSimulator() {
           </div>
 
           {/* Visualization */}
-          <div className="relative h-72 bg-gradient-to-br from-slate-100 to-slate-50 dark:from-slate-800 dark:to-slate-900 rounded-xl overflow-hidden">
+          <div className="relative h-72 bg-muted/30 rounded-md border overflow-hidden">
             {/* Connection Lines */}
             <svg className="absolute inset-0 w-full h-full">
               {/* Users to Load Balancer */}

--- a/components/games/packet-journey.tsx
+++ b/components/games/packet-journey.tsx
@@ -517,18 +517,13 @@ export default function PacketJourney() {
   }
 
   return (
-    <div className={cn(
-      "min-h-screen p-4",
-      isDark
-        ? "bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white"
-        : "bg-gradient-to-br from-blue-50 via-white to-cyan-50 text-gray-900"
-    )}>
+    <div className="p-4 bg-background text-foreground">
      <div className="max-w-7xl mx-auto space-y-6">
        {/* Header */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-4xl font-bold bg-linear-to-r from-blue-400 via-cyan-400 to-teal-400 bg-clip-text text-transparent flex items-center gap-3">
-              <Sparkles className="w-8 h-8 text-cyan-400" />
+            <h1 className="text-4xl font-bold text-primary flex items-center gap-3">
+              <Sparkles className="w-8 h-8 text-primary" />
               Network Packet Journey
             </h1>
             <p className={cn(
@@ -563,8 +558,8 @@ export default function PacketJourney() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
             >
-              <Alert className="bg-linear-to-r from-cyan-500/10 to-blue-500/10 border-cyan-400/50">
-                <Sparkles className="h-4 w-4 text-cyan-400" />
+              <Alert className="bg-primary/5 border-primary/20">
+                <Sparkles className="h-4 w-4 text-primary" />
                 <AlertDescription className="text-sm flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
                   <span>
                     <strong>Pro tip:</strong> Use keyboard shortcuts - <kbd className={cn("px-2 py-1 rounded text-xs", isDark ? "bg-slate-700" : "bg-gray-200")}>Space</kbd> to play/pause, <kbd className={cn("px-2 py-1 rounded text-xs", isDark ? "bg-slate-700" : "bg-gray-200")}>R</kbd> to reset, <kbd className={cn("px-2 py-1 rounded text-xs", isDark ? "bg-slate-700" : "bg-gray-200")}>Esc</kbd> to close details
@@ -603,7 +598,7 @@ export default function PacketJourney() {
               isDark ? "bg-slate-700" : "bg-gray-200"
             )}>
               <motion.div
-                className="h-full bg-linear-to-r from-cyan-500 to-blue-500"
+                className="h-full bg-primary"
                 initial={{ width: 0 }}
                 animate={{ width: `${stageProgress * 100}%` }}
                 transition={{ duration: 0.1 }}
@@ -935,7 +930,7 @@ export default function PacketJourney() {
                   </div>
                   <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden">
                     <motion.div
-                      className="h-full bg-linear-to-r from-cyan-500 to-blue-500"
+                      className="h-full bg-primary"
                       initial={{ width: 0 }}
                       animate={{ width: `${((currentStageIndex + (isReturning ? journeyStages.length : 0)) / (journeyStages.length * 2)) * 100}%` }}
                       transition={{ duration: 0.3 }}
@@ -953,12 +948,7 @@ export default function PacketJourney() {
             </CardHeader>
             <CardContent>
               {/* SVG Canvas - Redesigned for clarity */}
-              <div className={cn(
-                "relative w-full rounded-lg border overflow-hidden min-h-[400px] sm:min-h-[600px]",
-                isDark
-                  ? "bg-gradient-to-br from-slate-900 to-slate-800 border-slate-700"
-                  : "bg-gradient-to-br from-gray-50 to-gray-100 border-gray-300"
-              )}>
+              <div className="relative w-full rounded-md border bg-card overflow-hidden min-h-[400px] sm:min-h-[600px]">
                 <svg viewBox="0 0 100 100" className="w-full h-full" preserveAspectRatio="xMidYMid meet">
                   <defs>
                     {/* Gradient for the path */}
@@ -1333,7 +1323,7 @@ export default function PacketJourney() {
                     initial={{ opacity: 0, scale: 0.9 }}
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0 }}
-                    className="mt-4 p-4 bg-linear-to-r from-green-500/20 to-blue-500/20 border border-green-400 rounded-lg"
+                    className="mt-4 p-4 bg-green-500/10 border border-green-500/40 rounded-md"
                   >
                     <div className="flex items-center gap-3">
                       <CheckCircle2 className="w-8 h-8 text-green-400" />
@@ -1359,7 +1349,7 @@ export default function PacketJourney() {
                     initial={{ opacity: 0, scale: 0.9 }}
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0 }}
-                    className="mt-4 p-4 bg-linear-to-r from-red-500/20 to-orange-500/20 border border-red-400 rounded-lg"
+                    className="mt-4 p-4 bg-red-500/10 border border-red-500/40 rounded-md"
                   >
                     <div className="flex items-center gap-3">
                       <XCircle className="w-8 h-8 text-red-400" />
@@ -1660,10 +1650,10 @@ export default function PacketJourney() {
 
         {/* Info Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card className="bg-linear-to-br from-blue-500/20 to-cyan-500/20 border-blue-400">
+          <Card className="bg-muted/30 border">
             <CardContent className="pt-6">
               <div className="flex items-center gap-3">
-                <Sparkles className="w-8 h-8 text-blue-400" />
+                <Sparkles className="w-8 h-8 text-primary" />
                 <div>
                   <div className="text-2xl font-bold">{journeyStages.length}</div>
                   <div className={cn("text-sm", isDark ? "text-slate-300" : "text-gray-600")}>Network Hops</div>
@@ -1672,10 +1662,10 @@ export default function PacketJourney() {
             </CardContent>
           </Card>
 
-          <Card className="bg-linear-to-br from-purple-500/20 to-pink-500/20 border-purple-400">
+          <Card className="bg-muted/30 border">
             <CardContent className="pt-6">
               <div className="flex items-center gap-3">
-                <Timer className="w-8 h-8 text-purple-400" />
+                <Timer className="w-8 h-8 text-primary" />
                 <div>
                   <div className="text-2xl font-bold">{totalJourneyTime}ms</div>
                   <div className={cn("text-sm", isDark ? "text-slate-300" : "text-gray-600")}>Total Latency</div>
@@ -1684,10 +1674,10 @@ export default function PacketJourney() {
             </CardContent>
           </Card>
 
-          <Card className="bg-linear-to-br from-green-500/20 to-teal-500/20 border-green-400">
+          <Card className="bg-muted/30 border">
             <CardContent className="pt-6">
               <div className="flex items-center gap-3">
-                <TrendingUp className="w-8 h-8 text-green-400" />
+                <TrendingUp className="w-8 h-8 text-green-500" />
                 <div>
                   <div className="text-2xl font-bold">{(totalJourneyTime * 2).toFixed(0)}ms</div>
                   <div className={cn("text-sm", isDark ? "text-slate-300" : "text-gray-600")}>Round-Trip Time</div>
@@ -1789,7 +1779,7 @@ export default function PacketJourney() {
         </Card>
 
         {/* Educational Footer */}
-        <Card className="bg-linear-to-r from-indigo-500/10 to-purple-500/10 border-indigo-400">
+        <Card className="bg-primary/5 border-primary/20">
           <CardContent className="pt-6">
             <div className="space-y-3">
               <h3 className="font-bold flex items-center gap-2">

--- a/components/games/tcp-vs-udp.tsx
+++ b/components/games/tcp-vs-udp.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Play, Pause, RefreshCw, Wifi, WifiOff, Shield, Zap, Activity, AlertTriangle, Info, Lock, ArrowRightLeft, Keyboard } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 /**
  * TCP vs UDP Visual Simulator
@@ -410,7 +411,7 @@ export default function TcpVsUdpSimulator() {
   // --- Renderers ---
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 font-sans selection:bg-cyan-500/30">
+    <div className="bg-background text-foreground font-sans selection:bg-primary/30">
       <div className="max-w-6xl mx-auto p-4 md:p-6 flex flex-col gap-6">
         
         {/* Header */}
@@ -507,8 +508,8 @@ export default function TcpVsUdpSimulator() {
         </div>
 
         {/* Main Simulation Canvas */}
-        <div 
-          className="relative w-full h-96 bg-slate-100 dark:bg-slate-950 rounded-xl border-2 border-slate-300 dark:border-slate-800 overflow-hidden shadow-2xl"
+        <div
+          className="relative w-full h-96 rounded-md border bg-background overflow-hidden"
           ref={containerRef}
         >
           {/* Background Grid */}
@@ -603,12 +604,9 @@ export default function TcpVsUdpSimulator() {
             <div className="absolute inset-0 flex items-center justify-center bg-black/40 backdrop-blur-[2px] z-30">
               <div className="text-center">
                 <p className="text-slate-700 dark:text-slate-300 mb-2">Ready to simulate</p>
-                <button
-                  onClick={handleStartStop}
-                  className="bg-slate-900 dark:bg-white text-white dark:text-slate-900 px-6 py-2 rounded-full font-bold transition-colors flex items-center gap-2 mx-auto"
-                >
+                <Button onClick={handleStartStop} className="gap-2">
                   <Play size={18} fill="currentColor" /> Start Traffic
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/components/header/dropdown-menu.tsx
+++ b/components/header/dropdown-menu.tsx
@@ -166,7 +166,7 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
                                 {item.label}
                               </h4>
                               {item.badge && (
-                                <span className="px-2 py-0.5 bg-linear-to-r from-primary to-purple-600 text-white text-xs rounded-full font-bold">
+                                <span className="px-1.5 py-0.5 bg-primary/10 border border-primary/20 text-primary text-[10px] font-mono tabular-nums rounded">
                                   {item.badge}
                                 </span>
                               )}

--- a/components/header/mobile-menu.tsx
+++ b/components/header/mobile-menu.tsx
@@ -65,7 +65,7 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
                       </div>
                       <span className="flex-1">{item.label}</span>
                       {item.badge && (
-                        <span className="px-3 py-1 text-xs font-bold text-white rounded-full bg-linear-to-r from-primary to-purple-600">
+                        <span className="px-1.5 py-0.5 bg-primary/10 border border-primary/20 text-primary text-[10px] font-mono tabular-nums rounded">
                           {item.badge}
                         </span>
                       )}

--- a/components/header/nav-items.ts
+++ b/components/header/nav-items.ts
@@ -230,7 +230,7 @@ export const dropdownNavigation: Record<string, NavSection[]> = {
           description: '25 days of DevOps challenges',
           icon: Gift,
           featured: true,
-          badge: '2025',
+          badge: '2026',
         },
       ],
     },

--- a/content/advent-of-devops/day-1.md
+++ b/content/advent-of-devops/day-1.md
@@ -3,8 +3,8 @@ title: 'Day 1 - Build a Minimal Docker Image'
 day: 1
 excerpt: 'Learn to create the smallest possible Docker image for a Go application. Optimize for size, security, and performance using static compilation.'
 description: 'Create a minimal Docker image under 25MB using Go, multi-stage builds, Alpine Linux, and best practices for containerization.'
-publishedAt: '2025-12-01T00:00:00Z'
-updatedAt: '2025-12-14T00:00:00Z'
+publishedAt: '2026-12-01T00:00:00Z'
+updatedAt: '2026-12-14T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-1.md
+++ b/content/advent-of-devops/day-1.md
@@ -3,8 +3,8 @@ title: 'Day 1 - Build a Minimal Docker Image'
 day: 1
 excerpt: 'Learn to create the smallest possible Docker image for a Go application. Optimize for size, security, and performance using static compilation.'
 description: 'Create a minimal Docker image under 25MB using Go, multi-stage builds, Alpine Linux, and best practices for containerization.'
-publishedAt: '2026-12-01T00:00:00Z'
-updatedAt: '2026-12-14T00:00:00Z'
+publishedAt: '2025-12-01T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-10.md
+++ b/content/advent-of-devops/day-10.md
@@ -3,8 +3,8 @@ title: 'Day 10 - Wrap the App in a Helm Chart'
 day: 10
 excerpt: 'Package your Kubernetes application as a Helm chart for easy deployment and management across environments.'
 description: 'Learn Helm fundamentals by creating a reusable chart with templates, values, and helpers for deploying applications to Kubernetes.'
-publishedAt: '2026-12-10T00:00:00Z'
-updatedAt: '2026-12-10T00:00:00Z'
+publishedAt: '2025-12-10T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-10.md
+++ b/content/advent-of-devops/day-10.md
@@ -3,8 +3,8 @@ title: 'Day 10 - Wrap the App in a Helm Chart'
 day: 10
 excerpt: 'Package your Kubernetes application as a Helm chart for easy deployment and management across environments.'
 description: 'Learn Helm fundamentals by creating a reusable chart with templates, values, and helpers for deploying applications to Kubernetes.'
-publishedAt: '2025-12-10T00:00:00Z'
-updatedAt: '2025-12-10T00:00:00Z'
+publishedAt: '2026-12-10T00:00:00Z'
+updatedAt: '2026-12-10T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-11.md
+++ b/content/advent-of-devops/day-11.md
@@ -3,8 +3,8 @@ title: 'Day 11 - Basic Observability'
 day: 11
 excerpt: 'Set up monitoring and logging for your Kubernetes application with Prometheus and Grafana.'
 description: 'Implement observability fundamentals: metrics collection with Prometheus, visualization with Grafana, and centralized logging.'
-publishedAt: '2025-12-11T00:00:00Z'
-updatedAt: '2025-12-11T00:00:00Z'
+publishedAt: '2026-12-11T00:00:00Z'
+updatedAt: '2026-12-11T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Observability'
 tags:

--- a/content/advent-of-devops/day-11.md
+++ b/content/advent-of-devops/day-11.md
@@ -3,8 +3,8 @@ title: 'Day 11 - Basic Observability'
 day: 11
 excerpt: 'Set up monitoring and logging for your Kubernetes application with Prometheus and Grafana.'
 description: 'Implement observability fundamentals: metrics collection with Prometheus, visualization with Grafana, and centralized logging.'
-publishedAt: '2026-12-11T00:00:00Z'
-updatedAt: '2026-12-11T00:00:00Z'
+publishedAt: '2025-12-11T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Observability'
 tags:

--- a/content/advent-of-devops/day-12.md
+++ b/content/advent-of-devops/day-12.md
@@ -3,8 +3,8 @@ title: 'Day 12 - Log Parsing'
 day: 12
 excerpt: 'Parse and analyze application logs to extract meaningful insights and debug production issues.'
 description: 'Learn log parsing techniques using tools like jq, grep, awk, and LogQL to troubleshoot applications and extract valuable metrics from logs.'
-publishedAt: '2025-12-12T00:00:00Z'
-updatedAt: '2025-12-12T00:00:00Z'
+publishedAt: '2026-12-12T00:00:00Z'
+updatedAt: '2026-12-12T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Observability'
 tags:

--- a/content/advent-of-devops/day-12.md
+++ b/content/advent-of-devops/day-12.md
@@ -3,8 +3,8 @@ title: 'Day 12 - Log Parsing'
 day: 12
 excerpt: 'Parse and analyze application logs to extract meaningful insights and debug production issues.'
 description: 'Learn log parsing techniques using tools like jq, grep, awk, and LogQL to troubleshoot applications and extract valuable metrics from logs.'
-publishedAt: '2026-12-12T00:00:00Z'
-updatedAt: '2026-12-12T00:00:00Z'
+publishedAt: '2025-12-12T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Observability'
 tags:

--- a/content/advent-of-devops/day-13.md
+++ b/content/advent-of-devops/day-13.md
@@ -3,8 +3,8 @@ title: 'Day 13 - Security Scan'
 day: 13
 excerpt: 'Scan container images and infrastructure code for security vulnerabilities and misconfigurations.'
 description: 'Learn container and infrastructure security scanning with Trivy, Checkov, and automated security checks in CI/CD pipelines.'
-publishedAt: '2026-12-13T00:00:00Z'
-updatedAt: '2026-12-13T00:00:00Z'
+publishedAt: '2025-12-13T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-13.md
+++ b/content/advent-of-devops/day-13.md
@@ -3,8 +3,8 @@ title: 'Day 13 - Security Scan'
 day: 13
 excerpt: 'Scan container images and infrastructure code for security vulnerabilities and misconfigurations.'
 description: 'Learn container and infrastructure security scanning with Trivy, Checkov, and automated security checks in CI/CD pipelines.'
-publishedAt: '2025-12-13T00:00:00Z'
-updatedAt: '2025-12-13T00:00:00Z'
+publishedAt: '2026-12-13T00:00:00Z'
+updatedAt: '2026-12-13T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-14.md
+++ b/content/advent-of-devops/day-14.md
@@ -3,8 +3,8 @@ title: 'Day 14 - Networking Debugging'
 day: 14
 excerpt: 'Debug network connectivity issues in Kubernetes including DNS, service discovery, and network policies.'
 description: 'Master Kubernetes networking troubleshooting by debugging DNS resolution, service connectivity, network policies, and inter-pod communication.'
-publishedAt: '2026-12-14T00:00:00Z'
-updatedAt: '2026-12-14T00:00:00Z'
+publishedAt: '2025-12-14T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-14.md
+++ b/content/advent-of-devops/day-14.md
@@ -3,8 +3,8 @@ title: 'Day 14 - Networking Debugging'
 day: 14
 excerpt: 'Debug network connectivity issues in Kubernetes including DNS, service discovery, and network policies.'
 description: 'Master Kubernetes networking troubleshooting by debugging DNS resolution, service connectivity, network policies, and inter-pod communication.'
-publishedAt: '2025-12-14T00:00:00Z'
-updatedAt: '2025-12-14T00:00:00Z'
+publishedAt: '2026-12-14T00:00:00Z'
+updatedAt: '2026-12-14T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-15.md
+++ b/content/advent-of-devops/day-15.md
@@ -3,8 +3,8 @@ title: 'Day 15 - Bash Scripting Day'
 day: 15
 excerpt: 'Write a practical bash script to automate common DevOps tasks like deployments, backups, and health checks.'
 description: 'Master bash scripting fundamentals by creating robust automation scripts with error handling, logging, and best practices.'
-publishedAt: '2026-12-15T00:00:00Z'
-updatedAt: '2026-12-15T00:00:00Z'
+publishedAt: '2025-12-15T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Automation'
 tags:

--- a/content/advent-of-devops/day-15.md
+++ b/content/advent-of-devops/day-15.md
@@ -3,8 +3,8 @@ title: 'Day 15 - Bash Scripting Day'
 day: 15
 excerpt: 'Write a practical bash script to automate common DevOps tasks like deployments, backups, and health checks.'
 description: 'Master bash scripting fundamentals by creating robust automation scripts with error handling, logging, and best practices.'
-publishedAt: '2025-12-15T00:00:00Z'
-updatedAt: '2025-12-15T00:00:00Z'
+publishedAt: '2026-12-15T00:00:00Z'
+updatedAt: '2026-12-15T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Automation'
 tags:

--- a/content/advent-of-devops/day-16.md
+++ b/content/advent-of-devops/day-16.md
@@ -3,8 +3,8 @@ title: 'Day 16 - Autoscaling'
 day: 16
 excerpt: 'Configure horizontal pod autoscaling in Kubernetes to automatically scale applications based on CPU and memory usage.'
 description: 'Implement Kubernetes Horizontal Pod Autoscaler (HPA) and learn metrics-based scaling for efficient resource utilization and high availability.'
-publishedAt: '2025-12-16T00:00:00Z'
-updatedAt: '2025-12-16T00:00:00Z'
+publishedAt: '2026-12-16T00:00:00Z'
+updatedAt: '2026-12-16T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-16.md
+++ b/content/advent-of-devops/day-16.md
@@ -3,8 +3,8 @@ title: 'Day 16 - Autoscaling'
 day: 16
 excerpt: 'Configure horizontal pod autoscaling in Kubernetes to automatically scale applications based on CPU and memory usage.'
 description: 'Implement Kubernetes Horizontal Pod Autoscaler (HPA) and learn metrics-based scaling for efficient resource utilization and high availability.'
-publishedAt: '2026-12-16T00:00:00Z'
-updatedAt: '2026-12-16T00:00:00Z'
+publishedAt: '2025-12-16T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-17.md
+++ b/content/advent-of-devops/day-17.md
@@ -3,8 +3,8 @@ title: 'Day 17 - Serverless Deploy'
 day: 17
 excerpt: 'Deploy a serverless function to AWS Lambda with API Gateway, learning modern serverless architecture patterns.'
 description: 'Learn serverless deployment with AWS Lambda, API Gateway, and Infrastructure as Code using AWS SAM or Serverless Framework.'
-publishedAt: '2025-12-17T00:00:00Z'
-updatedAt: '2025-12-17T00:00:00Z'
+publishedAt: '2026-12-17T00:00:00Z'
+updatedAt: '2026-12-17T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Serverless'
 tags:

--- a/content/advent-of-devops/day-17.md
+++ b/content/advent-of-devops/day-17.md
@@ -3,8 +3,8 @@ title: 'Day 17 - Serverless Deploy'
 day: 17
 excerpt: 'Deploy a serverless function to AWS Lambda with API Gateway, learning modern serverless architecture patterns.'
 description: 'Learn serverless deployment with AWS Lambda, API Gateway, and Infrastructure as Code using AWS SAM or Serverless Framework.'
-publishedAt: '2026-12-17T00:00:00Z'
-updatedAt: '2026-12-17T00:00:00Z'
+publishedAt: '2025-12-17T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Serverless'
 tags:

--- a/content/advent-of-devops/day-18.md
+++ b/content/advent-of-devops/day-18.md
@@ -3,8 +3,8 @@ title: 'Day 18 - Deploy a Static Site'
 day: 18
 excerpt: 'Deploy a static website to AWS S3 with CloudFront CDN for global performance and HTTPS support.'
 description: 'Learn static site deployment using S3, CloudFront, and automation with GitHub Actions for continuous deployment.'
-publishedAt: '2026-12-18T00:00:00Z'
-updatedAt: '2026-12-18T00:00:00Z'
+publishedAt: '2025-12-18T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Cloud'
 tags:

--- a/content/advent-of-devops/day-18.md
+++ b/content/advent-of-devops/day-18.md
@@ -3,8 +3,8 @@ title: 'Day 18 - Deploy a Static Site'
 day: 18
 excerpt: 'Deploy a static website to AWS S3 with CloudFront CDN for global performance and HTTPS support.'
 description: 'Learn static site deployment using S3, CloudFront, and automation with GitHub Actions for continuous deployment.'
-publishedAt: '2025-12-18T00:00:00Z'
-updatedAt: '2025-12-18T00:00:00Z'
+publishedAt: '2026-12-18T00:00:00Z'
+updatedAt: '2026-12-18T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Cloud'
 tags:

--- a/content/advent-of-devops/day-19.md
+++ b/content/advent-of-devops/day-19.md
@@ -3,8 +3,8 @@ title: 'Day 19 - Load Testing'
 day: 19
 excerpt: 'Perform load testing on your application to identify performance bottlenecks and capacity limits.'
 description: 'Learn load testing fundamentals with k6, Apache Bench, and wrk to measure application performance under stress.'
-publishedAt: '2026-12-19T00:00:00Z'
-updatedAt: '2026-12-19T00:00:00Z'
+publishedAt: '2025-12-19T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Performance'
 tags:

--- a/content/advent-of-devops/day-19.md
+++ b/content/advent-of-devops/day-19.md
@@ -3,8 +3,8 @@ title: 'Day 19 - Load Testing'
 day: 19
 excerpt: 'Perform load testing on your application to identify performance bottlenecks and capacity limits.'
 description: 'Learn load testing fundamentals with k6, Apache Bench, and wrk to measure application performance under stress.'
-publishedAt: '2025-12-19T00:00:00Z'
-updatedAt: '2025-12-19T00:00:00Z'
+publishedAt: '2026-12-19T00:00:00Z'
+updatedAt: '2026-12-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Performance'
 tags:

--- a/content/advent-of-devops/day-2.md
+++ b/content/advent-of-devops/day-2.md
@@ -3,8 +3,8 @@ title: 'Day 2 - Fix the Slow Docker Build'
 day: 2
 excerpt: 'Debug and optimize a poorly written Dockerfile to reduce build time by at least 50%. Learn layer caching, build optimization, and best practices.'
 description: 'Improve Docker build performance through layer caching, dependency optimization, and efficient Dockerfile practices.'
-publishedAt: '2025-12-02T00:00:00Z'
-updatedAt: '2025-12-02T00:00:00Z'
+publishedAt: '2026-12-02T00:00:00Z'
+updatedAt: '2026-12-02T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-2.md
+++ b/content/advent-of-devops/day-2.md
@@ -3,8 +3,8 @@ title: 'Day 2 - Fix the Slow Docker Build'
 day: 2
 excerpt: 'Debug and optimize a poorly written Dockerfile to reduce build time by at least 50%. Learn layer caching, build optimization, and best practices.'
 description: 'Improve Docker build performance through layer caching, dependency optimization, and efficient Dockerfile practices.'
-publishedAt: '2026-12-02T00:00:00Z'
-updatedAt: '2026-12-02T00:00:00Z'
+publishedAt: '2025-12-02T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-20.md
+++ b/content/advent-of-devops/day-20.md
@@ -3,8 +3,8 @@ title: 'Day 20 - Secrets Management'
 day: 20
 excerpt: 'Securely manage application secrets and credentials using AWS Secrets Manager, Kubernetes Secrets, and best practices.'
 description: 'Learn proper secrets management with AWS Secrets Manager, Kubernetes Secrets, and External Secrets Operator for secure credential handling.'
-publishedAt: '2026-12-20T00:00:00Z'
-updatedAt: '2026-12-20T00:00:00Z'
+publishedAt: '2025-12-20T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-20.md
+++ b/content/advent-of-devops/day-20.md
@@ -3,8 +3,8 @@ title: 'Day 20 - Secrets Management'
 day: 20
 excerpt: 'Securely manage application secrets and credentials using AWS Secrets Manager, Kubernetes Secrets, and best practices.'
 description: 'Learn proper secrets management with AWS Secrets Manager, Kubernetes Secrets, and External Secrets Operator for secure credential handling.'
-publishedAt: '2025-12-20T00:00:00Z'
-updatedAt: '2025-12-20T00:00:00Z'
+publishedAt: '2026-12-20T00:00:00Z'
+updatedAt: '2026-12-20T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-21.md
+++ b/content/advent-of-devops/day-21.md
@@ -3,8 +3,8 @@ title: 'Day 21 - Create a Reusable Template Repo'
 day: 21
 excerpt: 'Build a GitHub template repository with DevOps best practices baked in for quick project bootstrapping.'
 description: 'Create a comprehensive template repository with CI/CD, testing, linting, Docker, and documentation for rapid project initialization.'
-publishedAt: '2025-12-21T00:00:00Z'
-updatedAt: '2025-12-21T00:00:00Z'
+publishedAt: '2026-12-21T00:00:00Z'
+updatedAt: '2026-12-21T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Automation'
 tags:

--- a/content/advent-of-devops/day-21.md
+++ b/content/advent-of-devops/day-21.md
@@ -3,8 +3,8 @@ title: 'Day 21 - Create a Reusable Template Repo'
 day: 21
 excerpt: 'Build a GitHub template repository with DevOps best practices baked in for quick project bootstrapping.'
 description: 'Create a comprehensive template repository with CI/CD, testing, linting, Docker, and documentation for rapid project initialization.'
-publishedAt: '2026-12-21T00:00:00Z'
-updatedAt: '2026-12-21T00:00:00Z'
+publishedAt: '2025-12-21T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Automation'
 tags:

--- a/content/advent-of-devops/day-22.md
+++ b/content/advent-of-devops/day-22.md
@@ -3,8 +3,8 @@ title: 'Day 22 - Run a Local Cluster'
 day: 22
 excerpt: 'Set up a local Kubernetes cluster with Minikube or Kind for development and testing without cloud costs.'
 description: 'Learn to run local Kubernetes clusters using Minikube, Kind, or k3d for fast development, testing, and learning.'
-publishedAt: '2026-12-22T00:00:00Z'
-updatedAt: '2026-12-22T00:00:00Z'
+publishedAt: '2025-12-22T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-22.md
+++ b/content/advent-of-devops/day-22.md
@@ -3,8 +3,8 @@ title: 'Day 22 - Run a Local Cluster'
 day: 22
 excerpt: 'Set up a local Kubernetes cluster with Minikube or Kind for development and testing without cloud costs.'
 description: 'Learn to run local Kubernetes clusters using Minikube, Kind, or k3d for fast development, testing, and learning.'
-publishedAt: '2025-12-22T00:00:00Z'
-updatedAt: '2025-12-22T00:00:00Z'
+publishedAt: '2026-12-22T00:00:00Z'
+updatedAt: '2026-12-22T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-23.md
+++ b/content/advent-of-devops/day-23.md
@@ -3,8 +3,8 @@ title: 'Day 23 - Container Networking Puzzle'
 day: 23
 excerpt: 'Solve complex container networking challenges involving multi-container apps, custom networks, and service discovery.'
 description: 'Master Docker networking by solving real-world challenges with custom networks, DNS, port mapping, and container communication.'
-publishedAt: '2026-12-23T00:00:00Z'
-updatedAt: '2026-12-23T00:00:00Z'
+publishedAt: '2025-12-23T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-23.md
+++ b/content/advent-of-devops/day-23.md
@@ -3,8 +3,8 @@ title: 'Day 23 - Container Networking Puzzle'
 day: 23
 excerpt: 'Solve complex container networking challenges involving multi-container apps, custom networks, and service discovery.'
 description: 'Master Docker networking by solving real-world challenges with custom networks, DNS, port mapping, and container communication.'
-publishedAt: '2025-12-23T00:00:00Z'
-updatedAt: '2025-12-23T00:00:00Z'
+publishedAt: '2026-12-23T00:00:00Z'
+updatedAt: '2026-12-23T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-24.md
+++ b/content/advent-of-devops/day-24.md
@@ -3,8 +3,8 @@ title: 'Day 24 - Harden a Config'
 day: 24
 excerpt: 'Apply security hardening best practices to application configurations, containers, and infrastructure.'
 description: 'Learn security hardening by applying CIS benchmarks, security best practices, and defensive configurations to your infrastructure.'
-publishedAt: '2025-12-24T00:00:00Z'
-updatedAt: '2025-12-24T00:00:00Z'
+publishedAt: '2026-12-24T00:00:00Z'
+updatedAt: '2026-12-24T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-24.md
+++ b/content/advent-of-devops/day-24.md
@@ -3,8 +3,8 @@ title: 'Day 24 - Harden a Config'
 day: 24
 excerpt: 'Apply security hardening best practices to application configurations, containers, and infrastructure.'
 description: 'Learn security hardening by applying CIS benchmarks, security best practices, and defensive configurations to your infrastructure.'
-publishedAt: '2026-12-24T00:00:00Z'
-updatedAt: '2026-12-24T00:00:00Z'
+publishedAt: '2025-12-24T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Security'
 tags:

--- a/content/advent-of-devops/day-25.md
+++ b/content/advent-of-devops/day-25.md
@@ -3,8 +3,8 @@ title: 'Day 25 - Write Your DevOps Journey'
 day: 25
 excerpt: 'Reflect on your DevOps learning journey, document what you built, and share your knowledge with the community.'
 description: 'Celebrate completing the Advent of DevOps by documenting your journey, creating a portfolio, and sharing your learnings with the world.'
-publishedAt: '2025-12-25T00:00:00Z'
-updatedAt: '2025-12-25T00:00:00Z'
+publishedAt: '2026-12-25T00:00:00Z'
+updatedAt: '2026-12-25T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Career'
 tags:

--- a/content/advent-of-devops/day-25.md
+++ b/content/advent-of-devops/day-25.md
@@ -3,8 +3,8 @@ title: 'Day 25 - Write Your DevOps Journey'
 day: 25
 excerpt: 'Reflect on your DevOps learning journey, document what you built, and share your knowledge with the community.'
 description: 'Celebrate completing the Advent of DevOps by documenting your journey, creating a portfolio, and sharing your learnings with the world.'
-publishedAt: '2026-12-25T00:00:00Z'
-updatedAt: '2026-12-25T00:00:00Z'
+publishedAt: '2025-12-25T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Career'
 tags:

--- a/content/advent-of-devops/day-3.md
+++ b/content/advent-of-devops/day-3.md
@@ -3,8 +3,8 @@ title: 'Day 3 - Add GitHub Actions CI'
 day: 3
 excerpt: 'Set up continuous integration for a repository without automation. Create a GitHub Actions workflow that runs tests on every push.'
 description: 'Learn to create GitHub Actions workflows for continuous integration, automated testing, and quality checks.'
-publishedAt: '2026-12-03T00:00:00Z'
-updatedAt: '2026-12-03T00:00:00Z'
+publishedAt: '2025-12-03T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'CI/CD'
 tags:

--- a/content/advent-of-devops/day-3.md
+++ b/content/advent-of-devops/day-3.md
@@ -3,8 +3,8 @@ title: 'Day 3 - Add GitHub Actions CI'
 day: 3
 excerpt: 'Set up continuous integration for a repository without automation. Create a GitHub Actions workflow that runs tests on every push.'
 description: 'Learn to create GitHub Actions workflows for continuous integration, automated testing, and quality checks.'
-publishedAt: '2025-12-03T00:00:00Z'
-updatedAt: '2025-12-03T00:00:00Z'
+publishedAt: '2026-12-03T00:00:00Z'
+updatedAt: '2026-12-03T00:00:00Z'
 difficulty: 'Beginner'
 category: 'CI/CD'
 tags:

--- a/content/advent-of-devops/day-4.md
+++ b/content/advent-of-devops/day-4.md
@@ -3,8 +3,8 @@ title: 'Day 4 - Speed Up CI with Caching'
 day: 4
 excerpt: 'Optimize a slow GitHub Actions workflow by adding intelligent caching for dependencies. Achieve 40% faster run times.'
 description: 'Learn GitHub Actions caching strategies to dramatically reduce CI/CD pipeline execution times.'
-publishedAt: '2025-12-04T00:00:00Z'
-updatedAt: '2025-12-04T00:00:00Z'
+publishedAt: '2026-12-04T00:00:00Z'
+updatedAt: '2026-12-04T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'CI/CD'
 tags:

--- a/content/advent-of-devops/day-4.md
+++ b/content/advent-of-devops/day-4.md
@@ -3,8 +3,8 @@ title: 'Day 4 - Speed Up CI with Caching'
 day: 4
 excerpt: 'Optimize a slow GitHub Actions workflow by adding intelligent caching for dependencies. Achieve 40% faster run times.'
 description: 'Learn GitHub Actions caching strategies to dramatically reduce CI/CD pipeline execution times.'
-publishedAt: '2026-12-04T00:00:00Z'
-updatedAt: '2026-12-04T00:00:00Z'
+publishedAt: '2025-12-04T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'CI/CD'
 tags:

--- a/content/advent-of-devops/day-5.md
+++ b/content/advent-of-devops/day-5.md
@@ -3,8 +3,8 @@ title: 'Day 5 - Debug a Broken Container'
 day: 5
 excerpt: 'Troubleshoot and fix a container that fails to start. Learn essential debugging techniques for containerized applications.'
 description: 'Master Docker debugging skills by diagnosing and fixing common container issues including crashes, networking problems, and misconfiguration.'
-publishedAt: '2026-12-05T00:00:00Z'
-updatedAt: '2026-12-05T00:00:00Z'
+publishedAt: '2025-12-05T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-5.md
+++ b/content/advent-of-devops/day-5.md
@@ -3,8 +3,8 @@ title: 'Day 5 - Debug a Broken Container'
 day: 5
 excerpt: 'Troubleshoot and fix a container that fails to start. Learn essential debugging techniques for containerized applications.'
 description: 'Master Docker debugging skills by diagnosing and fixing common container issues including crashes, networking problems, and misconfiguration.'
-publishedAt: '2025-12-05T00:00:00Z'
-updatedAt: '2025-12-05T00:00:00Z'
+publishedAt: '2026-12-05T00:00:00Z'
+updatedAt: '2026-12-05T00:00:00Z'
 difficulty: 'Beginner'
 category: 'Docker'
 tags:

--- a/content/advent-of-devops/day-6.md
+++ b/content/advent-of-devops/day-6.md
@@ -3,8 +3,8 @@ title: 'Day 6 - Write a Small Terraform Module'
 day: 6
 excerpt: 'Create your first reusable Terraform module to provision cloud infrastructure. Learn infrastructure as code fundamentals.'
 description: 'Build a practical Terraform module for AWS S3 bucket creation with proper configuration, variables, and outputs.'
-publishedAt: '2026-12-06T00:00:00Z'
-updatedAt: '2026-12-06T00:00:00Z'
+publishedAt: '2025-12-06T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Infrastructure as Code'
 tags:

--- a/content/advent-of-devops/day-6.md
+++ b/content/advent-of-devops/day-6.md
@@ -3,8 +3,8 @@ title: 'Day 6 - Write a Small Terraform Module'
 day: 6
 excerpt: 'Create your first reusable Terraform module to provision cloud infrastructure. Learn infrastructure as code fundamentals.'
 description: 'Build a practical Terraform module for AWS S3 bucket creation with proper configuration, variables, and outputs.'
-publishedAt: '2025-12-06T00:00:00Z'
-updatedAt: '2025-12-06T00:00:00Z'
+publishedAt: '2026-12-06T00:00:00Z'
+updatedAt: '2026-12-06T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Infrastructure as Code'
 tags:

--- a/content/advent-of-devops/day-7.md
+++ b/content/advent-of-devops/day-7.md
@@ -3,8 +3,8 @@ title: 'Day 7 - Improve the Terraform Module'
 day: 7
 excerpt: 'Enhance your Terraform module with advanced features like testing, documentation, and CI/CD integration.'
 description: 'Level up your Terraform module with comprehensive documentation, automated testing, and publishing to the Terraform Registry.'
-publishedAt: '2025-12-07T00:00:00Z'
-updatedAt: '2025-12-07T00:00:00Z'
+publishedAt: '2026-12-07T00:00:00Z'
+updatedAt: '2026-12-07T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Infrastructure as Code'
 tags:

--- a/content/advent-of-devops/day-7.md
+++ b/content/advent-of-devops/day-7.md
@@ -3,8 +3,8 @@ title: 'Day 7 - Improve the Terraform Module'
 day: 7
 excerpt: 'Enhance your Terraform module with advanced features like testing, documentation, and CI/CD integration.'
 description: 'Level up your Terraform module with comprehensive documentation, automated testing, and publishing to the Terraform Registry.'
-publishedAt: '2026-12-07T00:00:00Z'
-updatedAt: '2026-12-07T00:00:00Z'
+publishedAt: '2025-12-07T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Advanced'
 category: 'Infrastructure as Code'
 tags:

--- a/content/advent-of-devops/day-8.md
+++ b/content/advent-of-devops/day-8.md
@@ -3,8 +3,8 @@ title: 'Day 8 - Deploy a Small App on Kubernetes'
 day: 8
 excerpt: 'Deploy your first application to Kubernetes using Deployments, Services, and ConfigMaps. Learn the fundamentals of K8s.'
 description: 'Master Kubernetes basics by deploying a containerized application with proper configuration, service discovery, and health checks.'
-publishedAt: '2025-12-08T00:00:00Z'
-updatedAt: '2025-12-08T00:00:00Z'
+publishedAt: '2026-12-08T00:00:00Z'
+updatedAt: '2026-12-08T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-8.md
+++ b/content/advent-of-devops/day-8.md
@@ -3,8 +3,8 @@ title: 'Day 8 - Deploy a Small App on Kubernetes'
 day: 8
 excerpt: 'Deploy your first application to Kubernetes using Deployments, Services, and ConfigMaps. Learn the fundamentals of K8s.'
 description: 'Master Kubernetes basics by deploying a containerized application with proper configuration, service discovery, and health checks.'
-publishedAt: '2026-12-08T00:00:00Z'
-updatedAt: '2026-12-08T00:00:00Z'
+publishedAt: '2025-12-08T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-9.md
+++ b/content/advent-of-devops/day-9.md
@@ -3,8 +3,8 @@ title: 'Day 9 - Fix a Failing Pod'
 day: 9
 excerpt: 'Debug and fix a Kubernetes pod that crashes on startup. Master essential troubleshooting techniques.'
 description: 'Learn systematic Kubernetes debugging by diagnosing and fixing common pod failures including CrashLoopBackOff, ImagePullBackOff, and configuration errors.'
-publishedAt: '2026-12-09T00:00:00Z'
-updatedAt: '2026-12-09T00:00:00Z'
+publishedAt: '2025-12-09T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/day-9.md
+++ b/content/advent-of-devops/day-9.md
@@ -3,8 +3,8 @@ title: 'Day 9 - Fix a Failing Pod'
 day: 9
 excerpt: 'Debug and fix a Kubernetes pod that crashes on startup. Master essential troubleshooting techniques.'
 description: 'Learn systematic Kubernetes debugging by diagnosing and fixing common pod failures including CrashLoopBackOff, ImagePullBackOff, and configuration errors.'
-publishedAt: '2025-12-09T00:00:00Z'
-updatedAt: '2025-12-09T00:00:00Z'
+publishedAt: '2026-12-09T00:00:00Z'
+updatedAt: '2026-12-09T00:00:00Z'
 difficulty: 'Intermediate'
 category: 'Kubernetes'
 tags:

--- a/content/advent-of-devops/index.md
+++ b/content/advent-of-devops/index.md
@@ -3,8 +3,8 @@ title: 'Advent of DevOps 2026 - 25 Day Challenge'
 excerpt: 'Join us for 25 days of hands-on DevOps challenges. From Docker optimization to Kubernetes deployment, each day brings a new practical challenge to level up your DevOps skills.'
 description: 'A comprehensive 25-day DevOps challenge covering Docker, CI/CD, Kubernetes, Infrastructure as Code, security, monitoring, and more. Perfect for beginners and experienced practitioners.'
 featured: true
-publishedAt: '2026-12-01T00:00:00Z'
-updatedAt: '2026-12-01T00:00:00Z'
+publishedAt: '2025-12-01T00:00:00Z'
+updatedAt: '2026-04-19T00:00:00Z'
 tags:
   - DevOps
   - Docker

--- a/content/advent-of-devops/index.md
+++ b/content/advent-of-devops/index.md
@@ -1,10 +1,10 @@
 ---
-title: 'Advent of DevOps - 25 Day Challenge'
-excerpt: 'Join us for 25 days of hands-on DevOps challenges! From Docker optimization to Kubernetes deployment, each day brings a new practical challenge to level up your DevOps skills.'
+title: 'Advent of DevOps 2026 - 25 Day Challenge'
+excerpt: 'Join us for 25 days of hands-on DevOps challenges. From Docker optimization to Kubernetes deployment, each day brings a new practical challenge to level up your DevOps skills.'
 description: 'A comprehensive 25-day DevOps challenge covering Docker, CI/CD, Kubernetes, Infrastructure as Code, security, monitoring, and more. Perfect for beginners and experienced practitioners.'
 featured: true
-publishedAt: '2025-12-01T00:00:00Z'
-updatedAt: '2025-12-01T00:00:00Z'
+publishedAt: '2026-12-01T00:00:00Z'
+updatedAt: '2026-12-01T00:00:00Z'
 tags:
   - DevOps
   - Docker
@@ -15,7 +15,7 @@ tags:
   - Security
 ---
 
-# Advent of DevOps - 25 Day Challenge
+# Advent of DevOps 2026 - 25 Day Challenge
 
 Welcome to the Advent of DevOps! This is a hands-on, practical challenge designed to help you level up your DevOps skills through 25 days of real-world scenarios and tasks.
 


### PR DESCRIPTION
## Summary

Three focused follow-ups on one branch:

**1. Roadmap link fixes**
- Linux/Unix Basics: Linux Command Line Tutorial replaced with our own `/games/linux-terminal` (Learn Linux - Interactive Tutorial). Katacoda link replaced with Introduction to Linux ebook on Leanpub (Katacoda no longer exists)
- Shell Scripting: Bash Scripting Tutorial (shellscript.sh) swapped for the Introduction to Bash Scripting GitHub repo

**2. Hacktoberfest page sweep to amber/editorial aesthetic**
- Dropped the `[#183d5d]`/`[#93c2db]` hero color scheme + pulsing blur orbs + 12 floating GitPullRequest icons
- Hero: dot-grid background, `// hacktoberfest` mono label, `text-primary` "DevOps Challenge" with the squiggle underline (matches homepage)
- Challenge day cards: the per-day rainbow icon colors unified to `bg-primary/10 text-primary`, metadata rendered as mono `Day X · Beginner · 5 min` row
- Section separators (`$ cd /challenges`, `$ cat rewards.md`, etc.) between every section
- Rewards cards, What-You-Need tiles, FAQ, templates: all converted to the editorial `gap-px border-grid` pattern
- Setup terminal block kept (already on-brand)

**3. Advent of DevOps 2026 rebrand**
- `Advent of DevOps 2026` explicit in hero H1, metadata, OG alt text
- All 25 day files + index.md publish dates bumped from 2025-12 to 2026-12 (example log data inside exercises kept as-is since it's just sample output)
- Hero: red/green/primary rainbow clip-text title and the 20 falling-stars effect dropped. Clean `text-primary` "2026" with underline and dot-grid bg
- CTA section: red/blue/green wash replaced with flat `bg-primary/5` card
- Exercise content (daily tasks, code samples, solutions) untouched per request

## Test plan

- [ ] `/hacktoberfest` renders without the old hero color scheme or floating icons
- [ ] Day-card grid shows mono metadata row + unified amber icons
- [ ] `/advent-of-devops` H1 reads "Advent of DevOps 2026" with underlined year
- [ ] `/roadmap` Linux/Unix Basics section has the updated Leanpub + `/games/linux-terminal` links
- [ ] Bash Scripting section links to the GitHub repo