### PR TITLE
fix: trim blog post sidebar related posts from 3 to 2

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -88,7 +88,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     notFound();
   }
 
-  const relatedPosts = await getRelatedPosts(post.slug, post.category?.slug || '', 6);
+  const relatedPosts = await getRelatedPosts(post.slug, post.category?.slug || '', 5);
 
   // Check if post content contains affiliate links
   const affiliatePatterns = [
@@ -101,9 +101,11 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     new RegExp(pattern).test(post.content)
   );
 
-  // Split related posts for main section and sidebar
+  // Split related posts: 3 in the main bottom-of-page section (needs
+  // enough variety to be worth the scroll), 2 in the sidebar (sidebar
+  // space is tight and more than 2 starts to feel cluttered).
   const mainRelatedPosts = relatedPosts.slice(0, 3);
-  const sidebarRelatedPosts = relatedPosts.slice(3, 6);
+  const sidebarRelatedPosts = relatedPosts.slice(3, 5);
 
   // Breadcrumb items for schema
   const breadcrumbItems = [


### PR DESCRIPTION
Sidebar on individual posts was showing 3 related articles, which stacked up with the sponsor block and newsletter form to feel cluttered, especially on posts with 2-line titles.

- Dropped sidebar from 3 → 2 (`app/posts/[slug]/page.tsx:108`, slice `3..5` instead of `3..6`)
- Total fetch trimmed from 6 → 5 accordingly
- Bottom-of-page "Related Posts" section is unchanged (still 3 cards) — that's where readers actively scan for what's next

## Test plan
- [ ] Load any `/posts/<slug>` — sidebar shows 2 Related Posts, not 3
- [ ] Bottom "Related Posts" section still shows 3 cards