### PR TITLE
fix(comparisons): soften go-vs-rust cross-compilation claim

### DIFF
--- a/content/comparisons/go-vs-rust.json
+++ b/content/comparisons/go-vs-rust.json
@@ -116,7 +116,7 @@
       "name": "Cross-Compilation",
       "category": "Distribution",
       "toolA": { "value": "Trivial - set GOOS and GOARCH, single command builds", "rating": "good" },
-      "toolB": { "value": "Requires cross-compilation toolchains or cross-rs; works but needs setup", "rating": "neutral" }
+      "toolB": { "value": "Pure-Rust crates: rustup target add + cargo build --target= is a one-liner. With C dependencies (OpenSSL, SQLite, libgit2) you need a cross-linker, typically via cross-rs.", "rating": "neutral" }
     },
     {
       "name": "Error Handling",


### PR DESCRIPTION
A reader on `/comparisons/go-vs-rust` flagged that the cross-compilation row undersold Rust's story. They're right for the common case:

- **Pure-Rust crates**: `rustup target add x86_64-unknown-linux-musl && cargo build --target=...` is genuinely a one-liner. No extra tooling needed.
- **With C dependencies** (OpenSSL, SQLite, libgit2, ring, etc.): you need a cross-linker for the target's libc, typically via [`cross`](https://github.com/cross-rs/cross) which uses Docker images with the right toolchains.

The original copy said "Requires cross-compilation toolchains or cross-rs; works but needs setup" — that's the FFI case. Updated to mention both cases so readers don't dismiss Rust's cross-compile story.

Rating stays at `neutral` since the FFI case still requires extra setup that Go's `GOOS`/`GOARCH` doesn't.

## Test plan

- [ ] Visit `/comparisons/go-vs-rust` and confirm the Cross-Compilation row reads correctly with the new text
- [ ] No layout breakage from the longer cell content