### PR TITLE
fix(ci): IndexNow workflow survives multi-commit merges

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -27,7 +27,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          # A push event's github.event.before can be many commits behind
+          # (e.g. a merge commit that brings in several PR commits at once).
+          # fetch-depth: 2 was only enough for single-commit pushes and broke
+          # with 'bad object' on multi-commit merges. 0 fetches full history.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -41,6 +45,19 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: |
+          # Initial-push case: BEFORE_SHA is all zeros, diff against the empty
+          # tree so every current content file is submitted once.
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] \
+             || [ -z "$BEFORE_SHA" ]; then
+            BEFORE_SHA=$(git hash-object -t tree /dev/null)
+          fi
+          # Defensive: if the before SHA still isn't reachable (e.g. someone
+          # force-pushed main between the push event and this checkout),
+          # fall back to HEAD~1 so we at least submit the latest commit.
+          if ! git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+            echo "Warning: BEFORE_SHA $BEFORE_SHA not found, falling back to HEAD~1"
+            BEFORE_SHA=$(git rev-parse HEAD~1)
+          fi
           git diff --name-only --diff-filter=AM "$BEFORE_SHA" "$AFTER_SHA" \
             | { grep -E '^content/' || true; } > changed.txt
           echo "count=$(wc -l < changed.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**Error** (from the workflow log):
\`\`\`
Run git diff --name-only --diff-filter=AM "\$BEFORE_SHA" "\$AFTER_SHA"
  env:
    BEFORE_SHA: 9e788c2b8f36ab23c02f8af3c7dde05cfdaafd65
    AFTER_SHA: c8d927c1f8fc231191ff3a7db1ccafb399bf8f2a
fatal: bad object 9e788c2b8f36ab23c02f8af3c7dde05cfdaafd65
\`\`\`

**Cause**: the workflow used \`fetch-depth: 2\` and diffed against \`github.event.before\`. For single-commit pushes that works, but the SQLite comparisons PR merged with a **merge commit** that brought 2 new commits onto main (\`c8d927c\` → \`f7fcd37\` → \`9e788c2\`). \`github.event.before\` was \`9e788c2\` — 2 steps behind HEAD, which wasn't in the shallow checkout. The IndexNow submission step never actually ran; every recent merge has been silently skipped.

**Fix**:
- \`fetch-depth: 2\` → \`fetch-depth: 0\` so the full history is always reachable. The repo is ~1200 commits; negligible checkout cost.
- Handle the initial-push case (\`BEFORE_SHA\` is all zeros) by diffing against the empty-tree hash, so every content file gets submitted once on a first push to a brand-new branch.
- Defensive fallback: if \`BEFORE_SHA\` still isn't reachable (force-push, history rewrite), log a warning and fall back to \`HEAD~1\` rather than crashing.

**Backfill**: after merge, trigger the workflow manually via `Actions → IndexNow Submission → Run workflow`, leave the `urls` field blank, and it'll resubmit the whole sitemap to catch everything that got missed while this was broken.

## Test plan
- [ ] CI on this PR runs the workflow successfully (the PR itself is a merge scenario)
- [ ] Check the next push to main after merge — `[api-error]`-style logs should be gone; submission HTTP 200/202 should appear
- [ ] Run manual dispatch with blank `urls` to backfill missed URLs