### PR TITLE
fix(seo): lengthen short page titles flagged by SEO audit

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -41,15 +41,18 @@ export async function generateMetadata({
   }
 
   const socialImage = getSocialImagePath(slug, 'guides');
+  // Prefer the longer SEO title for the <title> tag and social cards
+  // when the frontmatter sets one. Display headings still use guide.title.
+  const pageTitle = guide.seoTitle || guide.title;
 
   return {
-    title: { absolute: guide.title },
+    title: { absolute: pageTitle },
     description: guide.description,
     alternates: {
       canonical: `/guides/${slug}`,
     },
     openGraph: {
-      title: guide.title,
+      title: pageTitle,
       description: guide.description,
       url: `/guides/${slug}`,
       type: 'article',
@@ -68,7 +71,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: 'summary_large_image',
-      title: guide.title,
+      title: pageTitle,
       description: guide.description,
       images: [socialImage || guide.image || '/og-image.jpg'],
     },

--- a/content/guides/owasp-top-10/index.md
+++ b/content/guides/owasp-top-10/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'OWASP Top 10'
+seoTitle: 'OWASP Top 10: Web Application Security Risks Guide'
 description: 'Learn about the OWASP Top 10 web application security risks. Understand each vulnerability, see real-world examples, and learn how to prevent them in your applications.'
 category:
   name: 'Security'

--- a/content/guides/security-gates/index.md
+++ b/content/guides/security-gates/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'Security Gates'
+seoTitle: 'Security Gates: Block Risky Deployments in CI/CD'
 description: 'Implement automated security gates that block deployments on critical vulnerabilities, policy violations, and security failures. Shift security left in your CI/CD pipeline.'
 category:
   name: 'Security'

--- a/lib/game-metadata.ts
+++ b/lib/game-metadata.ts
@@ -15,7 +15,10 @@ export async function generateGameMetadata(gameId: string): Promise<Metadata> {
     };
   }
 
-  const title = `${game.title} - DevOps Daily`;
+  // Prefer the longer SEO title for the page <title> when one is set.
+  // Falls back to the display title for games that already read fine.
+  const pageTitle = game.seoTitle || game.title;
+  const title = `${pageTitle} - DevOps Daily`;
   const description = game.description;
   const ogImage = `/images/games/${gameId}-og.png`;
 
@@ -25,7 +28,7 @@ export async function generateGameMetadata(gameId: string): Promise<Metadata> {
     // picked up by Google from the Organization/WebSite schema. OG + Twitter
     // titles below keep the suffix because social previews benefit from
     // brand presence.
-    title: { absolute: game.title },
+    title: { absolute: pageTitle },
     description,
     alternates: {
       canonical: game.href,

--- a/lib/games.ts
+++ b/lib/games.ts
@@ -2,6 +2,15 @@
 export interface Game {
   id: string;
   title: string;
+  /**
+   * Optional longer title used only for the <title> tag and OG/Twitter
+   * cards. SEO tools flag titles under ~30 chars; some games (Bug Hunter,
+   * BCDR Simulator) have short display titles that read fine on cards
+   * but are too short on their own as page titles. Set this when the
+   * display title needs more context for search engines and social
+   * previews.
+   */
+  seoTitle?: string;
   description: string;
   iconName: string;
   badgeText?: string;
@@ -151,6 +160,7 @@ const games: Game[] = [
     id: 'bcdr-simulator',
     type: 'simulator',
     title: 'BCDR Simulator',
+    seoTitle: 'BCDR Simulator: Interactive Disaster Recovery Planning',
     description:
       'Learn Business Continuity & Disaster Recovery with interactive RTO/RPO planning, failover strategies, and disaster scenarios. Understand hot, warm, and cold DR sites.',
     iconName: 'Shield',
@@ -242,6 +252,7 @@ const games: Game[] = [
     id: 'bug-hunter',
     type: 'game',
     title: 'Bug Hunter',
+    seoTitle: 'Bug Hunter: Snake-Style DevOps Game in the Browser',
     description:
       'DevOps-themed Snake game where you control a bug that infects healthy servers. Grow longer with each infection, but avoid crashing into walls or yourself!',
     iconName: 'Bug',

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -24,6 +24,13 @@ export type GuidePart = {
 
 export type Guide = {
   title: string;
+  /**
+   * Optional longer title used only for the <title> tag and OG/Twitter
+   * cards. Display headings stay short; the page title can carry more
+   * descriptive text for search engines when the natural title is too
+   * brief on its own.
+   */
+  seoTitle?: string;
   slug: string;
   description?: string;
   content: string;


### PR DESCRIPTION
Ahrefs flagged four pages with `<title>` tags that are too short:

| URL | Old title | New title (chars) |
|---|---|---|
| `/guides/security-gates` | Security Gates | Security Gates: Block Risky Deployments in CI/CD (48) |
| `/guides/owasp-top-10` | OWASP Top 10 | OWASP Top 10: Web Application Security Risks Guide (50) |
| `/games/bcdr-simulator` | BCDR Simulator | BCDR Simulator: Interactive Disaster Recovery Planning (54) |
| `/games/bug-hunter` | Bug Hunter | Bug Hunter: Snake-Style DevOps Game in the Browser (50) |

## Approach

Display titles still need to read cleanly on cards and as page headings, so I added an optional `seoTitle` field to both `Game` (`lib/games.ts`) and `Guide` (`lib/guides.ts`). When set, the Next.js metadata uses it for the `<title>` tag plus the OG / Twitter card titles. The display title (used on the page itself and on listing cards) is unchanged.

## Files

- `lib/games.ts` — added `seoTitle?: string` to the `Game` interface, set it on `bcdr-simulator` and `bug-hunter` entries
- `lib/guides.ts` — added `seoTitle?: string` to the `Guide` type
- `lib/game-metadata.ts` — `generateGameMetadata` now prefers `game.seoTitle` for the `<title>` and OG / Twitter
- `app/guides/[slug]/page.tsx` — `generateMetadata` now prefers `guide.seoTitle` for the same fields
- `content/guides/security-gates/index.md` — added `seoTitle` frontmatter field
- `content/guides/owasp-top-10/index.md` — added `seoTitle` frontmatter field

## Test plan

- [ ] `/guides/security-gates`: view source, confirm `<title>` shows the long title; H1 still says "Security Gates"
- [ ] `/guides/owasp-top-10`: same check
- [ ] `/games/bcdr-simulator`: page `<title>` shows the long title; cards on `/games` still show "BCDR Simulator"
- [ ] `/games/bug-hunter`: same check
- [ ] OG tags include the long title (curl + grep `og:title`, or check social share preview)