### PR TITLE
Add kuberns alternative

### DIFF
--- a/content/posts/heroku-alternatives-2026.md
+++ b/content/posts/heroku-alternatives-2026.md
@@ -18,7 +18,7 @@ tags:
   - Heroku
 ---
 
-On February 6, 2026, Heroku announced it's transitioning to a "sustaining engineering model" — essentially maintenance mode. While existing customers can continue using the platform, there will be no new features, and enterprise contracts are no longer available to new customers.
+On February 6, 2026, Heroku announced it's transitioning to a "sustaining engineering model", essentially maintenance mode. While existing customers can continue using the platform, there will be no new features, and enterprise contracts are no longer available to new customers.
 
 If you've been relying on Heroku for its simplicity and developer experience, now is the time to evaluate alternatives. Here are the best options for 2026.
 
@@ -29,11 +29,11 @@ If you've been relying on Heroku for its simplicity and developer experience, no
 [DigitalOcean App Platform](https://www.jdoqocy.com/click-101674709-15836238) is probably the closest experience to Heroku you'll find. It offers the same git-push-to-deploy workflow that made Heroku famous, with competitive pricing and excellent documentation.
 
 **Why it's great:**
-- **Heroku-like simplicity** — Connect your GitHub repo and deploy
-- **Automatic scaling** — Scale based on traffic without manual intervention
-- **Managed databases** — PostgreSQL, MySQL, Redis, and MongoDB available
-- **Transparent pricing** — Starts at $5/month for basic apps, no surprise bills
-- **Built-in CI/CD** — Automatic deployments on every push
+- **Heroku-like simplicity**: Connect your GitHub repo and deploy
+- **Automatic scaling**: Scale based on traffic without manual intervention
+- **Managed databases**: PostgreSQL, MySQL, Redis, and MongoDB available
+- **Transparent pricing**: Starts at $5/month for basic apps, no surprise bills
+- **Built-in CI/CD**: Automatic deployments on every push
 
 **Best for:** Teams migrating from Heroku who want minimal workflow changes.
 
@@ -60,11 +60,11 @@ services:
 Railway has gained massive popularity as a Heroku alternative, especially among indie developers and startups. It offers an incredibly polished developer experience with instant deployments.
 
 **Why it's great:**
-- **Instant deploys** — Push and your app is live in seconds
-- **Database provisioning** — PostgreSQL, MySQL, Redis with one click
-- **Environment management** — Easy staging/production workflows
-- **Usage-based pricing** — Pay only for what you use
-- **Nixpacks** — Automatic build detection (no Dockerfile needed)
+- **Instant deploys**: Push and your app is live in seconds
+- **Database provisioning**: PostgreSQL, MySQL, Redis with one click
+- **Environment management**: Easy staging/production workflows
+- **Usage-based pricing**: Pay only for what you use
+- **Nixpacks**: Automatic build detection (no Dockerfile needed)
 
 **Best for:** Indie hackers, startups, and developers who want the fastest path to production.
 
@@ -75,11 +75,11 @@ Railway has gained massive popularity as a Heroku alternative, especially among 
 Render positions itself as "the easiest cloud for developers" and delivers on that promise. It's been a popular Heroku alternative since 2019 and has matured significantly.
 
 **Why it's great:**
-- **Native Docker support** — Bring your Dockerfile or use auto-detection
-- **Free tier available** — Great for side projects and experiments
-- **Background workers** — First-class support for job queues
-- **Static sites** — Free hosting for static content
-- **Private networking** — Services can communicate securely
+- **Native Docker support**: Bring your Dockerfile or use auto-detection
+- **Free tier available**: Great for side projects and experiments
+- **Background workers**: First-class support for job queues
+- **Static sites**: Free hosting for static content
+- **Private networking**: Services can communicate securely
 
 **Best for:** Teams with diverse workloads (web apps, APIs, workers, static sites).
 
@@ -87,14 +87,14 @@ Render positions itself as "the easiest cloud for developers" and delivers on th
 
 ## 4. Fly.io
 
-Fly.io takes a different approach — it runs your apps at the edge, closer to your users. If latency matters for your application, Fly is worth considering.
+Fly.io takes a different approach, it runs your apps at the edge, closer to your users. If latency matters for your application, Fly is worth considering.
 
 **Why it's great:**
-- **Edge deployment** — Run apps in 30+ regions worldwide
-- **Machines API** — Fine-grained control over instances
-- **Built-in Postgres** — Distributed database with automatic failover
-- **Docker-native** — Ship containers directly
-- **Generous free tier** — 3 shared VMs, 160GB bandwidth
+- **Edge deployment**: Run apps in 30+ regions worldwide
+- **Machines API**: Fine-grained control over instances
+- **Built-in Postgres**: Distributed database with automatic failover
+- **Docker-native**: Ship containers directly
+- **Generous free tier**: 3 shared VMs, 160GB bandwidth
 
 **Best for:** Global applications where latency is critical.
 
@@ -105,11 +105,11 @@ Fly.io takes a different approach — it runs your apps at the edge, closer to y
 [Kuberns](https://kuberns.com) is the world's first agentic AI deployment platform. Connect your GitHub repo and an AI agent handles the entire deployment pipeline automatically. Zero config, zero YAML, zero DevOps setup required.
 
 **Why it's great:**
-- **AI-native deployments** — An agent manages your builds, scaling, and infrastructure end to end
-- **Zero config** — No Dockerfiles, no YAML, no Kubernetes knowledge needed
-- **Automated CI/CD** — Every push triggers a deployment automatically
-- **No per-user pricing** — Pay for what you use, not per seat
-- **AWS-backed infrastructure** — Reliable cloud under the hood without the complexity
+- **AI-native deployments**: An agent manages your builds, scaling, and infrastructure end to end
+- **Zero config**: No Dockerfiles, no YAML, no Kubernetes knowledge needed
+- **Automated CI/CD**: Every push triggers a deployment automatically
+- **No per-user pricing**: Pay for what you use, not per seat
+- **AWS-backed infrastructure**: Reliable cloud under the hood without the complexity
 
 **Best for:** Developers who want to skip DevOps entirely and go from GitHub repo to live app in minutes.
 
@@ -122,10 +122,10 @@ Fly.io takes a different approach — it runs your apps at the edge, closer to y
 If you're already in the AWS ecosystem, App Runner provides a Heroku-like experience without leaving AWS. It abstracts away ECS/Fargate complexity.
 
 **Why it's great:**
-- **AWS integration** — IAM, VPC, CloudWatch, etc.
-- **Auto-scaling** — Scale to zero or thousands
-- **Container or source** — Deploy from ECR or directly from code
-- **Pay per use** — No charges when scaled to zero
+- **AWS integration**: IAM, VPC, CloudWatch, etc.
+- **Auto-scaling**: Scale to zero or thousands
+- **Container or source**: Deploy from ECR or directly from code
+- **Pay per use**: No charges when scaled to zero
 
 **Best for:** Teams already invested in AWS who want simplified deployments.
 
@@ -136,10 +136,10 @@ If you're already in the AWS ecosystem, App Runner provides a Heroku-like experi
 Cloud Run is Google's serverless container platform. It's incredibly cost-effective for variable workloads since you only pay when requests are being processed.
 
 **Why it's great:**
-- **True serverless** — Scale to zero, pay nothing when idle
-- **Any language** — If it runs in a container, it runs on Cloud Run
-- **Generous free tier** — 2 million requests/month free
-- **Easy HTTPS** — Automatic TLS certificates
+- **True serverless**: Scale to zero, pay nothing when idle
+- **Any language**: If it runs in a container, it runs on Cloud Run
+- **Generous free tier**: 2 million requests/month free
+- **Easy HTTPS**: Automatic TLS certificates
 
 **Best for:** APIs and microservices with variable traffic patterns.
 
@@ -149,11 +149,11 @@ Cloud Run is Google's serverless container platform. It's incredibly cost-effect
 
 Before you migrate, here's what to prepare:
 
-1. **Export your data** — Dump databases, download files from Heroku's file storage
-2. **Document environment variables** — `heroku config` will list them all
-3. **Review add-ons** — Find equivalent services on your new platform
-4. **Update DNS** — Plan for the cutover with minimal downtime
-5. **Test thoroughly** — Run your test suite on the new platform before switching
+1. **Export your data**: Dump databases, download files from Heroku's file storage
+2. **Document environment variables**: `heroku config` will list them all
+3. **Review add-ons**: Find equivalent services on your new platform
+4. **Update DNS**: Plan for the cutover with minimal downtime
+5. **Test thoroughly**: Run your test suite on the new platform before switching
 
 ---
 

--- a/content/posts/heroku-alternatives-2026.md
+++ b/content/posts/heroku-alternatives-2026.md
@@ -100,7 +100,24 @@ Fly.io takes a different approach — it runs your apps at the edge, closer to y
 
 ---
 
-## 5. AWS App Runner
+## 5. Kuberns
+
+[Kuberns](https://kuberns.com) is the world's first agentic AI deployment platform. Connect your GitHub repo and an AI agent handles the entire pipeline automatically. No config files, no YAML, no Kubernetes required.
+
+**Why it's great:**
+- **Zero config** — No Dockerfiles or YAML, the AI figures it out
+- **AI-native pipeline** — An agent manages builds, scaling, and infrastructure end to end
+- **Vibe coding friendly** — One-click deploy directly from Cursor and Windsurf
+- **No per-user pricing** — Flat pricing regardless of team size
+- **Instant deployments** — Push your repo and it's live
+
+**Best for:** Developers using AI coding tools who want to ship without touching infrastructure.
+
+[Get started with Kuberns →](https://kuberns.com)
+
+---
+
+## 6. AWS App Runner
 
 If you're already in the AWS ecosystem, App Runner provides a Heroku-like experience without leaving AWS. It abstracts away ECS/Fargate complexity.
 
@@ -114,7 +131,7 @@ If you're already in the AWS ecosystem, App Runner provides a Heroku-like experi
 
 ---
 
-## 6. Google Cloud Run
+## 7. Google Cloud Run
 
 Cloud Run is Google's serverless container platform. It's incredibly cost-effective for variable workloads since you only pay when requests are being processed.
 

--- a/content/posts/heroku-alternatives-2026.md
+++ b/content/posts/heroku-alternatives-2026.md
@@ -102,16 +102,16 @@ Fly.io takes a different approach — it runs your apps at the edge, closer to y
 
 ## 5. Kuberns
 
-[Kuberns](https://kuberns.com) is the world's first agentic AI deployment platform. Connect your GitHub repo and an AI agent handles the entire pipeline automatically. No config files, no YAML, no Kubernetes required.
+[Kuberns](https://kuberns.com) is the world's first agentic AI deployment platform. Connect your GitHub repo and an AI agent handles the entire deployment pipeline automatically. Zero config, zero YAML, zero DevOps setup required.
 
 **Why it's great:**
-- **Zero config** — No Dockerfiles or YAML, the AI figures it out
-- **AI-native pipeline** — An agent manages builds, scaling, and infrastructure end to end
-- **Vibe coding friendly** — One-click deploy directly from Cursor and Windsurf
-- **No per-user pricing** — Flat pricing regardless of team size
-- **Instant deployments** — Push your repo and it's live
+- **AI-native deployments** — An agent manages your builds, scaling, and infrastructure end to end
+- **Zero config** — No Dockerfiles, no YAML, no Kubernetes knowledge needed
+- **Automated CI/CD** — Every push triggers a deployment automatically
+- **No per-user pricing** — Pay for what you use, not per seat
+- **AWS-backed infrastructure** — Reliable cloud under the hood without the complexity
 
-**Best for:** Developers using AI coding tools who want to ship without touching infrastructure.
+**Best for:** Developers who want to skip DevOps entirely and go from GitHub repo to live app in minutes.
 
 [Get started with Kuberns →](https://kuberns.com)
 


### PR DESCRIPTION
Added Kuberns as a Heroku alternative. It's the world's first agentic AI deployment platform — connect a GitHub repo and an AI agent handles the entire deployment pipeline automatically, zero config required. Happy to adjust anything.