### PR TITLE
feat: add interview questions - How to Set Up Cloud Cost Allocation Tags Across AWS, GCP, and Azure

### DIFF
--- a/content/interview-questions/activating-cost-allocation-tags.json
+++ b/content/interview-questions/activating-cost-allocation-tags.json
@@ -1,0 +1,53 @@
+{
+  "id": "activating-cost-allocation-tags",
+  "slug": "activating-cost-allocation-tags",
+  "title": "Activating Tags in Billing Reports",
+  "question": "Your team tagged every resource with team and environment, but the tags are not showing up in cost reports. What is going on, and how is this different on AWS, GCP, and Azure?",
+  "answer": "Tagging the resource is not the same as telling the billing system to treat that tag as a cost dimension. Each cloud handles this differently and this is the number one thing that trips people up. On AWS, user-defined tags have to be activated in Billing and Cost Management under Cost Allocation Tags. Until you activate them, they do not appear in Cost Explorer, the Cost and Usage Report (CUR), or budgets. Activation can take up to 24 hours to propagate and only applies to costs incurred after activation, not retroactively. On Azure, subscription and resource tags flow into Cost Management automatically, but inheritance is not the default. A VM does not inherit tags from its resource group unless you use an Azure Policy with the modify effect to push them down. Some costs like classic resources, reservations, and certain marketplace items do not carry tags at all. On GCP, labels flow into billing exports automatically once you enable detailed BigQuery billing export. There is no activation step, but labels on a parent resource (project, folder) do not propagate to child resources. You label the resource itself or you get nothing. So the answer to 'why are my tags missing from reports' is almost always one of: not activated (AWS), not inherited (Azure), not on the right resource (GCP), or tagged after the billing period started.",
+  "explanation": "This question separates candidates who have only read about tagging from those who have shipped a chargeback system. The activation gotcha on AWS and the inheritance gotcha on Azure are classic mid-career landmines. Strong candidates will also mention the 24-hour propagation delay and the fact that activation is not retroactive, which is the most common cause of 'why is last month's report still empty'.",
+  "category": "FinOps",
+  "difficulty": "intermediate",
+  "tier": "mid",
+  "tags": [
+    "finops",
+    "cloud-costs",
+    "tagging",
+    "multi-cloud",
+    "billing",
+    "cost-explorer"
+  ],
+  "codeExamples": [
+    {
+      "language": "bash",
+      "label": "Activate cost allocation tags on AWS",
+      "code": "# Activate user-defined tags (the step everyone forgets)\naws ce update-cost-allocation-tags-status \\\n  --cost-allocation-tags-status \\\n    TagKey=team,Status=Active \\\n    TagKey=environment,Status=Active \\\n    TagKey=cost-center,Status=Active\n\n# Verify which tags are active\naws ce list-cost-allocation-tags --status Active\n\n# Query costs grouped by the team tag (only works after activation)\naws ce get-cost-and-usage \\\n  --time-period Start=2026-04-01,End=2026-04-30 \\\n  --granularity MONTHLY \\\n  --metrics UnblendedCost \\\n  --group-by Type=TAG,Key=team"
+    },
+    {
+      "language": "bash",
+      "label": "Azure: propagate resource group tags to child resources",
+      "code": "# Assign the built-in policy that inherits a tag from the resource group\naz policy assignment create \\\n  --name inherit-team-tag \\\n  --display-name \"Inherit team tag from resource group\" \\\n  --policy \"cd3aa116-8754-49c9-a813-ad46512ece54\" \\\n  --scope \"/subscriptions/YOUR-SUB-ID\" \\\n  --params '{\"tagName\": {\"value\": \"team\"}}'\n\n# Remediate existing resources (applies the tag to what is already deployed)\naz policy remediation create \\\n  --name inherit-team-tag-remediation \\\n  --policy-assignment inherit-team-tag \\\n  --resource-discovery-mode ReEvaluateCompliance"
+    },
+    {
+      "language": "sql",
+      "label": "GCP: query billing export by label in BigQuery",
+      "code": "-- Cost per team for the current month from BigQuery billing export\nSELECT\n  (SELECT value FROM UNNEST(labels) WHERE key = 'team') AS team,\n  (SELECT value FROM UNNEST(labels) WHERE key = 'environment') AS environment,\n  ROUND(SUM(cost), 2) AS cost_usd,\n  ROUND(SUM(IFNULL((SELECT SUM(amount)\n                    FROM UNNEST(credits)), 0)), 2) AS credits_usd\nFROM `my-billing-project.billing_export.gcp_billing_export_resource_v1_XXXXXX`\nWHERE _PARTITIONTIME >= TIMESTAMP('2026-04-01')\n  AND _PARTITIONTIME <  TIMESTAMP('2026-05-01')\nGROUP BY team, environment\nORDER BY cost_usd DESC;"
+    }
+  ],
+  "followUpQuestions": [
+    "Your CFO wants a chargeback report for last quarter, but you only activated cost allocation tags two weeks ago. What can you actually deliver?",
+    "What AWS charges never show up against a tag no matter what you do?",
+    "How would you audit whether Azure tag inheritance is actually working end to end?"
+  ],
+  "commonMistakes": [
+    "Assuming AWS tags show up in Cost Explorer immediately after tagging resources",
+    "Expecting Azure resources to inherit resource group tags automatically",
+    "Labeling the GCP project and expecting every VM inside it to be attributed to that label in billing reports"
+  ],
+  "relatedTopics": [
+    "aws-cost-explorer",
+    "azure-cost-management",
+    "gcp-billing-export",
+    "bigquery-billing",
+    "chargeback"
+  ]
+}

--- a/content/interview-questions/chargeback-shared-untaggable-costs.json
+++ b/content/interview-questions/chargeback-shared-untaggable-costs.json
@@ -1,0 +1,56 @@
+{
+  "id": "chargeback-shared-untaggable-costs",
+  "slug": "chargeback-shared-untaggable-costs",
+  "title": "Chargeback Design for Shared and Untaggable Costs",
+  "question": "You are designing a chargeback system for 200 teams running across AWS, GCP, and Azure. How do you handle the 15 to 25 percent of the bill that cannot be tagged to a single team, like inter-AZ data transfer, support plans, NAT gateways, and shared Kubernetes clusters?",
+  "answer": "Chargeback at scale is 70 percent politics and 30 percent engineering. The engineering problem: 15 to 25 percent of your multi-cloud bill is not directly attributable. Inter-AZ data transfer, NAT gateway hours, support plans, marketplace subscriptions, management fees, reserved instance upfront payments, and shared services like a platform Kubernetes cluster all resist simple tag-based allocation. My approach has five parts. First, split the bill into three buckets: directly attributed (tagged, owner is obvious), indirectly attributed (shared but allocatable by proxy), and unallocated (absorbed centrally). Be explicit about which costs fall where. Second, pick allocation keys for the shared bucket and write them down before the first report goes out. Shared NAT gateway gets split by data transfer bytes per source VPC or by tagged VPC usage. Support plans get split as a flat percentage on each team's direct spend. Shared Kubernetes clusters get split using Kubecost or OpenCost based on namespace and workload labels, which is a separate tagging discipline from cloud resource tags. Reserved instance and Savings Plan discounts get amortized based on which team's instance hours matched the commitment. Third, normalize everything into a single warehouse. CUR 2.0 from AWS, BigQuery billing export from GCP, EA or MCA export from Azure, all landing in Snowflake, BigQuery, or Redshift. Normalize tag keys across clouds so AWS tag team, GCP label team, and Azure tag team all become one dimension. Fourth, publish monthly with a 2-week dispute window, then freeze. Disputes after freeze go to next month. Without a freeze you will re-run the report every time finance asks a question. Fifth, untagged resources hit a 'tax' bucket owned by the platform org, not individual teams. This creates pressure to tag without punishing teams for platform gaps. Report untagged spend publicly every month and it usually drops fast.",
+  "explanation": "This is a senior-level question to see if the candidate has lived through a real chargeback rollout or just read the FinOps Foundation docs. Strong candidates will break down the three buckets, acknowledge that some costs simply cannot be allocated cleanly, and talk about the organizational side (freeze windows, dispute process, public reporting). They will also mention normalizing across clouds in a warehouse, and the distinction between cloud-resource tags and Kubernetes-workload labels. Red flag: candidates who claim they can tag 100 percent of the bill or who skip the politics entirely.",
+  "category": "FinOps",
+  "difficulty": "advanced",
+  "tier": "senior",
+  "tags": [
+    "finops",
+    "cloud-costs",
+    "chargeback",
+    "tagging",
+    "multi-cloud",
+    "bigquery"
+  ],
+  "codeExamples": [
+    {
+      "language": "sql",
+      "label": "Split tagged vs untagged spend in GCP BigQuery billing export",
+      "code": "-- Bucket monthly spend into tagged teams vs an untagged tax bucket\nWITH normalized AS (\n  SELECT\n    COALESCE(\n      (SELECT value FROM UNNEST(labels) WHERE key = 'team'),\n      'UNTAGGED_TAX_BUCKET'\n    ) AS team,\n    service.description AS service,\n    cost,\n    IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0) AS credits\n  FROM `billing.gcp_billing_export_resource_v1_XXXXXX`\n  WHERE _PARTITIONTIME >= TIMESTAMP('2026-04-01')\n    AND _PARTITIONTIME <  TIMESTAMP('2026-05-01')\n)\nSELECT\n  team,\n  ROUND(SUM(cost + credits), 2)                              AS net_cost_usd,\n  ROUND(SUM(cost + credits)\n        / SUM(SUM(cost + credits)) OVER () * 100, 2)         AS pct_of_total,\n  COUNT(DISTINCT service)                                    AS service_count\nFROM normalized\nGROUP BY team\nORDER BY net_cost_usd DESC;"
+    },
+    {
+      "language": "sql",
+      "label": "Allocate shared NAT gateway spend proportionally to VPC usage (AWS CUR 2.0)",
+      "code": "-- Split shared NAT gateway data processing charges across teams\n-- based on each team's share of total tagged data transfer bytes\nWITH team_bytes AS (\n  SELECT\n    resource_tags_user_team AS team,\n    SUM(line_item_usage_amount) AS team_bytes\n  FROM cur_v2\n  WHERE line_item_product_code = 'AmazonEC2'\n    AND line_item_usage_type LIKE '%DataTransfer%'\n    AND resource_tags_user_team IS NOT NULL\n    AND billing_period_start_date = DATE '2026-04-01'\n  GROUP BY resource_tags_user_team\n),\nshared_nat AS (\n  SELECT SUM(line_item_unblended_cost) AS total_nat_cost\n  FROM cur_v2\n  WHERE line_item_usage_type LIKE '%NatGateway%'\n    AND (resource_tags_user_team IS NULL OR resource_tags_user_team = '')\n    AND billing_period_start_date = DATE '2026-04-01'\n)\nSELECT\n  t.team,\n  ROUND(s.total_nat_cost * (t.team_bytes / SUM(t.team_bytes) OVER ()), 2)\n    AS allocated_nat_cost_usd\nFROM team_bytes t\nCROSS JOIN shared_nat s\nORDER BY allocated_nat_cost_usd DESC;"
+    },
+    {
+      "language": "yaml",
+      "label": "Kubecost allocation config for a shared cluster",
+      "code": "# Kubecost allocation rules for shared platform cluster\n# Splits cluster cost by namespace label, not by cloud resource tag\nglobal:\n  notifications:\n    alertmanager:\n      enabled: true\n\nkubecostModel:\n  allocation:\n    # Required labels on every namespace - enforced by admission controller\n    requiredLabels:\n      - team\n      - environment\n      - cost-center\n\n    # Idle and system costs go to the platform team, not user workloads\n    shareIdle: false\n    shareTenancyCosts: true\n    shareNamespaces:\n      - kube-system\n      - kubecost\n      - cert-manager\n    shareToTeam: platform\n\n    # Reallocate unassigned spend so user teams see a true-cost view\n    shareSplit: weighted\n"
+    }
+  ],
+  "followUpQuestions": [
+    "How do you allocate Reserved Instance and Savings Plan discounts fairly when multiple teams benefit from the same commitment?",
+    "What would change in your design if you had to support GDPR-style data residency where some costs cannot cross regions even in reporting?",
+    "How do you stop teams from gaming the chargeback system once they see the numbers?",
+    "Would you build this on top of CUR and BigQuery yourself, or buy a tool like Vantage, CloudHealth, or Apptio? Why?"
+  ],
+  "commonMistakes": [
+    "Claiming every dollar can be tagged, then silently dropping untagged spend from reports",
+    "Running chargeback without a dispute and freeze window, so reports are never final",
+    "Allocating shared Kubernetes costs using cloud resource tags instead of namespace-level labels through Kubecost or OpenCost",
+    "Ignoring that reservations and Savings Plans break naive per-hour team attribution"
+  ],
+  "relatedTopics": [
+    "finops-maturity",
+    "cur-v2",
+    "kubecost",
+    "opencost",
+    "reserved-instance-amortization",
+    "bigquery-billing-export"
+  ]
+}

--- a/content/interview-questions/cost-allocation-tags-basics.json
+++ b/content/interview-questions/cost-allocation-tags-basics.json
@@ -1,0 +1,43 @@
+{
+  "id": "cost-allocation-tags-basics",
+  "slug": "cost-allocation-tags-basics",
+  "title": "Cost Allocation Tags Basics",
+  "question": "Can you explain what cost allocation tags are and why teams use them across AWS, GCP, and Azure?",
+  "answer": "Cost allocation tags are key-value labels you attach to cloud resources so the billing system can split the bill by team, environment, project, or customer. All three major clouds support the same idea but name it slightly differently. AWS and Azure call them tags, GCP calls them labels. Without them your bill is one giant number per service like $47,000 on RDS and nobody knows who spent it. With them you can answer 'how much did the payments team spend last month' in seconds. Common uses: chargeback (billing internal teams for their actual usage), showback (giving teams visibility so they self-correct), scoped budget alerts, forecasting per team or product, and finding orphaned resources (no owner tag usually means nobody will miss it when it gets deleted).",
+  "explanation": "This is a warm-up question to check if the candidate has actually worked with cloud billing, not just spun up a few VMs. Strong candidates mention the tags vs labels naming, explain why tags matter for FinOps, and tie it back to dollars. Weaker candidates say 'for organization' without connecting tags to money or to a business problem.",
+  "category": "FinOps",
+  "difficulty": "beginner",
+  "tier": "junior",
+  "tags": [
+    "finops",
+    "cloud-costs",
+    "tagging",
+    "multi-cloud",
+    "aws",
+    "gcp",
+    "azure"
+  ],
+  "codeExamples": [
+    {
+      "language": "bash",
+      "label": "Tag the same logical resource in each cloud",
+      "code": "# AWS: tag an EC2 instance\naws ec2 create-tags \\\n  --resources i-0123456789abcdef0 \\\n  --tags Key=team,Value=payments Key=environment,Value=prod\n\n# GCP: add labels to a Compute Engine VM\ngcloud compute instances add-labels my-vm \\\n  --labels=team=payments,environment=prod \\\n  --zone=us-central1-a\n\n# Azure: tag a VM\naz resource tag \\\n  --tags team=payments environment=prod \\\n  --resource-group my-rg \\\n  --name my-vm \\\n  --resource-type Microsoft.Compute/virtualMachines"
+    }
+  ],
+  "followUpQuestions": [
+    "What is the difference between showback and chargeback?",
+    "Why do AWS tags and GCP labels have different character rules?",
+    "How would you find every untagged resource in an AWS account?"
+  ],
+  "commonMistakes": [
+    "Saying tags are just for organization without connecting them to the bill",
+    "Confusing AWS resource tags with IAM tags or session tags",
+    "Assuming every resource type supports tags (some AWS billing items like data transfer do not)"
+  ],
+  "relatedTopics": [
+    "finops",
+    "cloud-billing",
+    "showback-chargeback",
+    "resource-governance"
+  ]
+}

--- a/content/interview-questions/enforcing-tagging-policies-multi-cloud.json
+++ b/content/interview-questions/enforcing-tagging-policies-multi-cloud.json
@@ -1,0 +1,52 @@
+{
+  "id": "enforcing-tagging-policies-multi-cloud",
+  "slug": "enforcing-tagging-policies-multi-cloud",
+  "title": "Enforcing Tagging Policies Across Clouds",
+  "question": "How do you actually enforce that every resource in AWS, GCP, and Azure gets the required tags? Walk me through what you would put in place.",
+  "answer": "I think about enforcement in two layers: prevention (block creation without tags) and detection (find violations after the fact). You need both, because 100 percent prevention is impossible and detection alone is too slow. On AWS I use Organizations Tag Policies to standardize keys and values, plus Service Control Policies to deny resource creation without certain tags, plus AWS Config rule required-tags for drift detection. On Azure I use Azure Policy with the deny effect for missing tags, and the modify effect to auto-append tags inherited from the resource group. Azure inheritance is a trap, resources do not auto-inherit resource group tags so you have to add a policy for that. On GCP the native story is weaker. Organization Policy does not enforce labels as cleanly, so I lean on Terraform default labels plus policy-as-code (OPA or Sentinel) in the CI pipeline, and BigQuery billing export queries to catch anything that slipped through. The practical order I follow: first, get 90 percent coverage through Terraform default tags in the provider blocks. Second, add policy engines to block the console cowboys. Third, run nightly scans that flag untagged resources back to the owning team in Slack. If you start with policy engines before fixing Terraform, you will just break deploys.",
+  "explanation": "Enforcement is where tagging programs live or die. Junior candidates will describe what a tag is. Mid candidates mention one native tool per cloud. Strong candidates lay out the prevention plus detection model, mention the Azure inheritance gotcha, acknowledge GCP has weaker native enforcement, and say that IaC default tags should carry most of the weight. Watch for candidates who say 'just use Azure Policy' without acknowledging it does not solve GCP or block changes from the console unless configured carefully.",
+  "category": "FinOps",
+  "difficulty": "intermediate",
+  "tier": "mid",
+  "tags": [
+    "finops",
+    "cloud-costs",
+    "tagging",
+    "multi-cloud",
+    "policy-as-code",
+    "governance"
+  ],
+  "codeExamples": [
+    {
+      "language": "json",
+      "label": "AWS Organizations Tag Policy",
+      "code": "{\n  \"tags\": {\n    \"team\": {\n      \"tag_key\": { \"@@assign\": \"team\" },\n      \"tag_value\": {\n        \"@@assign\": [\"payments\", \"identity\", \"growth\", \"platform\", \"data\"]\n      },\n      \"enforced_for\": {\n        \"@@assign\": [\n          \"ec2:instance\",\n          \"rds:db\",\n          \"s3:bucket\",\n          \"lambda:function\"\n        ]\n      }\n    },\n    \"environment\": {\n      \"tag_key\": { \"@@assign\": \"environment\" },\n      \"tag_value\": {\n        \"@@assign\": [\"prod\", \"staging\", \"dev\", \"sandbox\"]\n      }\n    },\n    \"cost-center\": {\n      \"tag_key\": { \"@@assign\": \"cost-center\" }\n    }\n  }\n}"
+    },
+    {
+      "language": "json",
+      "label": "Azure Policy that denies resources missing the team tag",
+      "code": "{\n  \"mode\": \"Indexed\",\n  \"policyRule\": {\n    \"if\": {\n      \"allOf\": [\n        {\n          \"field\": \"tags['team']\",\n          \"exists\": \"false\"\n        },\n        {\n          \"field\": \"type\",\n          \"notIn\": [\n            \"Microsoft.Resources/deployments\",\n            \"Microsoft.Resources/deploymentScripts\"\n          ]\n        }\n      ]\n    },\n    \"then\": {\n      \"effect\": \"deny\"\n    }\n  },\n  \"parameters\": {}\n}"
+    },
+    {
+      "language": "rego",
+      "label": "OPA policy for GCP Terraform plans in CI",
+      "code": "# Reject plans that create GCP resources without required labels\npackage terraform.gcp.tagging\n\nrequired_labels := {\"team\", \"environment\", \"cost-center\"}\n\ndeny[msg] {\n  resource := input.resource_changes[_]\n  startswith(resource.type, \"google_\")\n  resource.change.actions[_] == \"create\"\n\n  labels := object.get(resource.change.after, \"labels\", {})\n  missing := required_labels - {k | labels[k]}\n  count(missing) > 0\n\n  msg := sprintf(\n    \"%s '%s' is missing required labels: %v\",\n    [resource.type, resource.address, missing]\n  )\n}"
+    }
+  ],
+  "followUpQuestions": [
+    "What breaks if you enforce a deny policy in a brownfield environment with thousands of existing untagged resources?",
+    "How would you onboard a team that has never tagged anything without blocking all their deploys on day one?",
+    "Why does the Azure policy exclude Microsoft.Resources/deployments and similar types?"
+  ],
+  "commonMistakes": [
+    "Rolling out deny policies org-wide on day one and breaking every pipeline",
+    "Forgetting that Azure resources do not inherit resource group tags automatically",
+    "Relying only on IaC and ignoring the console and ClickOps resources that bypass CI"
+  ],
+  "relatedTopics": [
+    "aws-tag-policies",
+    "azure-policy",
+    "opa-terraform",
+    "policy-as-code"
+  ]
+}

--- a/content/interview-questions/essential-cloud-cost-tags.json
+++ b/content/interview-questions/essential-cloud-cost-tags.json
@@ -1,0 +1,46 @@
+{
+  "id": "essential-cloud-cost-tags",
+  "slug": "essential-cloud-cost-tags",
+  "title": "Essential Tags for Multi-Cloud Cost Allocation",
+  "question": "If you were designing a tagging standard for a company running on AWS, GCP, and Azure, which tags would you require on every resource and why?",
+  "answer": "Keep the required set small. Five tags is my baseline: environment (prod, staging, dev, sandbox), team or owner (who pays and who to call at 3am), cost-center (the accounting code finance actually uses), application or service (which product this resource belongs to), and managed-by (terraform, pulumi, manual, console). Those five answer the questions finance asks every month and give engineering enough to drive ownership. Optional but common additions: project or ticket for short-lived resources, customer for multi-tenant SaaS workloads, and data-classification for compliance. Two rules I insist on. First, pick one casing and stick to it. team=payments, Team=Payments, and TEAM=PAYMENTS are three different values to the billing system and will fragment your reports. Lowercase with hyphens is the safest across AWS, GCP, and Azure since GCP labels reject uppercase anyway. Second, fewer mandatory tags means higher compliance. If you require 15 tags, engineers will copy-paste junk values to get past the policy. Start with 3 to 5 that finance and engineering agreed on together, then add more only when you have a concrete reporting need.",
+  "explanation": "This question tests whether the candidate has actually shipped a tagging policy or just read about one. Strong candidates will explain the tradeoff between completeness and compliance, mention case sensitivity and the GCP label restrictions, and talk about getting finance involved early. Watch for candidates who list 12 required tags - they usually have not had to enforce them across a real org.",
+  "category": "FinOps",
+  "difficulty": "intermediate",
+  "tier": "mid",
+  "tags": [
+    "finops",
+    "cloud-costs",
+    "tagging",
+    "multi-cloud",
+    "governance"
+  ],
+  "codeExamples": [
+    {
+      "language": "hcl",
+      "label": "Terraform default tags for AWS and shared locals for Azure and GCP",
+      "code": "# AWS: default_tags apply to every resource in this provider block\nprovider \"aws\" {\n  region = \"us-east-1\"\n\n  default_tags {\n    tags = {\n      team        = \"payments\"\n      environment = \"prod\"\n      cost-center = \"eng-4200\"\n      application = \"checkout-api\"\n      managed-by  = \"terraform\"\n    }\n  }\n}\n\n# Shared tag map for Azure and GCP resources\nlocals {\n  common_tags = {\n    team        = \"payments\"\n    environment = \"prod\"\n    cost-center = \"eng-4200\"\n    application = \"checkout-api\"\n    managed-by  = \"terraform\"\n  }\n}\n\nresource \"azurerm_linux_virtual_machine\" \"api\" {\n  name                = \"prod-api-01\"\n  resource_group_name = azurerm_resource_group.rg.name\n  location            = \"eastus\"\n  tags                = local.common_tags\n  # ... size, image, nic omitted\n}\n\nresource \"google_compute_instance\" \"api\" {\n  name         = \"prod-api-01\"\n  machine_type = \"e2-standard-2\"\n  zone         = \"us-central1-a\"\n  labels       = local.common_tags\n  # ... boot_disk, network_interface omitted\n}"
+    },
+    {
+      "language": "yaml",
+      "label": "Tagging standard documented for humans",
+      "code": "# tagging-standard.yaml - single source of truth for the org\nrequired_tags:\n  - key: team\n    description: Engineering team that owns the resource\n    allowed_values: [payments, identity, growth, platform, data]\n\n  - key: environment\n    description: Deployment environment\n    allowed_values: [prod, staging, dev, sandbox]\n\n  - key: cost-center\n    description: Finance cost center code\n    pattern: \"^eng-[0-9]{4}$\"\n\n  - key: application\n    description: Logical application name this resource supports\n    pattern: \"^[a-z0-9-]+$\"\n\n  - key: managed-by\n    description: How this resource was provisioned\n    allowed_values: [terraform, pulumi, helm, manual]\n\ncasing: lowercase-hyphen\nenforcement:\n  aws: organizations-tag-policy + aws-config\n  azure: azure-policy-deny\n  gcp: terraform-default + opa-in-ci"
+    }
+  ],
+  "followUpQuestions": [
+    "Why lowercase and hyphens instead of camelCase?",
+    "How do you handle tag sprawl when every team wants to add their own?",
+    "What do you do when finance wants a tag that engineering cannot answer at resource creation time?"
+  ],
+  "commonMistakes": [
+    "Requiring 10+ mandatory tags and wondering why compliance is at 40 percent",
+    "Mixing casing conventions across clouds so team=Payments and team=payments show up as two teams in reports",
+    "Not agreeing the tag values with finance first, so cost-center codes in the cloud do not match the ones in the ERP"
+  ],
+  "relatedTopics": [
+    "tagging-standards",
+    "terraform-default-tags",
+    "cost-allocation",
+    "finops-governance"
+  ]
+}


### PR DESCRIPTION
Auto-generated interview questions for topic: **How to Set Up Cloud Cost Allocation Tags Across AWS, GCP, and Azure**

Category: FinOps
Tags: finops, cloud-costs, tagging, multi-cloud

Created by content-pipeline.