### PR TITLE
seo: drop '| DevOps Daily' suffix from content page titles

### DIFF
--- a/app/advent-of-devops/[slug]/page.tsx
+++ b/app/advent-of-devops/[slug]/page.tsx
@@ -44,7 +44,7 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(slug, 'advent');
 
   return {
-    title: day.title,
+    title: { absolute: day.title },
     description: day.excerpt || day.description,
     alternates: {
       canonical: `/advent-of-devops/${day.slug}`,

--- a/app/categories/[slug]/page.tsx
+++ b/app/categories/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: `Category: ${category.name} - DevOps Articles and Tutorials`,
+    title: { absolute: `Category: ${category.name} - DevOps Articles and Tutorials` },
     description: `Explore the ${category.name} category for articles, tutorials, and guides covering DevOps practices. ${category.longDescription || category.description}`,
     alternates: {
       canonical: `/categories/${slug}`,

--- a/app/checklists/[slug]/page.tsx
+++ b/app/checklists/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(
   }
 
   return {
-   title: `${checklist.title} | The DevOps Daily`,
+   title: { absolute: checklist.title },
    description: checklist.description,
    alternates: {
      canonical: `/checklists/${resolvedParams.slug}`,

--- a/app/comparisons/[slug]/page.tsx
+++ b/app/comparisons/[slug]/page.tsx
@@ -30,12 +30,12 @@ export async function generateMetadata({
     return {};
   }
 
-  const title = `${comparison.toolA.name} vs ${comparison.toolB.name}: Feature Comparison, Pros/Cons, and Verdict | DevOps Daily`;
+  const title = `${comparison.toolA.name} vs ${comparison.toolB.name}: Feature Comparison, Pros/Cons, and Verdict`;
   const description = comparison.description;
   const socialImage = `/images/comparisons/${comparison.slug}-og.png`;
 
   return {
-    title,
+    title: { absolute: title },
     description,
     alternates: {
       canonical: `/comparisons/${comparison.slug}`,

--- a/app/exercises/[id]/page.tsx
+++ b/app/exercises/[id]/page.tsx
@@ -38,7 +38,7 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(exercise.id, 'exercises');
 
   return {
-    title: `${exercise.title} - DevOps Exercise`,
+    title: { absolute: `${exercise.title} - DevOps Exercise` },
     description: exercise.description,
     alternates: {
       canonical: `/exercises/${exercise.id}`,

--- a/app/experts/[slug]/page.tsx
+++ b/app/experts/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: `${expert.name} - ${expert.title || 'DevOps Expert'} | DevOps Daily`,
+    title: { absolute: `${expert.name} - ${expert.title || 'DevOps Expert'}` },
     description: expert.bio || `Hire ${expert.name} for DevOps consulting and services`,
     alternates: {
       canonical: `/experts/${slug}`,

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: FlashcardPageProps): Promise<
   }
 
   return {
-    title: `${flashcardSet.title} - DevOps Flashcards`,
+    title: { absolute: `${flashcardSet.title} - DevOps Flashcards` },
     description: flashcardSet.description,
     alternates: {
       canonical: `/flashcards/${id}`,

--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(slug, 'guides');
 
   return {
-    title: `${part.title} - ${guide.title}`,
+    title: { absolute: `${part.title} - ${guide.title}` },
     description: part.description || guide.description,
     alternates: {
       canonical: `/guides/${slug}/${partSlug}`,

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(slug, 'guides');
 
   return {
-    title: guide.title,
+    title: { absolute: guide.title },
     description: guide.description,
     alternates: {
       canonical: `/guides/${slug}`,

--- a/app/hacktoberfest/[slug]/page.tsx
+++ b/app/hacktoberfest/[slug]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   if (!day) return {};
 
   return {
-    title: `${day.title} | Hacktoberfest 2026`,
+    title: { absolute: `${day.title} - Hacktoberfest 2026` },
     description: day.excerpt,
     alternates: {
       canonical: `/hacktoberfest/${slug}`,

--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const description = `${question.question} - ${question.category} interview question for ${tier} DevOps engineers`;
   
   return {
-    title: `${question.title} | Interview Question | The DevOps Daily`,
+    title: { absolute: `${question.title} - Interview Question` },
     description,
     alternates: {
       canonical: `/interview-questions/${tier}/${slug}`,

--- a/app/interview-questions/[tier]/page.tsx
+++ b/app/interview-questions/[tier]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const meta = tierMeta[tier as ExperienceTier];
   
   return {
-    title: `${meta.title} | The DevOps Daily`,
+    title: { absolute: meta.title },
     description: meta.description,
     alternates: {
       canonical: `/interview-questions/${tier}`,

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(slug, 'news');
 
   return {
-    title: digest.title,
+    title: { absolute: digest.title },
     description: digest.excerpt || digest.summary,
     alternates: {
       canonical: `/news/${digest.slug}`,

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   const image = ogExists ? ogImage : '/og-image.png';
 
   return {
-    title: `${newsletter.title} | DevOps Daily`,
+    title: { absolute: newsletter.title },
     description: `DevOps Daily Newsletter - Week ${newsletter.week}, ${newsletter.year}. Weekly roundup of new content and learning resources.`,
     alternates: { canonical: `/newsletters/${slug}` },
     openGraph: {

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -44,7 +44,10 @@ export async function generateMetadata({
   const socialImage = getSocialImagePath(slug, 'posts');
 
   return {
-    title: post.title,
+    // Absolute: skip the '%s | DevOps Daily' layout template. Post titles
+    // are always topic-specific and rank better without the redundant
+    // brand suffix. OG + Twitter below keep the brand in social previews.
+    title: { absolute: post.title },
     description: post.excerpt,
     alternates: {
       canonical: `/posts/${post.slug}`,

--- a/app/quizzes/[slug]/page.tsx
+++ b/app/quizzes/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: `${quizConfig.title} - Learn ${quizConfig.category}`,
+    title: { absolute: `${quizConfig.title} - Learn ${quizConfig.category}` },
     description: quizConfig.description,
     alternates: {
       canonical: `/quizzes/${slug}`,

--- a/app/roadmap/devsecops/layout.tsx
+++ b/app/roadmap/devsecops/layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'DevSecOps Roadmap - Security-First DevOps Journey',
+  title: { absolute: 'DevSecOps Roadmap - Security-First DevOps Journey' },
   description:
     'A comprehensive roadmap for integrating security into your DevOps practices. Learn to build secure pipelines, implement security automation, and shift security left.',
   alternates: {

--- a/app/roadmap/junior/layout.tsx
+++ b/app/roadmap/junior/layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Junior DevOps Roadmap - Start Your DevOps Journey',
+  title: { absolute: 'Junior DevOps Roadmap - Start Your DevOps Journey' },
   description:
     'A beginner-friendly roadmap specifically designed for aspiring DevOps engineers. Clear, focused learning path without the overwhelm.',
   alternates: {

--- a/app/roadmap/layout.tsx
+++ b/app/roadmap/layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'DevOps Roadmap',
+  title: { absolute: 'DevOps Roadmap - Your Path to DevOps Mastery' },
   description:
     'Strategic learning path for aspiring DevOps engineers. Discover the skills, technologies, and career progression from beginner to expert level.',
   alternates: {

--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const metadata: Record<RoadmapSlug, Metadata> = {
     junior: {
-      title: 'Junior DevOps Roadmap - Start Your DevOps Journey',
+      title: { absolute: 'Junior DevOps Roadmap - Start Your DevOps Journey' },
       description:
         'A beginner-friendly roadmap specifically designed for aspiring DevOps engineers. Clear, focused learning path without the overwhelm.',
       alternates: {
@@ -55,7 +55,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       },
     },
     devsecops: {
-      title: 'DevSecOps Roadmap - Security-First DevOps',
+      title: { absolute: 'DevSecOps Roadmap - Security-First DevOps' },
       description:
         'Master the integration of security practices into the DevOps pipeline. Learn to build secure, compliant, and resilient systems.',
       alternates: {

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
   }
 
   return {
-    title: `${tagName} - DevOps Articles and Tutorials`,
+    title: { absolute: `${tagName} - DevOps Articles and Tutorials` },
     description: `Browse all articles, tutorials, and guides about ${tagName}. Learn the latest DevOps practices and techniques.`,
     alternates: {
       canonical: `/tags/${tag}`,

--- a/lib/game-metadata.ts
+++ b/lib/game-metadata.ts
@@ -20,7 +20,12 @@ export async function generateGameMetadata(gameId: string): Promise<Metadata> {
   const ogImage = `/images/games/${gameId}-og.png`;
 
   return {
-    title: game.title,
+    // Absolute title so Next.js doesn't append '| DevOps Daily'. Game page
+    // titles already identify the site through topic context; the brand is
+    // picked up by Google from the Organization/WebSite schema. OG + Twitter
+    // titles below keep the suffix because social previews benefit from
+    // brand presence.
+    title: { absolute: game.title },
     description,
     alternates: {
       canonical: game.href,


### PR DESCRIPTION
Addresses the redundancy Bobby spotted in Google Search Console — every content page title had " | DevOps Daily" appended, even ones that already contain "DevOps" ("DevOps Roadmap | DevOps Daily"). The suffix ate ~15 of the ~60-char SERP display budget on every page.

## Why this is the right call (and not an SEO risk)

Google's own [title-link best practices](https://developers.google.com/search/docs/appearance/title-link#page-title) since the 2022 rewrite update:

1. Keep titles focused on the page's **content**, not the brand.
2. Google pulls the site name separately from the `Organization` / `WebSite` schema (we already ship this via `components/schema-markup.tsx`) and renders it **below** the title in mobile SERPs.
3. Explicitly flagged as a quality issue: "don't add the site name repeatedly or as part of the template pattern."

What stays the same:
- **OG and Twitter titles** — social shares still show the brand. Users outside Google SERPs benefit from the brand.
- **Hub/index pages** (`/posts`, `/guides`, `/tools`, homepage) — untouched, so generic navigation titles still get the brand via the default `%s | DevOps Daily` template in `app/layout.tsx`.
- **Schema.org markup** — unchanged. Google still gets `"name": "DevOps Daily"` the way it wants to.

## What changed

22 files, ~32 lines. Pattern across the board: `title: post.title` → `title: { absolute: post.title }`. Next.js's `absolute` variant suppresses the layout template.

- `app/posts/[slug]`, `app/news/[slug]`, `app/guides/[slug]`, `app/guides/[slug]/[part]`
- `app/exercises/[id]`, `app/checklists/[slug]`, `app/flashcards/[id]`, `app/quizzes/[slug]`
- `app/interview-questions/[tier]` + `[tier]/[slug]`
- `app/comparisons/[slug]`, `app/newsletters/[slug]`
- `app/advent-of-devops/[slug]`, `app/hacktoberfest/[slug]`
- `app/experts/[slug]`, `app/categories/[slug]`, `app/tags/[tag]`
- `app/roadmap/layout.tsx` + `/junior` + `/devsecops`, `app/roadmaps/[slug]/page.tsx`
- `lib/game-metadata.ts` — shared helper; single-line change covers all 30+ individual game pages

### Bonus cleanup: double-brand titles
Several files were **hand-appending** `| The DevOps Daily` / `| DevOps Daily` before the layout template added it again, producing titles like `"X | The DevOps Daily | DevOps Daily"`. Those were:
- `app/checklists/[slug]/page.tsx:28`
- `app/interview-questions/[tier]/[slug]/page.tsx:42`
- `app/newsletters/[slug]/page.tsx:31`
- `app/experts/[slug]/page.tsx:40`
- `app/interview-questions/[tier]/page.tsx:40`

Those literals were stripped — the `absolute` title now ships just the meaningful content.

## Verification
- `bunx tsc --noEmit` — no new errors introduced (ran before and after; same count of pre-existing warnings, all in unrelated files)
- No changes to canonical URLs, OG tags, Twitter cards, JSON-LD, or sitemap
- Google will re-crawl and update titles over the next 1-2 weeks; short-term ranking noise is normal for any title change but we're keeping content + structure identical

## Test plan
- [ ] `pnpm build` succeeds
- [ ] Spot-check `/posts/<slug>`, `/guides/<slug>`, `/quizzes/<slug>`, `/games/<slug>` — `<title>` shows just the content, no " | DevOps Daily" appended
- [ ] Spot-check the same pages — OG `<meta>` tags still include the brand
- [ ] `/` homepage title unchanged (still uses the default from `app/layout.tsx`)
- [ ] `/posts` hub page still shows "All Posts | DevOps Daily" (no explicit override means template still applies)