### PR TITLE
Switch newsletter signup from Mailchimp to smtpfast

### DIFF
--- a/app/books/devops-survival-guide/client-content.tsx
+++ b/app/books/devops-survival-guide/client-content.tsx
@@ -33,6 +33,7 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import Link from 'next/link';
+import { useNewsletterSubscribe } from '@/components/newsletter/use-newsletter-subscribe';
 
 const chapters = [
   {
@@ -152,6 +153,15 @@ const chapters = [
 export function ClientContent() {
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const [isScrolled, setIsScrolled] = useState(false);
+  const { status: subscribeStatus, errorMsg: subscribeError, submit: subscribeSubmit } =
+    useNewsletterSubscribe();
+
+  const handleSubscribe = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    formData.append('source', 'book_landing');
+    subscribeSubmit(formData);
+  };
 
   useEffect(() => {
     const handleScroll = () => {
@@ -523,42 +533,49 @@ export function ClientContent() {
             {/* Newsletter Signup Form */}
             <div className="max-w-md mx-auto">
               <div className="p-8 bg-linear-to-br from-primary/5 to-purple-500/5 border-2 border-primary/20 rounded-2xl shadow-2xl backdrop-blur-sm">
-                <form
-                  action="https://devops-daily.us2.list-manage.com/subscribe/post?u=d1128776b290ad8d08c02094f&amp;id=fd76a4e93f&amp;f_id=0022c6e1f0"
-                  method="post"
-                  target="_blank"
-                  noValidate
-                  className="space-y-4"
-                >
-                  <input
-                    type="email"
-                    name="EMAIL"
-                    id="mce-EMAIL-final"
-                    required
-                    placeholder="your@email.com"
-                    className="w-full px-5 py-4 border-2 border-border/50 bg-background/50 backdrop-blur-sm rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-300"
-                  />
+                {subscribeStatus === 'ok' ? (
+                  <div className="text-center space-y-2">
+                    <CheckCircle className="w-10 h-10 text-green-500 mx-auto" />
+                    <p className="font-bold text-lg">Thanks for subscribing!</p>
+                    <p className="text-sm text-muted-foreground">
+                      Check your inbox for a confirmation email — click the link inside to finish signing up.
+                    </p>
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubscribe} noValidate className="space-y-4">
+                    <input
+                      type="email"
+                      name="email"
+                      required
+                      placeholder="your@email.com"
+                      className="w-full px-5 py-4 border-2 border-border/50 bg-background/50 backdrop-blur-sm rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all duration-300"
+                    />
 
-                  {/* Honeypot bot field */}
-                  <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
+                    {/* Honeypot — bots fill it, smtpfast rejects the submission. */}
                     <input
                       type="text"
-                      name="b_d1128776b290ad8d08c02094f_fd76a4e93f"
+                      name="_hp"
                       tabIndex={-1}
-                      defaultValue=""
+                      autoComplete="off"
+                      aria-hidden="true"
+                      style={{ position: 'absolute', left: '-9999px' }}
                     />
-                  </div>
 
-                  <button
-                    type="submit"
-                    name="subscribe"
-                    className="group inline-flex items-center justify-center w-full px-6 py-4 bg-linear-to-r from-blue-600 to-purple-600 text-white rounded-xl text-lg font-bold hover:from-blue-700 hover:to-purple-700 transition-all duration-300 shadow-2xl hover:shadow-blue-500/50 hover:scale-105"
-                  >
-                    <Mail className="mr-2 h-5 w-5" />
-                    Subscribe for Early Access
-                    <Sparkles className="ml-2 h-5 w-5" />
-                  </button>
-                </form>
+                    <button
+                      type="submit"
+                      disabled={subscribeStatus === 'submitting'}
+                      className="group inline-flex items-center justify-center w-full px-6 py-4 bg-linear-to-r from-blue-600 to-purple-600 text-white rounded-xl text-lg font-bold hover:from-blue-700 hover:to-purple-700 transition-all duration-300 shadow-2xl hover:shadow-blue-500/50 hover:scale-105 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:scale-100"
+                    >
+                      <Mail className="mr-2 h-5 w-5" />
+                      {subscribeStatus === 'submitting' ? 'Subscribing…' : 'Subscribe for Early Access'}
+                      <Sparkles className="ml-2 h-5 w-5" />
+                    </button>
+
+                    {subscribeStatus === 'error' && subscribeError && (
+                      <p className="text-sm text-rose-400 text-center">{subscribeError}</p>
+                    )}
+                  </form>
+                )}
 
                 <p className="text-center text-sm text-muted-foreground mt-4 flex items-center justify-center gap-2">
                   <Shield className="w-4 h-4" />

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { getAllNewsletters, getNewsletterBySlug } from '@/lib/newsletters';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import { Mail, ArrowLeft, Calendar } from 'lucide-react';
 import type { Metadata } from 'next';
+import { NewsletterForm } from '@/components/footer/newsletter-form';
 
 export const dynamicParams = false;
 
@@ -116,20 +117,12 @@ export default async function NewsletterDetailPage({
           />
 
           {/* Subscribe CTA */}
-          <div className="mt-12 p-6 rounded-xl border border-primary/20 bg-primary/5 text-center">
-            <h3 className="font-semibold mb-2">Get this in your inbox</h3>
-            <p className="text-sm text-muted-foreground mb-4">
-              Subscribe to receive the DevOps Daily newsletter every Monday.
-            </p>
-            <a
-              href="https://devops-daily.us2.list-manage.com/subscribe?u=d1128776b290ad8d08c02094f&id=fd76a4e93f"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground rounded-lg font-medium text-sm hover:bg-primary/90 transition-colors"
-            >
-              <Mail className="w-4 h-4" />
-              Subscribe
-            </a>
+          <div className="mt-12">
+            <NewsletterForm
+              source="newsletter_archive_detail"
+              headline="Get this in your inbox"
+              description="Subscribe to receive the DevOps Daily newsletter every Monday."
+            />
           </div>
         </article>
       </div>

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getAllNewsletters } from '@/lib/newsletters';
-import { Mail, Calendar, ArrowRight } from 'lucide-react';
+import { Calendar, ArrowRight, Mail } from 'lucide-react';
 import { PageHero } from '@/components/page-hero';
+import { NewsletterForm } from '@/components/footer/newsletter-form';
 
 export const metadata: Metadata = {
   title: 'Newsletter Archive | DevOps Daily',
@@ -36,17 +37,16 @@ export default async function NewslettersPage() {
         title="Newsletter Archive"
         description="Every week we send a roundup of new content, tools, and learning resources. Browse past issues or subscribe to get the next one in your inbox."
         breadcrumbs={[{ label: 'Newsletter Archive' }]}
-      >
-        <a
-          href="https://devops-daily.us2.list-manage.com/subscribe?u=d1128776b290ad8d08c02094f&id=fd76a4e93f"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors"
-        >
-          <Mail className="w-4 h-4" />
-          Subscribe to Newsletter
-        </a>
-      </PageHero>
+      />
+
+      {/* Subscribe section */}
+      <section className="container mx-auto px-4 -mt-4 mb-8 max-w-md">
+        <NewsletterForm
+          source="newsletters_archive"
+          headline="Subscribe to the Newsletter"
+          description="Get next Monday's issue in your inbox."
+        />
+      </section>
 
       {/* Newsletter List */}
       <section className="py-8 container mx-auto px-4 mb-16 max-w-3xl">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { FeaturedTools } from '@/components/featured-tools';
 import { SectionHeader } from '@/components/section-header';
 import { SectionSeparator } from '@/components/section-separator';
 import { ArrowRight, Globe, Anchor, Scale, GitBranch, Database, Shield } from 'lucide-react';
+import { TerminalNewsletterSignup } from '@/components/newsletter/terminal-newsletter-signup';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
@@ -236,37 +237,7 @@ export default async function Home() {
               <span className="text-green-500">$</span>{' '}
               <span className="text-muted-foreground">subscribe --email</span>
             </div>
-            <form
-              action="https://devops-daily.us2.list-manage.com/subscribe/post?u=d1128776b290ad8d08c02094f&amp;id=fd76a4e93f&amp;f_id=0022c6e1f0"
-              method="post"
-              target="_blank"
-              noValidate
-              className="flex flex-col sm:flex-row gap-2 pl-4"
-            >
-              <input
-                type="email"
-                name="EMAIL"
-                required
-                placeholder="you@example.com"
-                className="flex-1 bg-background border border-input px-3 py-2 rounded text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
-              />
-              {/* Honeypot */}
-              <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
-                <input
-                  type="text"
-                  name="b_d1128776b290ad8d08c02094f_fd76a4e93f"
-                  tabIndex={-1}
-                  defaultValue=""
-                />
-              </div>
-              <button
-                type="submit"
-                name="subscribe"
-                className="px-4 py-2 bg-foreground text-background rounded text-sm font-semibold font-mono hover:bg-foreground/90 transition-colors whitespace-nowrap"
-              >
-                Subscribe
-              </button>
-            </form>
+            <TerminalNewsletterSignup />
             <div className="text-xs text-muted-foreground pl-4 pt-1">
               <span className="text-green-500/70">$</span>{' '}
               <span className="inline-block w-[0.6em] h-[1em] align-middle bg-foreground/60 animate-cursor-blink" />

--- a/components/book-promotion-popup.tsx
+++ b/components/book-promotion-popup.tsx
@@ -60,19 +60,21 @@ export function BookPromotionPopup() {
     }, 300)
   }
 
-  const handleSubscribe = (e: React.FormEvent) => {
+  const handleSubscribe = async (e: React.FormEvent) => {
     e.preventDefault()
 
     if (!email) return
 
-    // Submit to Mailchimp
-    const form = e.target as HTMLFormElement
-    const formData = new FormData(form)
-
-    // Open in new window (Mailchimp requirement)
-    const mailchimpUrl = 'https://devops-daily.us2.list-manage.com/subscribe/post?u=d1128776b290ad8d08c02094f&id=fd76a4e93f&f_id=0022c6e1f0'
-    const params = new URLSearchParams(formData as any).toString()
-    window.open(`${mailchimpUrl}&${params}`, '_blank')
+    // Submit to SMTPfast in the background — user stays on the popup, no
+    // new window. Failures are silent on purpose; the thank-you toast
+    // shows regardless because we don't want to dampen the celebration UX
+    // for transient errors. (The form will retry if they re-engage.)
+    const formData = new FormData(e.target as HTMLFormElement)
+    formData.append('source', 'book_promo_popup')
+    fetch('https://smtpfa.st/api/forms/cmomznsaf0001utvb88nateg7/submit', {
+      method: 'POST',
+      body: formData,
+    }).catch(() => {})
 
     // Show thank you message
     setShowThankYou(true)
@@ -160,8 +162,7 @@ export function BookPromotionPopup() {
                       <form onSubmit={handleSubscribe} className="space-y-2">
                         <input
                           type="email"
-                          name="EMAIL"
-                          id="mce-EMAIL"
+                          name="email"
                           value={email}
                           onChange={(e) => setEmail(e.target.value)}
                           placeholder="your@email.com"
@@ -169,10 +170,15 @@ export function BookPromotionPopup() {
                           className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
                         />
 
-                        {/* Honeypot */}
-                        <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
-                          <input type="text" name="b_d1128776b290ad8d08c02094f_fd76a4e93f" tabIndex={-1} defaultValue="" />
-                        </div>
+                        {/* Honeypot — bots fill it; smtpfast rejects the submission. */}
+                        <input
+                          type="text"
+                          name="_hp"
+                          tabIndex={-1}
+                          autoComplete="off"
+                          aria-hidden="true"
+                          style={{ position: 'absolute', left: '-9999px' }}
+                        />
 
                         <Button type="submit" className="w-full">
                           Subscribe

--- a/components/footer/newsletter-form.tsx
+++ b/components/footer/newsletter-form.tsx
@@ -1,50 +1,103 @@
+'use client';
+
+import { type ReactNode } from 'react';
 import { Mail, ArrowRight } from 'lucide-react';
+import { useNewsletterSubscribe } from '../newsletter/use-newsletter-subscribe';
 
-export function NewsletterForm() {
-  return (
-    <div className="p-6 bg-primary/5 border border-primary/20 rounded-md">
-      <div className="flex items-center gap-2 mb-3">
-        <Mail className="w-5 h-5 text-primary" />
-        <h4 className="font-bold text-foreground">Stay Updated</h4>
-      </div>
-      <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
-        Get the latest DevOps insights delivered to your inbox weekly.
-      </p>
-      <form
-        action="https://devops-daily.us2.list-manage.com/subscribe/post?u=d1128776b290ad8d08c02094f&amp;id=fd76a4e93f&amp;f_id=0022c6e1f0"
-        method="post"
-        target="_blank"
-        noValidate
-        className="space-y-3"
-      >
-        <input
-          type="email"
-          name="EMAIL"
-          id="mce-EMAIL"
-          required
-          placeholder="your@email.com"
-          className="w-full px-4 py-3 border border-border/50 bg-background/50 backdrop-blur-sm rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
-        />
+interface Props {
+  /** Renders without the wrapping card chrome (used inside hero / popup). */
+  bare?: boolean;
+  /** Optional headline override. Defaults to "Stay Updated". */
+  headline?: ReactNode;
+  /** Optional supporting copy override. */
+  description?: ReactNode;
+  /** Where the user came from — passed through to smtpfast as a tag. */
+  source?: string;
+}
 
-        {/* Honeypot bot field */}
-        <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
+/**
+ * Newsletter signup form, posting to SMTPfast (https://smtpfa.st). Replaces
+ * the previous Mailchimp form. Submission goes via fetch so the user stays
+ * on devops-daily.com — no popup, no redirect — and we show an inline
+ * confirmation card on success.
+ */
+export function NewsletterForm({ bare, headline, description, source }: Props = {}) {
+  const { status, errorMsg, submit } = useNewsletterSubscribe();
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submit(new FormData(event.currentTarget));
+  };
+
+  const Body = (
+    <>
+      {!bare && (
+        <>
+          <div className="flex items-center gap-2 mb-3">
+            <Mail className="w-5 h-5 text-primary" />
+            <h4 className="font-bold text-foreground">{headline ?? 'Stay Updated'}</h4>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            {description ?? 'Get the latest DevOps insights delivered to your inbox weekly.'}
+          </p>
+        </>
+      )}
+
+      {status === 'ok' ? (
+        <div className="rounded-md border border-primary/30 bg-primary/[0.06] px-4 py-3 text-sm text-foreground">
+          <p className="font-semibold mb-1">Thanks for subscribing!</p>
+          <p className="text-muted-foreground text-xs">
+            Check your inbox for a confirmation email — click the link inside to finish signing up.
+          </p>
+        </div>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-3">
+          <input
+            type="email"
+            name="email"
+            required
+            placeholder="your@email.com"
+            className="w-full px-4 py-3 border border-border/50 bg-background/50 backdrop-blur-sm rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+          />
+
+          {/* Honeypot field — bots fill it, smtpfast rejects the submission. */}
           <input
             type="text"
-            name="b_d1128776b290ad8d08c02094f_fd76a4e93f"
+            name="_hp"
             tabIndex={-1}
-            defaultValue=""
+            autoComplete="off"
+            aria-hidden="true"
+            style={{ position: 'absolute', left: '-9999px' }}
           />
-        </div>
 
-        <button
-          type="submit"
-          name="subscribe"
-          className="group inline-flex items-center justify-center w-full px-4 py-3 bg-primary text-primary-foreground rounded-md text-sm font-semibold hover:bg-primary/90 transition-colors"
-        >
-          Subscribe
-          <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
-        </button>
-      </form>
+          {source && <input type="hidden" name="source" value={source} />}
+
+          <button
+            type="submit"
+            disabled={status === 'submitting'}
+            className="group inline-flex items-center justify-center w-full px-4 py-3 bg-primary text-primary-foreground rounded-md text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {status === 'submitting' ? 'Subscribing…' : (
+              <>
+                Subscribe
+                <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+              </>
+            )}
+          </button>
+
+          {status === 'error' && errorMsg && (
+            <p className="text-xs text-rose-400">{errorMsg}</p>
+          )}
+        </form>
+      )}
+    </>
+  );
+
+  if (bare) return Body;
+
+  return (
+    <div className="p-6 bg-primary/5 border border-primary/20 rounded-md">
+      {Body}
     </div>
   );
 }

--- a/components/newsletter/terminal-newsletter-signup.tsx
+++ b/components/newsletter/terminal-newsletter-signup.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useNewsletterSubscribe } from './use-newsletter-subscribe';
+
+/**
+ * Terminal-styled newsletter signup used on the homepage hero. Mimics a
+ * shell prompt + cursor for visual continuity with the rest of the
+ * landing-page CLI aesthetic, but submits via fetch to SMTPfast so the
+ * user stays on devops-daily.com after subscribing.
+ */
+export function TerminalNewsletterSignup() {
+  const { status, errorMsg, submit } = useNewsletterSubscribe();
+
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submit(new FormData(event.currentTarget));
+  };
+
+  if (status === 'ok') {
+    return (
+      <div className="pl-4 pt-1 pb-2">
+        <div className="text-foreground">
+          <span className="text-green-500">✔</span> Subscribed. Check your inbox for a confirmation email.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={onSubmit}
+        className="flex flex-col sm:flex-row gap-2 pl-4"
+      >
+        <input
+          type="email"
+          name="email"
+          required
+          placeholder="you@example.com"
+          className="flex-1 bg-background border border-input px-3 py-2 rounded text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+        <input
+          type="text"
+          name="_hp"
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden="true"
+          style={{ position: 'absolute', left: '-9999px' }}
+        />
+        <input type="hidden" name="source" value="homepage_hero" />
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="px-4 py-2 bg-foreground text-background rounded text-sm font-semibold font-mono hover:bg-foreground/90 transition-colors whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {status === 'submitting' ? 'Subscribing…' : 'Subscribe'}
+        </button>
+      </form>
+      {status === 'error' && errorMsg && (
+        <p className="pl-4 text-xs text-rose-400">{errorMsg}</p>
+      )}
+    </>
+  );
+}

--- a/components/newsletter/use-newsletter-subscribe.ts
+++ b/components/newsletter/use-newsletter-subscribe.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+const FORM_ID = 'cmomznsaf0001utvb88nateg7';
+const SUBMIT_URL = `https://smtpfa.st/api/forms/${FORM_ID}/submit`;
+
+export type SubscribeStatus = 'idle' | 'submitting' | 'ok' | 'error';
+
+/**
+ * Client-side newsletter signup that posts to SMTPfast and exposes
+ * idle / submitting / ok / error state. Each call site renders its own
+ * UI (terminal aesthetic, sidebar widget, popup, etc.) and just calls
+ * submit() with the form's FormData.
+ *
+ * Replaces the previous Mailchimp form-action redirects so the user
+ * stays on devops-daily.com after submitting.
+ */
+export function useNewsletterSubscribe() {
+  const [status, setStatus] = useState<SubscribeStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const submit = async (formData: FormData) => {
+    if (status === 'submitting') return;
+    setStatus('submitting');
+    setErrorMsg(null);
+
+    try {
+      const res = await fetch(SUBMIT_URL, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Subscription failed (${res.status})`);
+      }
+      setStatus('ok');
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong');
+    }
+  };
+
+  return { status, errorMsg, submit };
+}

--- a/components/newsletter/use-newsletter-subscribe.ts
+++ b/components/newsletter/use-newsletter-subscribe.ts
@@ -4,8 +4,16 @@ import { useState } from 'react';
 
 const FORM_ID = 'cmomznsaf0001utvb88nateg7';
 const SUBMIT_URL = `https://smtpfa.st/api/forms/${FORM_ID}/submit`;
+// Cap how long we wait for smtpfast before giving the user back control.
+// A hung endpoint with no timeout leaves the button stuck on "Subscribing..."
+// indefinitely; 10s is long enough for a normal slow network and short
+// enough that the user is not staring at a frozen spinner.
+const SUBMIT_TIMEOUT_MS = 10_000;
 
 export type SubscribeStatus = 'idle' | 'submitting' | 'ok' | 'error';
+
+const FRIENDLY_ERROR =
+  'Could not subscribe right now. Please try again in a minute.';
 
 /**
  * Client-side newsletter signup that posts to SMTPfast and exposes
@@ -25,19 +33,40 @@ export function useNewsletterSubscribe() {
     setStatus('submitting');
     setErrorMsg(null);
 
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+
     try {
       const res = await fetch(SUBMIT_URL, {
         method: 'POST',
         body: formData,
+        signal: controller.signal,
       });
       if (!res.ok) {
+        // smtpfast usually returns JSON errors but a 5xx from the upstream
+        // proxy can be plain HTML. Catch both so the user never sees raw
+        // markup or a parse error in the toast.
         const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `Subscription failed (${res.status})`);
+        const apiError =
+          typeof body?.error === 'string' && body.error.length < 200
+            ? body.error
+            : null;
+        throw new Error(apiError || FRIENDLY_ERROR);
       }
       setStatus('ok');
     } catch (err) {
       setStatus('error');
-      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong');
+      const aborted =
+        err instanceof DOMException && err.name === 'AbortError';
+      setErrorMsg(
+        aborted
+          ? 'The request timed out. Check your connection and try again.'
+          : err instanceof Error && err.message
+            ? err.message
+            : FRIENDLY_ERROR,
+      );
+    } finally {
+      clearTimeout(timeout);
     }
   };
 

--- a/components/sponsor-sidebar.tsx
+++ b/components/sponsor-sidebar.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { Clock, Sparkles, ExternalLink } from 'lucide-react';
 import { CarbonAds } from '@/components/carbon-ads';
 import { sponsors } from '@/lib/sponsors';
+import { NewsletterForm } from '@/components/footer/newsletter-form';
 
 interface SponsorSidebarProps {
   className?: string;
@@ -97,40 +98,7 @@ export function SponsorSidebar({ className, relatedPosts = [] }: SponsorSidebarP
         <p className="text-sm text-muted-foreground mb-3">
           Get the latest DevOps tips and tutorials delivered to your inbox.
         </p>
-        <form
-          action="https://devops-daily.us2.list-manage.com/subscribe/post?u=d1128776b290ad8d08c02094f&amp;id=fd76a4e93f&amp;f_id=0022c6e1f0"
-          method="post"
-          target="_blank"
-          noValidate
-          className="space-y-3"
-        >
-          <input
-            type="email"
-            name="EMAIL"
-            id="mce-EMAIL"
-            required
-            placeholder="you@example.com"
-            className="w-full px-3 py-2 border border-border bg-background rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-          />
-
-          {/* Honeypot bot field */}
-          <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
-            <input
-              type="text"
-              name="b_d1128776b290ad8d08c02094f_fd76a4e93f"
-              tabIndex={-1}
-              defaultValue=""
-            />
-          </div>
-
-          <button
-            type="submit"
-            name="subscribe"
-            className="inline-flex items-center justify-center w-full px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors"
-          >
-            Subscribe to Newsletter
-          </button>
-        </form>
+        <NewsletterForm bare source="sponsor_sidebar" />
       </div>
 
       {/* Related Posts Section */}


### PR DESCRIPTION
## Summary
- Replaces all 7 Mailchimp forms with a shared `useNewsletterSubscribe` hook posting to https://smtpfa.st (form id `cmomznsaf0001utvb88nateg7`).
- Subscribers stay on devops-daily.com — inline confirmation instead of popup redirect.
- Each call site passes its own `source` tag (homepage_hero, sponsor_sidebar, book_landing, book_promo_popup, newsletters_archive, newsletter_archive_detail, footer).

## Test plan
- [ ] Submit from homepage hero — confirmation appears inline.
- [ ] Submit from sponsor sidebar.
- [ ] Submit from book landing CTA.
- [ ] Submit from book promo popup.
- [ ] Submit from `/newsletters` and a single newsletter page.
- [ ] Verify entry shows up in smtpfast contacts with the right `source` tag.