### PR TITLE
fix(seo): single H1 per page across content templates

### DIFF
--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -113,7 +113,7 @@ export default async function FlashcardPage({ params }: FlashcardPageProps) {
                 </Badge>
                 <Badge variant="outline">{flashcardSet.category}</Badge>
               </div>
-              <h1 className="text-3xl md:text-4xl font-bold mb-2">{flashcardSet.title}</h1>
+              <h2 className="text-3xl md:text-4xl font-bold mb-2">{flashcardSet.title}</h2>
               <p className="text-lg text-muted-foreground mb-4">{flashcardSet.description}</p>
               <div className="flex items-center gap-4 text-sm text-muted-foreground">
                 <div className="flex items-center gap-1">

--- a/components/checklists/checklist-page-client.tsx
+++ b/components/checklists/checklist-page-client.tsx
@@ -97,9 +97,9 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
           </span>
         </div>
 
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-3">
+        <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-3">
           {checklist.title}
-        </h1>
+        </h2>
         <p className="text-lg text-gray-600 dark:text-gray-400 mb-4">
           {checklist.description}
         </p>

--- a/components/games/bug-hunter.tsx
+++ b/components/games/bug-hunter.tsx
@@ -365,9 +365,9 @@ return (
            <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-red-500 to-orange-600 flex items-center justify-center">
              <Bug className="w-7 h-7 text-white" />
            </div>
-           <h1 className="text-4xl md:text-5xl font-bold text-slate-900 dark:text-white">
+           <h2 className="text-4xl md:text-5xl font-bold text-slate-900 dark:text-white">
              Bug Hunter
-           </h1>
+           </h2>
          </div>
          <p className="text-xl text-slate-600 dark:text-gray-400 max-w-2xl mx-auto">
          Control a glitch that infects healthy servers. Grow longer with each infection, but don't crash!

--- a/components/games/cards-against-devops.tsx
+++ b/components/games/cards-against-devops.tsx
@@ -614,9 +614,9 @@ return (
               <div className="w-12 h-12 rounded-md bg-primary/10 flex items-center justify-center">
                 <Heart className="w-6 h-6 text-primary" />
               </div>
-              <h1 className="text-3xl sm:text-4xl font-bold text-primary">
+              <h2 className="text-3xl sm:text-4xl font-bold text-primary">
                 Cards Against DevOps
-              </h1>
+              </h2>
             </div>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
               The hilariously inappropriate DevOps party game. Fill in the blanks with the most

--- a/components/games/cicd-stack-generator-impl.tsx
+++ b/components/games/cicd-stack-generator-impl.tsx
@@ -379,9 +379,9 @@ export default function CICDStackGenerator() {
 
   return (
     <div className="flex flex-col items-center w-full max-w-4xl mx-auto my-8">
-      <h1 className="text-3xl md:text-4xl font-bold mb-4 text-center text-primary">
+      <h2 className="text-3xl md:text-4xl font-bold mb-4 text-center text-primary">
         CI/CD Stack Generator
-      </h1>
+      </h2>
 
       <p className="text-center text-muted-foreground mb-8 max-w-2xl">
         Spin the wheels to get your perfect (or perfectly cursed) DevOps stack!

--- a/components/games/dbms-simulator.tsx
+++ b/components/games/dbms-simulator.tsx
@@ -322,9 +322,9 @@ export default function DbmsSimulator() {
               <Database className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               <span className="text-sm font-medium text-blue-700 dark:text-blue-300">Interactive Learning</span>
             </div>
-            <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-cyan-600 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent">
+            <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-cyan-600 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent">
               Database Management Systems
-            </h1>
+            </h2>
             <p className="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
               Learn about different types of databases, their use cases, and trade-offs through interactive exploration
             </p>

--- a/components/games/ddos-simulator.tsx
+++ b/components/games/ddos-simulator.tsx
@@ -587,9 +587,9 @@ export default function DDoSSimulator() {
             <div className="w-12 h-12 rounded-md bg-red-500 flex items-center justify-center">
               <Shield className="w-6 h-6 text-white" />
             </div>
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-primary">
+            <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-primary">
               DDoS Attack Simulator
-            </h1>
+            </h2>
           </div>
           <p className={cn(
             "text-lg max-w-2xl mx-auto mb-4",

--- a/components/games/devops-memes.tsx
+++ b/components/games/devops-memes.tsx
@@ -404,9 +404,9 @@ export default function DevOpsMemes() {
             </Badge>
           </div>
 
-          <h1 className="text-4xl md:text-6xl font-bold mb-4 bg-linear-to-r from-orange-600 via-red-600 to-pink-600 bg-clip-text text-transparent">
+          <h2 className="text-4xl md:text-6xl font-bold mb-4 bg-linear-to-r from-orange-600 via-red-600 to-pink-600 bg-clip-text text-transparent">
             🧪 You Might Be a DevOps Engineer If...
-          </h1>
+          </h2>
 
           <p className="text-lg text-muted-foreground max-w-3xl mx-auto leading-relaxed">
             Auto-generating hilarious (and painfully accurate) DevOps memes. Each click brings a new

--- a/components/games/fork-bomb-simulator.tsx
+++ b/components/games/fork-bomb-simulator.tsx
@@ -413,7 +413,7 @@ export default function ForkBombSimulator() {
       <div className="text-center space-y-2">
         <div className="flex items-center justify-center gap-2">
           <Zap className="w-6 h-6 text-red-500" />
-          <h1 className="text-2xl md:text-3xl font-bold">Fork Bomb Simulator</h1>
+          <h2 className="text-2xl md:text-3xl font-bold">Fork Bomb Simulator</h2>
           <Zap className="w-6 h-6 text-red-500" />
         </div>
         <p className="text-muted-foreground text-sm max-w-xl mx-auto">

--- a/components/games/game-seo-content.tsx
+++ b/components/games/game-seo-content.tsx
@@ -27,7 +27,7 @@ export function GameSeoContent({
     <>
       {/* Visually hidden but indexable by crawlers */}
       <div className="sr-only">
-        <h1>{title}</h1>
+        <h2>{title}</h2>
         <p>{description}</p>
         {category && <p>Category: {category}</p>}
         {learningPoints && learningPoints.length > 0 && (
@@ -48,7 +48,7 @@ export function GameSeoContent({
       {/* Fallback for users with JavaScript disabled */}
       <noscript>
         <div className="container mx-auto px-4 py-8">
-          <h1 className="text-3xl font-bold mb-4">{title}</h1>
+          <h2 className="text-3xl font-bold mb-4">{title}</h2>
           <p className="text-lg mb-4">{description}</p>
           {learningPoints && learningPoints.length > 0 && (
             <>

--- a/components/games/gitops-workflow.tsx
+++ b/components/games/gitops-workflow.tsx
@@ -387,7 +387,7 @@ export default function GitOpsWorkflow() {
             <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 mb-4">
               <GitBranch className="w-10 h-10 text-white" />
             </div>
-            <h1 className="text-4xl font-bold mb-4">GitOps Workflow Simulator</h1>
+            <h2 className="text-4xl font-bold mb-4">GitOps Workflow Simulator</h2>
             <p className="text-xl text-muted-foreground mb-8">
               Learn GitOps principles through interactive scenarios
             </p>
@@ -1060,7 +1060,7 @@ export default function GitOpsWorkflow() {
           <div className="inline-flex items-center justify-center w-24 h-24 rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 mb-6">
             <CheckCircle2 className="w-12 h-12 text-white" />
           </div>
-          <h1 className="text-4xl font-bold mb-4">Great Work!</h1>
+          <h2 className="text-4xl font-bold mb-4">Great Work!</h2>
           <p className="text-xl text-muted-foreground">
             You\'ve completed the GitOps Workflow Simulator
           </p>

--- a/components/games/infra-tarot.tsx
+++ b/components/games/infra-tarot.tsx
@@ -367,9 +367,9 @@ export default function InfraTarot() {
                 animate={{ scale: 1 }}
                 transition={{ delay: 0.2, duration: 0.5 }}
               >
-                <h1 className="text-5xl md:text-7xl font-bold text-primary">
+                <h2 className="text-5xl md:text-7xl font-bold text-primary">
                   Infra Tarot
-                </h1>
+                </h2>
               </motion.div>
               <motion.div
                 animate={{

--- a/components/games/linux-terminal.tsx
+++ b/components/games/linux-terminal.tsx
@@ -1359,7 +1359,7 @@ Swap:       2097152           0     2097152`;
       <div className="text-center mb-8">
         <div className="flex items-center justify-center gap-3 mb-4">
           <Terminal className="h-10 w-10 text-green-500" />
-          <h1 className="text-3xl md:text-4xl font-bold">Learn Linux</h1>
+          <h2 className="text-3xl md:text-4xl font-bold">Learn Linux</h2>
         </div>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
           Master essential Linux commands through interactive lessons.

--- a/components/games/packet-journey.tsx
+++ b/components/games/packet-journey.tsx
@@ -522,10 +522,10 @@ export default function PacketJourney() {
        {/* Header */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
-            <h1 className="text-4xl font-bold text-primary flex items-center gap-3">
+            <h2 className="text-4xl font-bold text-primary flex items-center gap-3">
               <Sparkles className="w-8 h-8 text-primary" />
               Network Packet Journey
-            </h1>
+            </h2>
             <p className={cn(
               "mt-2",
               isDark ? "text-slate-300" : "text-gray-600"

--- a/components/games/rate-limit-simulator.tsx
+++ b/components/games/rate-limit-simulator.tsx
@@ -413,9 +413,9 @@ export default function RateLimitSimulator() {
         animate={{ opacity: 1, y: 0 }}
         className="text-center space-y-4"
       >
-        <h1 className="text-4xl md:text-5xl font-bold text-primary">
+        <h2 className="text-4xl md:text-5xl font-bold text-primary">
           Rate Limit Simulator
-        </h1>
+        </h2>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
           Learn rate limiting, backoff strategies, and API throttling through interactive simulation
         </p>

--- a/components/games/scalable-sentry.tsx
+++ b/components/games/scalable-sentry.tsx
@@ -1269,7 +1269,7 @@ export default function ScalableSentry() {
               "absolute inset-0 flex flex-col items-center justify-center backdrop-blur-sm rounded-lg z-20",
               isDark ? "bg-slate-950/95" : "bg-white/95"
             )}>
-                <h1 className="text-5xl font-black text-primary mb-2">SCALABLE SENTRY</h1>
+                <h2 className="text-5xl font-black text-primary mb-2">SCALABLE SENTRY</h2>
                 <p className={cn(
                   "mb-8 tracking-widest uppercase text-sm",
                   isDark ? "text-slate-400" : "text-gray-600"
@@ -1306,7 +1306,7 @@ export default function ScalableSentry() {
         {gameState === 'gameover' && (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-red-950/90 backdrop-blur-md rounded-lg z-20">
                 <AlertTriangle size={64} className="text-red-500 mb-4" />
-                <h1 className="text-4xl font-bold text-white mb-2">SYSTEM CRITICAL</h1>
+                <h2 className="text-4xl font-bold text-white mb-2">SYSTEM CRITICAL</h2>
                 <p className="text-red-200 mb-2">503 Service Unavailable</p>
                 <p className="text-red-300 text-sm mb-6">
                   Processed: {stats.requestsProcessed} | Dropped: {stats.requestsDropped} | Wave: {stats.wave}

--- a/components/games/tcp-vs-udp.tsx
+++ b/components/games/tcp-vs-udp.tsx
@@ -417,9 +417,9 @@ export default function TcpVsUdpSimulator() {
         {/* Header */}
         <header className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-slate-700 pb-4">
           <div>
-            <h1 className="text-3xl font-bold text-primary">
+            <h2 className="text-3xl font-bold text-primary">
               Protocol Simulator
-            </h1>
+            </h2>
             <p className="text-slate-600 dark:text-slate-400 text-sm mt-1">
               Visualize the 3-Way Handshake and Reliability mechanisms.
             </p>

--- a/components/games/uptime-defender.tsx
+++ b/components/games/uptime-defender.tsx
@@ -422,9 +422,9 @@ export default function UptimeDefender() {
           animate={{ opacity: 1, y: 0 }}
           className="text-center"
         >
-          <h1 className="text-5xl font-bold mb-4 bg-linear-to-r from-green-500 to-emerald-600 bg-clip-text text-transparent">
+          <h2 className="text-5xl font-bold mb-4 bg-linear-to-r from-green-500 to-emerald-600 bg-clip-text text-transparent">
             Uptime Defender
-          </h1>
+          </h2>
           <p className="text-xl text-muted-foreground mb-8">
             Defend your infrastructure's uptime against incoming incidents!
           </p>
@@ -517,9 +517,9 @@ export default function UptimeDefender() {
           animate={{ opacity: 1, scale: 1 }}
           className="text-center"
         >
-          <h1 className="text-5xl font-bold mb-4">
+          <h2 className="text-5xl font-bold mb-4">
             {uptime > 0 ? '🎉 Mission Complete!' : '💥 System Down!'}
-          </h1>
+          </h2>
 
           {isNewHighScore && (
             <motion.div

--- a/components/interview-questions/interview-question-page.tsx
+++ b/components/interview-questions/interview-question-page.tsx
@@ -47,7 +47,7 @@ export function InterviewQuestionPage({ question, tier }: InterviewQuestionPageP
           </Badge>
           <Badge variant="outline">{question.category}</Badge>
         </div>
-        <h1 className="text-4xl font-bold mb-4">{question.title}</h1>
+        <h2 className="text-4xl font-bold mb-4">{question.title}</h2>
       </div>
 
       {/* Question */}

--- a/content/guides/security-gates/01-policy-as-code.md
+++ b/content/guides/security-gates/01-policy-as-code.md
@@ -3,8 +3,6 @@ title: 'Policy as Code'
 description: 'Write and enforce security policies using OPA, Kyverno, and Conftest. Automate policy validation in CI/CD and Kubernetes admission control.'
 ---
 
-# Policy as Code
-
 Policy as Code lets you define security requirements as code, version control them, and enforce them automatically. Instead of PDF documents that nobody reads, you write executable policies that block non-compliant changes.
 
 ## Why Policy as Code?

--- a/content/guides/security-gates/02-vulnerability-gates.md
+++ b/content/guides/security-gates/02-vulnerability-gates.md
@@ -3,8 +3,6 @@ title: "Vulnerability Gates"
 description: "Automated vulnerability scanning and threshold enforcement in CI/CD pipelines"
 ---
 
-# Vulnerability Gates
-
 Vulnerability gates automatically scan dependencies, container images, and code for known security vulnerabilities, blocking deployments when critical issues are detected.
 
 ## Overview

--- a/content/guides/security-gates/03-compliance-gates.md
+++ b/content/guides/security-gates/03-compliance-gates.md
@@ -3,8 +3,6 @@ title: "Compliance Gates"
 description: "Enforce regulatory requirements and security standards in CI/CD pipelines"
 ---
 
-# Compliance Gates
-
 Compliance gates ensure infrastructure and applications meet regulatory requirements (PCI-DSS, SOC 2, HIPAA, CIS Benchmarks) before deployment.
 
 ## Overview

--- a/content/guides/security-gates/04-cicd-integration.md
+++ b/content/guides/security-gates/04-cicd-integration.md
@@ -3,8 +3,6 @@ title: "CI/CD Integration"
 description: "Complete security gate orchestration across GitHub Actions, GitLab CI, and Jenkins"
 ---
 
-# CI/CD Integration
-
 Orchestrating multiple security gates in CI/CD pipelines requires careful sequencing, parallel execution, and failure handling to balance security with developer velocity.
 
 ## Complete Pipeline Architecture


### PR DESCRIPTION
Ahrefs flagged 118 URLs with multiple H1 tags. Auditing the templates showed three distinct duplication patterns:

| URLs | Pattern | Fix |
|---|---|---|
| 61 | `/interview-questions/[tier]/[slug]` — `PageHero` h1 + `InterviewQuestionPage` h1 | demote inner |
| 16 | `/games/[slug]` — `SimulatorShell` h1 + `GameSeoContent` h1s (sr-only and noscript) + per-game h1 | demote all but `SimulatorShell` |
| 17 | `/checklists/[slug]` — `PageHero` h1 + `ChecklistPageClient` h1 | demote inner |
| 18 | `/flashcards/[id]` — `PageHero` h1 + inline `<h1>` in the page render | demote inline |
| 4 | `/guides/security-gates/[part]` — page header h1 + redundant `# Title` at top of markdown | drop the markdown duplicate |
| 2 | `/posts/[slug]` and `/advent-of-devops` — could not reproduce statically; likely transient or Ahrefs cache; will check after the next crawl | — |

The convention this PR locks in:

- The layout/shell component (`PageHero`, `SimulatorShell`) is the single canonical H1.
- Everything else (game implementations, page-internal headers, markdown bodies) uses H2 or deeper.

## Files

- 16 components in `components/games/` demoted h1 -> h2 via `sed`. `SimulatorShell` keeps its h1.
- `components/games/game-seo-content.tsx` had two h1s (sr-only block + noscript fallback). Both demoted; SimulatorShell remains the canonical.
- `components/interview-questions/interview-question-page.tsx` h1 demoted.
- `components/checklists/checklist-page-client.tsx` h1 demoted.
- `app/flashcards/[id]/page.tsx` inline h1 demoted.
- `content/guides/security-gates/{01-04}*.md` had redundant `# Title` lines after the frontmatter. Removed because the part page renders `currentPart.title` as h1 already.

## Test plan

- [ ] `view-source:` on any flagged URL shows exactly one `<h1>`
- [ ] H1 reads correctly (the page title, not a sub-section)
- [ ] H2 hierarchy on sub-sections still semantically valid (no h2->h4 jumps caused by the demote)
- [ ] Visual rendering unchanged where the inner h1 was visible (Tailwind classes preserved on the new h2 element)