### PR TITLE
fix(seo): batch SEO cleanup - OG tags, OG fallback, orphan pages, 404 links, meta description length

### DIFF
--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -43,7 +43,15 @@ export const metadata: Metadata = {
     description:
       'Curated collection of the best DevOps, SRE, and Cloud Engineering books. From beginner guides to advanced practices.',
     type: 'website',
-    images: ['/images/pages/books-og.png'],
+    url: '/books',
+    images: [
+      {
+        url: '/images/pages/books-og.png',
+        width: 1200,
+        height: 630,
+        alt: 'DevOps Books',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',

--- a/app/categories/[slug]/page.tsx
+++ b/app/categories/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { notFound } from 'next/navigation';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import { FolderOpen } from 'lucide-react';
 import Link from 'next/link';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import type { Metadata } from 'next';
 
 export const dynamicParams = false;
@@ -36,15 +37,26 @@ export async function generateMetadata({
     return {};
   }
 
+  // Old template prefixed every category description with a generic
+  // "Explore the X category for articles, tutorials, and guides covering
+  // DevOps practices." which alone is ~95 chars and pushed every page
+  // over Google's 160-char meta cap. Switch to the category's own short
+  // description (punchy and keyword-rich) and truncate as a safety net.
+  const baseDescription =
+    category.description ||
+    category.longDescription ||
+    `${category.name} articles, tutorials, and guides on DevOps Daily.`;
+  const description = truncateMetaDescription(baseDescription);
+
   return {
     title: { absolute: `Category: ${category.name} - DevOps Articles and Tutorials` },
-    description: `Explore the ${category.name} category for articles, tutorials, and guides covering DevOps practices. ${category.longDescription || category.description}`,
+    description,
     alternates: {
       canonical: `/categories/${slug}`,
     },
     openGraph: {
       title: `Category: ${category.name} - DevOps Articles and Tutorials`,
-      description: `Explore the ${category.name} category for articles, tutorials, and guides covering DevOps practices. ${category.longDescription || category.description}`,
+      description,
       url: `/categories/${slug}`,
       type: 'website',
       images: [
@@ -59,7 +71,7 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: `Category: ${category.name} - DevOps Articles and Tutorials`,
-      description: `Explore the ${category.name} category for articles, tutorials, and guides covering DevOps practices. ${category.longDescription || category.description}`,
+      description,
       images: ['/og-image.png'],
     },
   };

--- a/app/checklists/[slug]/page.tsx
+++ b/app/checklists/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getAllChecklists, getChecklistBySlug } from '@/lib/checklists';
 import { ChecklistPageClient } from '@/components/checklists/checklist-page-client';
 import { PageHero } from '@/components/page-hero';
 import { ListChecks } from 'lucide-react';
+import { truncateMetaDescription } from '@/lib/meta-description';
 
 export async function generateStaticParams() {
   const checklists = await getAllChecklists();
@@ -24,15 +25,17 @@ export async function generateMetadata(
     };
   }
 
+  const description = truncateMetaDescription(checklist.description);
+
   return {
    title: { absolute: checklist.title },
-   description: checklist.description,
+   description,
    alternates: {
      canonical: `/checklists/${resolvedParams.slug}`,
    },
    openGraph: {
      title: `${checklist.title} - The DevOps Daily`,
-    description: checklist.description,
+    description,
     type: 'website',
     url: `/checklists/${resolvedParams.slug}`,
     siteName: 'The DevOps Daily',
@@ -51,7 +54,7 @@ export async function generateMetadata(
     site: '@TheDevOpsDaily',
     creator: '@TheDevOpsDaily',
     title: `${checklist.title} - The DevOps Daily`,
-    description: checklist.description,
+    description,
     images: [`/images/checklists/${resolvedParams.slug}-og.png`],
    },
   };

--- a/app/comparisons/[slug]/page.tsx
+++ b/app/comparisons/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import { getComparisonBySlug, getAllComparisons } from '@/lib/comparisons';
 import { ComparisonPageClient } from '@/components/comparisons/comparison-page-client';
 import { BreadcrumbSchema, ArticleSchema } from '@/components/schema-markup';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import type { Metadata } from 'next';
 
 export const dynamicParams = false;
@@ -31,7 +32,7 @@ export async function generateMetadata({
   }
 
   const title = `${comparison.toolA.name} vs ${comparison.toolB.name}: Feature Comparison, Pros/Cons, and Verdict`;
-  const description = comparison.description;
+  const description = truncateMetaDescription(comparison.description);
   const socialImage = `/images/comparisons/${comparison.slug}-og.png`;
 
   return {

--- a/app/exercises/[id]/page.tsx
+++ b/app/exercises/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/schema-markup';
 import { ExerciseSeriesNav } from '@/components/exercise-series-nav';
 import { getSocialImagePath } from '@/lib/image-utils';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import type { Metadata } from 'next';
 
 export const dynamicParams = false;
@@ -36,16 +37,17 @@ export async function generateMetadata({
   }
 
   const socialImage = getSocialImagePath(exercise.id, 'exercises');
+  const description = truncateMetaDescription(exercise.description);
 
   return {
     title: { absolute: `${exercise.title} - DevOps Exercise` },
-    description: exercise.description,
+    description,
     alternates: {
       canonical: `/exercises/${exercise.id}`,
     },
     openGraph: {
       title: `${exercise.title} - DevOps Exercise`,
-      description: exercise.description,
+      description,
       url: `/exercises/${exercise.id}`,
       type: 'article',
       images: [
@@ -60,7 +62,7 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: `${exercise.title} - DevOps Exercise`,
-      description: exercise.description,
+      description,
       images: [socialImage],
     },
   };

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, BookOpen, Clock, Layers } from 'lucide-react'
 import Link from 'next/link'
 import * as Icons from 'lucide-react'
 import { PageHero } from '@/components/page-hero'
+import { truncateMetaDescription } from '@/lib/meta-description'
 
 interface FlashcardPageProps {
   params: Promise<{
@@ -32,15 +33,17 @@ export async function generateMetadata({ params }: FlashcardPageProps): Promise<
     }
   }
 
+  const description = truncateMetaDescription(flashcardSet.description)
+
   return {
     title: { absolute: `${flashcardSet.title} - DevOps Flashcards` },
-    description: flashcardSet.description,
+    description,
     alternates: {
       canonical: `/flashcards/${id}`,
     },
     openGraph: {
       title: `${flashcardSet.title} - DevOps Daily`,
-      description: flashcardSet.description,
+      description,
       type: 'website',
       url: `/flashcards/${id}`,
       images: [
@@ -55,7 +58,7 @@ export async function generateMetadata({ params }: FlashcardPageProps): Promise<
     twitter: {
       card: 'summary_large_image',
       title: `${flashcardSet.title} - DevOps Daily`,
-      description: flashcardSet.description,
+      description,
       images: [`/images/flashcards/${id}-og.png`],
     },
   }

--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({
       type: 'article',
       images: [
         {
-          url: socialImage || '/og-image.jpg',
+          url: socialImage || '/og-image.png',
           width: 1200,
           height: 630,
           alt: guide.title,
@@ -81,7 +81,7 @@ export async function generateMetadata({
       card: 'summary_large_image',
       title: `${part.title} - ${guide.title}`,
       description: part.description || guide.description,
-      images: [socialImage || '/og-image.jpg'],
+      images: [socialImage || '/og-image.png'],
     },
   };
 }

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { GuidePartNavigation } from '@/components/guide-part-navigation';
 import { ReportIssue } from '@/components/report-issue';
 import { GiscusComments } from '@/components/giscus-comments';
 import { getSocialImagePath } from '@/lib/image-utils';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import { RelatedPosts } from '@/components/related-posts';
 import type { Metadata } from 'next';
 
@@ -44,16 +45,17 @@ export async function generateMetadata({
   // Prefer the longer SEO title for the <title> tag and social cards
   // when the frontmatter sets one. Display headings still use guide.title.
   const pageTitle = guide.seoTitle || guide.title;
+  const description = truncateMetaDescription(guide.description);
 
   return {
     title: { absolute: pageTitle },
-    description: guide.description,
+    description,
     alternates: {
       canonical: `/guides/${slug}`,
     },
     openGraph: {
       title: pageTitle,
-      description: guide.description,
+      description,
       url: `/guides/${slug}`,
       type: 'article',
       images: [
@@ -72,7 +74,7 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: pageTitle,
-      description: guide.description,
+      description,
       images: [socialImage || guide.image || '/og-image.png'],
     },
   };

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata({
       type: 'article',
       images: [
         {
-          url: socialImage || guide.image || '/og-image.jpg',
+          url: socialImage || guide.image || '/og-image.png',
           width: 1200,
           height: 630,
           alt: guide.title,
@@ -73,7 +73,7 @@ export async function generateMetadata({
       card: 'summary_large_image',
       title: pageTitle,
       description: guide.description,
-      images: [socialImage || guide.image || '/og-image.jpg'],
+      images: [socialImage || guide.image || '/og-image.png'],
     },
   };
 }

--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       url: `/interview-questions/${tier}/${slug}`,
       images: [
         {
-          url: socialImage || '/og-image.jpg',
+          url: socialImage || '/og-image.png',
           width: 1200,
           height: 630,
           alt: question.title,
@@ -62,7 +62,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       card: 'summary_large_image',
       title: question.title,
       description,
-      images: [socialImage || '/og-image.jpg'],
+      images: [socialImage || '/og-image.png'],
     },
   };
 }

--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { interviewQuestions, getQuestionBySlug } from '@/content/interview-quest
 import { InterviewQuestionPage } from '@/components/interview-questions/interview-question-page';
 import { PageHero } from '@/components/page-hero';
 import { getSocialImagePath } from '@/lib/image-utils';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import type { ExperienceTier } from '@/lib/interview-utils';
 
 const validTiers: ExperienceTier[] = ['junior', 'mid', 'senior'];
@@ -36,7 +37,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   const socialImage = getSocialImagePath(slug, 'interview-questions');
-  const description = `${question.question} - ${question.category} interview question for ${tier} DevOps engineers`;
+  // Some questions are long enough that the auto-built description blows
+  // past 160 chars; trim at sentence boundary so Google does not truncate.
+  const description = truncateMetaDescription(
+    `${question.question} - ${question.category} interview question for ${tier} DevOps engineers`,
+  );
   
   return {
     title: { absolute: `${question.title} - Interview Question` },

--- a/app/interview-questions/[tier]/page.tsx
+++ b/app/interview-questions/[tier]/page.tsx
@@ -49,7 +49,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       url: `/interview-questions/${tier}`,
       images: [
         {
-          url: '/og-image.jpg',
+          url: '/og-image.png',
           width: 1200,
           height: 630,
           alt: meta.title,
@@ -60,7 +60,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       card: 'summary_large_image',
       title: meta.title,
       description: meta.description,
-      images: ['/og-image.jpg'],
+      images: ['/og-image.png'],
     },
   };
 }

--- a/app/interview-questions/[tier]/page.tsx
+++ b/app/interview-questions/[tier]/page.tsx
@@ -47,11 +47,20 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       description: meta.description,
       type: 'website',
       url: `/interview-questions/${tier}`,
+      images: [
+        {
+          url: '/og-image.jpg',
+          width: 1200,
+          height: 630,
+          alt: meta.title,
+        },
+      ],
     },
     twitter: {
       card: 'summary_large_image',
       title: meta.title,
       description: meta.description,
+      images: ['/og-image.jpg'],
     },
   };
 }

--- a/app/interview-questions/[tier]/page.tsx
+++ b/app/interview-questions/[tier]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { interviewQuestions, getQuestionsByTier, getAllCategories } from '@/content/interview-questions';
 import { InterviewTierPage } from '@/components/interview-questions/interview-tier-page';
@@ -98,6 +99,31 @@ export default async function TierPage({ params }: PageProps) {
         questions={questions}
         categories={categories}
       />
+      {/* All-questions index. Server-rendered so the slug pages are
+          actually linked from somewhere - without these links every
+          /interview-questions/{tier}/{slug} page is an SEO orphan. */}
+      <section className="container mx-auto px-4 max-w-4xl py-12 border-t">
+        <h2 className="text-2xl font-bold mb-2">All {tierLabel} Questions</h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          Browse every {tierLabel.toLowerCase()} question with its own page.
+          Useful for sharing, bookmarking, or jumping straight to a topic.
+        </p>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+          {questions.map((q) => (
+            <li key={q.id}>
+              <Link
+                href={`/interview-questions/${tier}/${q.slug}`}
+                className="text-sm text-foreground hover:text-primary hover:underline"
+              >
+                {q.title}
+              </Link>
+              <span className="ml-2 text-xs text-muted-foreground">
+                {q.category}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
     </>
   );
 }

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -35,6 +35,7 @@ export async function generateMetadata({
       title: newsletter.title,
       description: `Weekly roundup - Week ${newsletter.week}, ${newsletter.year}`,
       type: 'article',
+      url: `/newsletters/${slug}`,
       publishedTime: newsletter.date,
       images: [
         {

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -15,6 +15,14 @@ export const metadata: Metadata = {
       'Browse past issues of the DevOps Daily newsletter.',
     type: 'website',
     url: '/newsletters',
+    images: [
+      {
+        url: '/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'DevOps Daily Newsletter Archive',
+      },
+    ],
   },
 };
 

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     url: '/newsletters',
     images: [
       {
-        url: '/og-image.jpg',
+        url: '/og-image.png',
         width: 1200,
         height: 630,
         alt: 'DevOps Daily Newsletter Archive',

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -59,7 +59,7 @@ export async function generateMetadata({
       url: `/posts/${post.slug}`,
       images: [
         {
-          url: socialImage || post.image || '/og-image.jpg',
+          url: socialImage || post.image || '/og-image.png',
           width: 1200,
           height: 630,
           alt: post.title,
@@ -74,7 +74,7 @@ export async function generateMetadata({
       card: 'summary_large_image',
       title: post.title,
       description: post.excerpt,
-      images: [socialImage || post.image || '/og-image.jpg'],
+      images: [socialImage || post.image || '/og-image.png'],
     },
   };
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { ReportIssue } from '@/components/report-issue';
 import { GiscusComments } from '@/components/giscus-comments';
 import { getSocialImagePath } from '@/lib/image-utils';
+import { truncateMetaDescription } from '@/lib/meta-description';
 
 import type { Metadata } from 'next';
 
@@ -42,20 +43,24 @@ export async function generateMetadata({
   }
 
   const socialImage = getSocialImagePath(slug, 'posts');
+  // post.excerpt is shown in full on the page itself, but Google clips
+  // descriptions over ~160 chars. Trim at the last sentence boundary so
+  // the meta tag stays in range without dropping keywords.
+  const metaDescription = truncateMetaDescription(post.excerpt);
 
   return {
     // Absolute: skip the '%s | DevOps Daily' layout template. Post titles
     // are always topic-specific and rank better without the redundant
     // brand suffix. OG + Twitter below keep the brand in social previews.
     title: { absolute: post.title },
-    description: post.excerpt,
+    description: metaDescription,
     alternates: {
       canonical: `/posts/${post.slug}`,
     },
     openGraph: {
       type: 'article',
       title: post.title,
-      description: post.excerpt,
+      description: metaDescription,
       url: `/posts/${post.slug}`,
       images: [
         {
@@ -73,7 +78,7 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: post.title,
-      description: post.excerpt,
+      description: metaDescription,
       images: [socialImage || post.image || '/og-image.png'],
     },
   };

--- a/app/quizzes/[slug]/page.tsx
+++ b/app/quizzes/[slug]/page.tsx
@@ -46,6 +46,7 @@ export async function generateMetadata({
       title: `${quizConfig.title} - DevOps Daily`,
       description: quizConfig.description,
       type: 'website',
+      url: `/quizzes/${slug}`,
       images: [
         {
           url: `/images/quizzes/${slug}-og.png`,

--- a/app/quizzes/[slug]/page.tsx
+++ b/app/quizzes/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import GenericQuiz from '@/components/games/generic-quiz';
 import { getQuizById, getAllQuizzes, getRelatedQuizzes } from '@/lib/quiz-loader';
+import { truncateMetaDescription } from '@/lib/meta-description';
 import { ReportIssue } from '@/components/report-issue';
 import { ArrowLeft, Twitter, Facebook, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -36,15 +37,17 @@ export async function generateMetadata({
     return {};
   }
 
+  const description = truncateMetaDescription(quizConfig.description);
+
   return {
     title: { absolute: `${quizConfig.title} - Learn ${quizConfig.category}` },
-    description: quizConfig.description,
+    description,
     alternates: {
       canonical: `/quizzes/${slug}`,
     },
     openGraph: {
       title: `${quizConfig.title} - DevOps Daily`,
-      description: quizConfig.description,
+      description,
       type: 'website',
       url: `/quizzes/${slug}`,
       images: [
@@ -59,7 +62,7 @@ export async function generateMetadata({
     twitter: {
       card: 'summary_large_image',
       title: `${quizConfig.title} - DevOps Daily`,
-      description: quizConfig.description,
+      description,
       images: [`/images/quizzes/${slug}-og.png`],
     },
   };

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     url: '/search',
     images: [
       {
-        url: '/og-image.jpg',
+        url: '/og-image.png',
         width: 1200,
         height: 630,
         alt: 'DevOps Daily Search',
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Search | DevOps Daily',
     description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
-    images: ['/og-image.jpg'],
+    images: ['/og-image.png'],
   },
 };
 

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -12,11 +12,21 @@ export const metadata: Metadata = {
     title: 'Search | DevOps Daily',
     description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
     type: 'website',
+    url: '/search',
+    images: [
+      {
+        url: '/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'DevOps Daily Search',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Search | DevOps Daily',
     description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
+    images: ['/og-image.jpg'],
   },
 };
 

--- a/content/advent-of-devops/day-21.md
+++ b/content/advent-of-devops/day-21.md
@@ -91,8 +91,8 @@ project-template/
 # Project Name
 
 [![CI](https://github.com/username/repo/workflows/CI/badge.svg)](https://github.com/username/repo/actions)
-[![License](https://img.shields.io/github/license/username/repo)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+![License](https://img.shields.io/github/license/username/repo)
+![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
 > Brief description of what this project does
 
@@ -208,11 +208,11 @@ npm run test:coverage
 
 ## Deployment
 
-See [DEPLOYMENT.md](docs/DEPLOYMENT.md) for deployment instructions.
+See `docs/DEPLOYMENT.md` in the repo for deployment instructions.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
+Please read `docs/CONTRIBUTING.md` in the repo for details on our code of conduct and the process for submitting pull requests.
 
 ## License
 

--- a/content/advent-of-devops/day-7.md
+++ b/content/advent-of-devops/day-7.md
@@ -159,10 +159,10 @@ module "bucket_with_lifecycle" {
 
 ## Examples
 
-- [Basic](./examples/basic) - Simple bucket creation
-- [With Lifecycle](./examples/with-lifecycle) - Lifecycle rules
-- [Encrypted](./examples/encrypted) - KMS encryption
-- [Complete](./examples/complete) - All features
+- **Basic** - Simple bucket creation
+- **With Lifecycle** - Lifecycle rules
+- **Encrypted** - KMS encryption
+- **Complete** - All features
 
 ## Development
 
@@ -199,11 +199,11 @@ cd test && go test -v
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md)
+See `CONTRIBUTING.md` in the repo for the contribution guidelines.
 
 ## License
 
-MIT Licensed. See [LICENSE](./LICENSE)
+MIT Licensed. See the `LICENSE` file in the repo.
 ```
 
 ### CI/CD Pipeline

--- a/content/guides/security-gates/index.md
+++ b/content/guides/security-gates/index.md
@@ -48,10 +48,10 @@ This guide teaches you how to implement security gates using policy-as-code, aut
 
 This guide covers essential security gate implementations:
 
-1. **[Policy as Code](./01-policy-as-code)** — OPA, Kyverno, and admission control
-2. **[Vulnerability Gates](./02-vulnerability-gates)** — Fail builds on critical CVEs
-3. **[Compliance Gates](./03-compliance-gates)** — CIS benchmarks, PCI-DSS, SOC 2
-4. **[CI/CD Integration](./04-cicd-integration)** — Automated enforcement in your pipeline
+1. **[Policy as Code](/guides/security-gates/01-policy-as-code)** — OPA, Kyverno, and admission control
+2. **[Vulnerability Gates](/guides/security-gates/02-vulnerability-gates)** — Fail builds on critical CVEs
+3. **[Compliance Gates](/guides/security-gates/03-compliance-gates)** — CIS benchmarks, PCI-DSS, SOC 2
+4. **[CI/CD Integration](/guides/security-gates/04-cicd-integration)** — Automated enforcement in your pipeline
 
 ## Types of Security Gates
 
@@ -270,10 +270,10 @@ Document and track accepted risks/false positives.
 
 Start implementing security gates:
 
-1. **[Policy as Code](./01-policy-as-code)** — Write and enforce security policies
-2. **[Vulnerability Gates](./02-vulnerability-gates)** — Block critical CVEs
-3. **[Compliance Gates](./03-compliance-gates)** — Automate compliance checks
-4. **[CI/CD Integration](./04-cicd-integration)** — Integrate gates into your pipeline
+1. **[Policy as Code](/guides/security-gates/01-policy-as-code)** — Write and enforce security policies
+2. **[Vulnerability Gates](/guides/security-gates/02-vulnerability-gates)** — Block critical CVEs
+3. **[Compliance Gates](/guides/security-gates/03-compliance-gates)** — Automate compliance checks
+4. **[CI/CD Integration](/guides/security-gates/04-cicd-integration)** — Integrate gates into your pipeline
 
 ---
 

--- a/lib/game-metadata.ts
+++ b/lib/game-metadata.ts
@@ -1,6 +1,7 @@
 // lib/game-metadata.ts
 import type { Metadata } from 'next';
 import { getGameById } from './games';
+import { truncateMetaDescription } from './meta-description';
 
 /**
  * Generate Next.js metadata for a game page
@@ -19,7 +20,7 @@ export async function generateGameMetadata(gameId: string): Promise<Metadata> {
   // Falls back to the display title for games that already read fine.
   const pageTitle = game.seoTitle || game.title;
   const title = `${pageTitle} - DevOps Daily`;
-  const description = game.description;
+  const description = truncateMetaDescription(game.description);
   const ogImage = `/images/games/${gameId}-og.png`;
 
   return {

--- a/lib/meta-description.ts
+++ b/lib/meta-description.ts
@@ -1,0 +1,39 @@
+/**
+ * Trims a long description down to fit Google's recommended meta description
+ * length (~155-160 chars). Tries to cut at the last sentence boundary to keep
+ * the result readable; falls back to a word boundary if no early sentence end
+ * exists. Keeps the first words intact, which is where the keywords usually
+ * live, so SEO signal is preserved.
+ *
+ * Pass through anything already short enough.
+ */
+export function truncateMetaDescription(
+  text: string | undefined | null,
+  maxLength = 155,
+): string {
+  if (!text) return '';
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+
+  // Find the last sentence end (period, !, ?) within the limit.
+  const slice = trimmed.slice(0, maxLength + 1);
+  const sentenceEnd = Math.max(
+    slice.lastIndexOf('. '),
+    slice.lastIndexOf('! '),
+    slice.lastIndexOf('? '),
+  );
+
+  if (sentenceEnd > 80) {
+    // The +1 keeps the closing punctuation.
+    return trimmed.slice(0, sentenceEnd + 1);
+  }
+
+  // No good sentence break: cut at the last word boundary and add ellipsis.
+  const wordEnd = slice.lastIndexOf(' ');
+  if (wordEnd > 0) {
+    return trimmed.slice(0, wordEnd).replace(/[,;:.\s]+$/, '') + '...';
+  }
+
+  // Pathological single-word input - just hard cut.
+  return trimmed.slice(0, maxLength - 3) + '...';
+}


### PR DESCRIPTION
## Summary

Ahrefs flagged 42 URLs as having incomplete Open Graph tags. Auditing the CSV, the 42 URLs collapse to **six page templates** with **four distinct missing-tag patterns**. Patching the templates fixes every flagged URL plus future pages of the same shapes.

## Missing-tag pattern → page template

| Pattern | URLs | Template | Fix |
|---|---|---|---|
| Missing `og:url` | 32 | `/quizzes/[slug]` | add `url: /quizzes/${slug}` to openGraph |
| Missing `og:url` | 4 | `/newsletters/[slug]` | add `url: /newsletters/${slug}` |
| Missing `og:image` (+ dims/alt) | 1 | `/newsletters` index | add the standard 1200×630 image with dims/alt |
| Missing `og:image` (+ dims/alt) | 3 | `/interview-questions/[tier]` | add og:image + matching twitter image so junior/mid/senior tiers have full social cards |
| Missing `og:url` + `og:image` | 1 | `/search` | add og:url, og:image with dims/alt, twitter image |
| Missing image dims + `og:url` | 1 | `/books` | switch the openGraph images entry from a bare URL string to `{url, width, height, alt}`, plus add og:url |

Templates use site-level `/og-image.jpg` as the fallback image where no per-page OG asset exists yet (interview-questions tiers, search, newsletters index). Per-page OG image generation for those routes can come in a separate PR.

## Test plan

- [ ] `curl https://devops-daily.com/quizzes/sql-quiz | grep og:` shows `og:url`
- [ ] `/newsletters/2026-week-17`: same check
- [ ] `/newsletters`: source includes `og:image` plus dims and alt
- [ ] `/interview-questions/senior`: source includes a complete OG card
- [ ] `/search`: source includes `og:url` and `og:image`
- [ ] `/books`: source includes `og:image:width`, `og:image:height`, `og:image:alt`, `og:url`
- [ ] Twitter card validator on each shows a complete preview