### PR TITLE
fix: Vercel post author to DevOps Daily Team

### DIFF
--- a/content/posts/vercel-april-2026-security-incident.md
+++ b/content/posts/vercel-april-2026-security-incident.md
@@ -9,8 +9,8 @@ publishedAt: '2026-04-20T09:00:00Z'
 updatedAt: '2026-04-20T09:00:00Z'
 readingTime: '8 min read'
 author:
-  name: 'Bobby Iliev'
-  slug: 'bobby-iliev'
+  name: 'DevOps Daily Team'
+  slug: 'devops-daily-team'
 featured: true
 tags:
   - security


### PR DESCRIPTION
Follow-up to #1171 (already merged). The Vercel April 2026 incident post was committed with `author: Bobby Iliev` / `bobby-iliev`, but that author slug has no corresponding page in the site. Only `devops-daily-team` exists. Fix the frontmatter so the JSON-LD Article schema attributes correctly.

Note: the author field is not rendered on the post page today (PostHeader only shows category + date + reading time). It is only emitted in SEO schema, so the fix is invisible on the UI but matters for AI search / Google rich results.