### PR TITLE
fix(seo): add related-content sections to boost internal links

### DIFF
--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Briefcase } from 'lucide-react';
 import { interviewQuestions, getQuestionBySlug } from '@/content/interview-questions';
@@ -87,6 +88,21 @@ export default async function QuestionPage({ params }: PageProps) {
 
   const capitalizedTier = tier.charAt(0).toUpperCase() + tier.slice(1);
 
+  // Related questions - same category, any tier (not just this one), excluding
+  // the current question. Sorted: same-tier first, then other tiers. Capped
+  // to 5 so the section stays readable but still gives crawlers and readers
+  // a meaningful set of next-step links.
+  const related = interviewQuestions
+    .filter(
+      (q) => q.category === question.category && q.slug !== question.slug,
+    )
+    .sort((a, b) => {
+      if (a.tier === tier && b.tier !== tier) return -1;
+      if (a.tier !== tier && b.tier === tier) return 1;
+      return a.title.localeCompare(b.title);
+    })
+    .slice(0, 5);
+
   return (
     <>
       <PageHero
@@ -100,6 +116,31 @@ export default async function QuestionPage({ params }: PageProps) {
         ]}
       />
       <InterviewQuestionPage question={question} tier={tier as ExperienceTier} />
+
+      {related.length > 0 && (
+        <section className="container mx-auto px-4 max-w-4xl pb-12">
+          <h2 className="text-xl font-semibold mb-4">
+            More {question.category} interview questions
+          </h2>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+            {related.map((q) => (
+              <li key={q.id}>
+                <Link
+                  href={`/interview-questions/${q.tier}/${q.slug}`}
+                  className="text-sm text-foreground hover:text-primary hover:underline"
+                >
+                  {q.title}
+                </Link>
+                {q.tier !== tier && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {q.tier}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </>
   );
 }

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { ReportIssue } from '@/components/report-issue';
 import { GiscusComments } from '@/components/giscus-comments';
 import { getSocialImagePath } from '@/lib/image-utils';
+import Link from 'next/link';
 
 import type { Metadata } from 'next';
 
@@ -85,6 +86,17 @@ export default async function NewsDigestPage({
   if (!digest) {
     notFound();
   }
+
+  // Sibling weeks. The list is sorted newest-first by getAllNews(), so the
+  // "next" week (chronologically) is at idx-1 and the "previous" week is at
+  // idx+1. Used for the prev/next nav at the bottom and the "Recent digests"
+  // sidebar list - both feed real internal links to weeks that previously
+  // had no inbound links beyond the /news index.
+  const all = await getAllNews();
+  const idx = all.findIndex((n) => n.slug === digest.slug);
+  const newer = idx > 0 ? all[idx - 1] : null;
+  const older = idx >= 0 && idx < all.length - 1 ? all[idx + 1] : null;
+  const recent = all.filter((n) => n.slug !== digest.slug).slice(0, 5);
 
   // Breadcrumb items for schema
   const breadcrumbItems = [
@@ -162,6 +174,37 @@ export default async function NewsDigestPage({
                 <ReportIssue type="news" slug={digest.slug} title={digest.title} />
               </div>
 
+              {/* Prev / next week nav. Gives every weekly digest an inbound
+                  internal link from at least its sibling weeks. */}
+              {(newer || older) && (
+                <nav className="mt-12 pt-8 border-t grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  {older ? (
+                    <Link
+                      href={`/news/${older.slug}`}
+                      className="rounded-lg border p-4 hover:bg-muted/40 transition-colors"
+                    >
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Previous digest
+                      </p>
+                      <p className="font-medium">{older.title}</p>
+                    </Link>
+                  ) : (
+                    <span />
+                  )}
+                  {newer && (
+                    <Link
+                      href={`/news/${newer.slug}`}
+                      className="rounded-lg border p-4 hover:bg-muted/40 transition-colors text-right sm:col-start-2"
+                    >
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Next digest
+                      </p>
+                      <p className="font-medium">{newer.title}</p>
+                    </Link>
+                  )}
+                </nav>
+              )}
+
               {/* Giscus Discussions */}
               <GiscusComments className="mt-12" title={digest.title} />
             </article>
@@ -171,6 +214,27 @@ export default async function NewsDigestPage({
           <aside className="lg:col-span-3">
             <div className="sticky top-8 space-y-6">
               <SponsorSidebar className="!relative !top-auto" />
+
+              {/* Recent digests - five most recent siblings, server-rendered
+                  so each week's links flow into the index even before the
+                  user scrolls. */}
+              {recent.length > 0 && (
+                <div className="bg-card border rounded-lg p-6">
+                  <h3 className="font-semibold mb-3">Recent digests</h3>
+                  <ul className="space-y-2">
+                    {recent.map((n) => (
+                      <li key={n.slug}>
+                        <Link
+                          href={`/news/${n.slug}`}
+                          className="text-sm text-foreground hover:text-primary hover:underline"
+                        >
+                          {n.title}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
               {/* Share Section */}
               <div className="bg-card border rounded-lg p-6">

--- a/components/games/simulator-shell.tsx
+++ b/components/games/simulator-shell.tsx
@@ -5,7 +5,7 @@ import { BreadcrumbSchema, SoftwareApplicationSchema } from '@/components/schema
 import { GameActions } from '@/components/games/game-actions';
 import { GameSponsors } from '@/components/games/game-sponsors';
 import { CarbonAds } from '@/components/carbon-ads';
-import { getGameById } from '@/lib/games';
+import { getGameById, getActiveGames } from '@/lib/games';
 import { cn } from '@/lib/utils';
 
 interface SimulatorShellProps {
@@ -56,6 +56,20 @@ export async function SimulatorShell({
   const href = game?.href ?? `/games/${slug}`;
   const category = game?.category ?? 'DevOps Simulator';
   const tags = game?.tags;
+
+  // Pick up to 3 related games. Same category first, then fall back to any
+  // active game so even niche categories have a "try next" list. Excludes
+  // the current game and anything coming-soon.
+  const allGames = await getActiveGames();
+  const sameCategory = game?.category
+    ? allGames.filter(
+        (g) => g.id !== slug && g.category === game.category,
+      )
+    : [];
+  const otherGames = allGames.filter(
+    (g) => g.id !== slug && !sameCategory.includes(g),
+  );
+  const relatedGames = [...sameCategory, ...otherGames].slice(0, 3);
 
   const shareUrl = `https://devops-daily.com${href}`;
   const defaultShareText = shareText ?? `Check out ${title} on DevOps Daily`;
@@ -111,6 +125,33 @@ export async function SimulatorShell({
           {educational && (
             <section className="w-full my-10 rounded-md border bg-muted/20 p-6">
               {educational}
+            </section>
+          )}
+
+          {/* Try next - related games. Server-rendered so each game has
+              real internal inlinks from at least 3 sibling games (was 1
+              link, from /games index, before this section existed). */}
+          {relatedGames.length > 0 && (
+            <section className="w-full my-10">
+              <h2 className="text-lg font-semibold mb-4">Try next</h2>
+              <ul className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                {relatedGames.map((g) => (
+                  <li key={g.id}>
+                    <Link
+                      href={g.href}
+                      className="block rounded-lg border p-4 hover:border-primary/50 hover:bg-muted/30 transition-colors"
+                    >
+                      <p className="text-xs text-muted-foreground font-mono mb-2">
+                        {g.type === 'simulator' ? '// simulator' : '// game'}
+                      </p>
+                      <p className="font-medium mb-1">{g.title}</p>
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {g.description}
+                      </p>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </section>
           )}
 

--- a/content/advent-of-devops/day-21.md
+++ b/content/advent-of-devops/day-21.md
@@ -216,7 +216,7 @@ Please read `docs/CONTRIBUTING.md` in the repo for details on our code of conduc
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the `LICENSE` file in the repo for details.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Ahrefs flagged 137 URLs with only one dofollow inbound internal link. Most sit under detail templates that previously linked back to the index page only — no sibling-to-sibling discovery. This PR adds three natural cross-link sections targeting the largest groups (102 of 137 URLs).

## What changed

### 1. Interview question slug page (60 URLs)

New "More {category} interview questions" section below the question body. Picks 5 sibling questions from the same category, same-tier first then other tiers, so a junior reader sees 5 directly relevant follow-ups instead of having to bounce back to the tier list.

### 2. News slug page (23 URLs)

- Prev/next weekly nav at the bottom of each article. Every week now has an inbound link from the next week and one from the previous week.
- "Recent digests" sidebar block (last 5 weeks).

Combined, every weekly digest gets ~5-7 fresh inlinks from sibling weeks.

### 3. `SimulatorShell` (19 game URLs, propagates to all 38 games)

New "Try next" section above the CarbonAds slot with 3 related games. Same-category games first, then any active game so even niche categories have a list. Renders inside the shared shell so every game picks it up without per-game edits.

## Drive-by

- `content/advent-of-devops/day-21.md` had a stray `[LICENSE](LICENSE)` link that I missed in the earlier 404-cleanup pass. Replaced with backtick text matching the other repo-file references on the page (consistent with `[CONTRIBUTING.md]` etc. that I already cleaned up).

## Not in this PR

- `/quizzes/*` (12 URLs): the page already has a `RelatedQuizzes` section. The remaining flags are likely Ahrefs-cache or quizzes with too few same-category siblings. Will re-check after re-crawl.
- `/checklists`, `/flashcards`, `/exercises` (4-6 URLs each): same pattern, low volume, can extend in a follow-up.
- `/newsletters/*` (4 URLs): can add prev/next to the newsletter slug page in a follow-up.
- `/roadmaps/*`, `/tools/*`, `/books` (singletons): can land in a small follow-up.

Bigger pattern: the SEO health is fundamentally limited by the lack of cross-type linking. We should build an opinionated `RelatedContent` component that, given a category + tags, surfaces the strongest cross-type matches (a quiz next to a guide on the same topic, a checklist next to a post). Worth a separate PR if the SEO numbers move enough on this batch.

## Test plan

- [ ] `/interview-questions/junior/bash-scripting-basics`: scroll to the bottom — section lists up to 5 sibling questions in the same category
- [ ] `/news/2026-week-17`: prev/next nav at the bottom links to weeks 16 and 18 (or whichever exist), sidebar shows the 5 most recent
- [ ] Any `/games/*` page: "Try next" section above ads shows 3 related games
- [ ] Visual regression: existing layouts unchanged on flashcards / checklists / quizzes since they aren't touched by this PR
- [ ] No broken markdown links in `content/advent-of-devops/day-21.md`