### PR TITLE
docs: remove duplicated Useful Commands block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,30 +400,6 @@ docker compose build dev
 # Run a one-off command in the dev container
 docker compose run --rm dev pnpm lint
 ```
-docker compose up prod --build
-
-# Run in background
-docker compose up -d prod
-```
-
-#### Useful Commands
-
-```bash
-# Stop all services
-docker compose down
-
-# Stop and remove volumes (clean slate)
-docker compose down -v
-
-# View logs for a specific service
-docker compose logs -f dev
-
-# Rebuild a specific service
-docker compose build dev
-
-# Run a one-off command in the dev container
-docker compose run --rm dev pnpm lint
-```
 
 ## 📄 License
 


### PR DESCRIPTION
**Bug** (from the screenshot): the "Useful Commands" heading + code block were rendering as literal text inside a code block instead of as a heading + bash snippet.

**Cause**: lines 403-426 of README.md were a **duplicate** of the Production Mode + Useful Commands block above. The duplicate started mid-block without an opening code fence, so the \`\`\`\`\`\`\` that followed opened a fence rather than closing one — everything after it, including the \`#### Useful Commands\` heading, got absorbed into a code block until the next \`\`\`\`\`\`\`.

**Fix**: deleted the 24 duplicated lines. The block above was already correct and complete; no content was lost.

## Test plan
- [ ] GitHub preview of README shows "Useful Commands" as a heading again
- [ ] "## 📄 License" renders immediately after the final code block