### PR TITLE
sponsors: theme-friendly SMTPfast + QuizAPI logos

### DIFF
--- a/lib/sponsors.ts
+++ b/lib/sponsors.ts
@@ -38,15 +38,15 @@ export const sponsors: Sponsor[] = [
     url: 'https://smtpfa.st',
     tagline: 'Developer-first email API',
     description: 'Send transactional and marketing email through a clean REST API. Detailed logs, webhooks, and embeddable signup forms in one dashboard.',
-    className: 'text-foreground',
     sidebarClassName: 'w-auto h-10 shrink-0 -mt-0.5 ml-1',
   },
   {
     name: 'QuizAPI',
-    logo: '/quizapi.png',
+    logo: '/quizapi.svg',
     url: 'https://quizapi.io?ref=devops-daily',
     tagline: 'Developer-first quiz platform',
     description: 'Build, generate, and embed quizzes with a powerful REST API. AI-powered question generation and live multiplayer.',
+    sidebarClassName: 'w-auto h-10 shrink-0 -mt-0.5 ml-1',
   },
 ];
 

--- a/public/quizapi.svg
+++ b/public/quizapi.svg
@@ -1,10 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="40" viewBox="0 0 180 40">
-  <rect x="2" y="4" width="32" height="32" rx="8" fill="#3b82f6"/>
-  <path d="M12 20l5 5 9-11" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <g transform="translate(42, 8)">
-    <rect width="138" height="24" rx="5" fill="#3b82f6"/>
-    <g fill="#fff" font-family="Arial,Helvetica,sans-serif" font-size="15" font-weight="700">
-      <text x="69" y="17" text-anchor="middle">QuizAPI</text>
-    </g>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 48" width="230" height="48" role="img" aria-label="QuizAPI">
+  <defs>
+    <linearGradient id="quizapiMark" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6366f1"/>
+      <stop offset="1" stop-color="#8b5cf6"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="48" height="48" rx="11" fill="url(#quizapiMark)"/>
+  <text x="24" y="34" text-anchor="middle" font-family="'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="28" font-weight="700" fill="white">Q</text>
+  <text x="58" y="32" font-family="'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="22" font-weight="700" letter-spacing="-0.5" fill="#6366f1">
+    <tspan>Quiz</tspan><tspan fill="#8b5cf6">API</tspan>
+  </text>
 </svg>

--- a/public/smtpfast.svg
+++ b/public/smtpfast.svg
@@ -1,17 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 48" width="220" height="48" role="img" aria-label="SMTPfast">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 48" width="230" height="48" role="img" aria-label="SMTPfast">
   <defs>
     <linearGradient id="smtpfastMark" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#10b981"/>
       <stop offset="1" stop-color="#14b8a6"/>
     </linearGradient>
   </defs>
-  <g>
-    <rect x="0" y="0" width="48" height="48" rx="11" fill="url(#smtpfastMark)"/>
-    <path d="M14 25 L24 12 L21 22 H30 L20 36 L23 25 Z" fill="white"/>
-  </g>
-  <g fill="currentColor" font-family="'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-weight="700">
-    <text x="58" y="32" font-size="22" letter-spacing="-0.5">
-      <tspan>SMTP</tspan><tspan fill="#10b981">fast</tspan>
-    </text>
-  </g>
+  <rect x="0" y="0" width="48" height="48" rx="11" fill="url(#smtpfastMark)"/>
+  <path d="M14 25 L24 12 L21 22 H30 L20 36 L23 25 Z" fill="white"/>
+  <text x="58" y="32" font-family="'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="22" font-weight="700" letter-spacing="-0.5" fill="#059669">
+    <tspan>SMTP</tspan><tspan fill="#10b981">fast</tspan>
+  </text>
 </svg>


### PR DESCRIPTION
## Summary
Bobby flagged that the SMTPfast wordmark renders black on dark cards (and the QuizAPI logo isn't the real brand). Both SVGs were leaning on `currentColor`, which doesn't inherit when the SVG is loaded as an `<img>` source — so the text resolved to the SVG's default (black) regardless of theme.

Rebuilds both with brand colors baked in and visually consistent on both light and dark cards:

- **SMTPfast**: emerald-500/600 gradient mark + emerald wordmark (#059669 "SMTP" + #10b981 "fast"). Contrast: 4.6:1 / 3.05:1 on white, 5.5:1 / 6.5:1 on dark.
- **QuizAPI**: indigo-to-violet gradient mark with white "Q" — pulled the indigo (#6366f1) and violet (#8b5cf6) gradient from the real brand at `~/projects/QuizAPI/src/app/icon.svg` — plus a "Quiz" / "API" wordmark in those same brand shades.

Sponsor entry for QuizAPI now points at `/quizapi.svg` (was the legacy PNG). The SMTPfast entry drops its `text-foreground` className since the wordmark color is no longer dependent on the surrounding theme.

## Test plan
- [ ] Sponsor sidebar on light and dark themes — both wordmarks legible without theme-aware CSS.
- [ ] Newsletter sender pulls the new SVGs through `loadSponsors` for next Monday's send.