### PR TITLE
fix(embed): apply theme query param to game embeds

### DIFF
--- a/app/games/[slug]/embed/embed-client.tsx
+++ b/app/games/[slug]/embed/embed-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSearchParams, usePathname } from 'next/navigation';
+import { useTheme } from 'next-themes';
 import { EmbedBadge } from '@/components/embed';
 import { Suspense, useEffect } from 'react';
 
@@ -15,9 +16,24 @@ function EmbedContent({ slug, title, GameComponent }: EmbedClientProps) {
   const theme = searchParams.get('theme') || 'dark';
   const hideTitle = searchParams.get('hideTitle') === 'true';
   const pathname = usePathname();
+  const { setTheme } = useTheme();
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://devops-daily.com';
   const gameUrl = `${siteUrl}/games/${slug}`;
+
+  // Apply the embed's theme via next-themes so the host site's iframe
+  // renders in light/dark regardless of the visitor's system preference.
+  // theme=auto falls back to whatever the user has - same as the regular
+  // site behaviour. The previous `data-theme={theme}` attribute had no
+  // effect because the app uses Tailwind's class-strategy theming, which
+  // requires `class="dark"` on <html>, not a data attribute.
+  useEffect(() => {
+    if (theme === 'light' || theme === 'dark') {
+      setTheme(theme);
+    } else {
+      setTheme('system');
+    }
+  }, [theme, setTheme]);
 
   // Hide header/footer when in embed mode
   useEffect(() => {


### PR DESCRIPTION
## Problem

The embed URL accepts `?theme=light|dark|auto`, but `light` and `dark` had no effect — the iframe always rendered in whatever mode the visitor's system was set to.

## Root cause

`embed-client.tsx` was reading the param and setting it as `data-theme={theme}` on a wrapper div. The app uses Tailwind's class-strategy dark mode through `next-themes`, which means a theme switch requires `class="dark"` on `<html>`, not a data attribute. The data attribute was effectively dead code.

`embed-layout.tsx` (the other code path, used by `?embed=true` on regular game pages) already wraps content in `<ThemeProvider attribute="class" defaultTheme={theme}>` and works correctly. The two embed code paths had drifted.

## Fix

In `embed-client.tsx`, call `setTheme()` from `next-themes` in a `useEffect` based on the query param:

- `theme=light` / `theme=dark` → force that mode regardless of the visitor's system preference (desired for embeds: every viewer sees the same look)
- `theme=auto` or no param → fall back to `system`, matching the regular site

The `hideTitle` param already works (it's a conditional render of the title bar). The preview iframe inside the embed modal loads the same embed URL and picks up the theme fix automatically — no modal-side changes needed.

## Test plan

- [ ] Open `/games/{any}/embed?theme=light` in a browser whose system theme is dark — embed renders light
- [ ] Same URL with `?theme=dark` — embed renders dark
- [ ] Same URL with `?theme=auto` or no theme — follows system preference
- [ ] Same URL with `?hideTitle=true` — top header bar is hidden, badge still renders
- [ ] Open the "Embed" modal on any game page, switch the theme dropdown, confirm the live iframe preview reflects the new theme