### PR TITLE
SEO: rewrite short meta descriptions, fix sitemap, drop duplicate H1s

### DIFF
--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -5,7 +5,8 @@ import { getAllCategories } from '@/lib/categories';
 
 export const metadata = {
   title: 'Categories',
-  description: 'Browse all DevOps categories',
+  description:
+    'Browse DevOps Daily content by category: Docker, Kubernetes, AWS, Git, Terraform, Linux, security, CI/CD, networking, and more, with posts and guides linked.',
   alternates: {
     canonical: '/categories',
   },

--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -21,7 +21,7 @@ import * as Icons from 'lucide-react'
 export const metadata: Metadata = {
   title: 'DevOps Flashcards',
   description:
-    'Interactive flashcards to learn and retain DevOps concepts, tools, and best practices.',
+    'Interactive DevOps flashcards covering Kubernetes, Docker, Terraform, Git, Linux, and CI/CD. Useful for interview prep, certification study, and daily practice.',
   alternates: {
     canonical: '/flashcards',
   },

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -6,7 +6,8 @@ import { getAllGuides } from '@/lib/guides';
 
 export const metadata = {
   title: 'Guides',
-  description: 'In-depth guides for DevOps professionals',
+  description:
+    'In-depth DevOps guides covering Docker, Kubernetes, AWS, Git, Terraform, Linux, Bash, Postgres, networking, security, and CI/CD, each split into chapters.',
   alternates: {
     canonical: '/guides',
   },

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -27,9 +27,16 @@ export async function generateMetadata({
     .then((fs) => fs.access(`${process.cwd()}/public${ogImage}`).then(() => true).catch(() => false));
   const image = ogExists ? ogImage : '/og-image.png';
 
+  // Prefer a per-issue description from the newsletter's frontmatter so each
+  // page has its own, distinct meta description (Bing flagged the previous
+  // shared template as too short / duplicated across issues).
+  const description =
+    newsletter.description ||
+    `DevOps Daily Newsletter - Week ${newsletter.week}, ${newsletter.year}. Weekly roundup of new content and learning resources.`;
+
   return {
     title: { absolute: newsletter.title },
-    description: `DevOps Daily Newsletter - Week ${newsletter.week}, ${newsletter.year}. Weekly roundup of new content and learning resources.`,
+    description,
     alternates: { canonical: `/newsletters/${slug}` },
     openGraph: {
       title: newsletter.title,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -4,13 +4,13 @@ import { SearchPageClient } from '@/components/search-page-client';
 
 export const metadata: Metadata = {
   title: 'Search | DevOps Daily',
-  description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
+  description: 'Search across DevOps Daily posts, guides, quizzes, games, flashcards, comparisons, and tools to find content on Docker, Kubernetes, AWS, CI/CD, and more.',
   alternates: {
     canonical: '/search',
   },
   openGraph: {
     title: 'Search | DevOps Daily',
-    description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
+    description: 'Search across DevOps Daily posts, guides, quizzes, games, flashcards, comparisons, and tools to find content on Docker, Kubernetes, AWS, CI/CD, and more.',
     type: 'website',
     url: '/search',
     images: [
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Search | DevOps Daily',
-    description: 'Search across all DevOps Daily content - posts, guides, quizzes, games, and more.',
+    description: 'Search across DevOps Daily posts, guides, quizzes, games, flashcards, comparisons, and tools to find content on Docker, Kubernetes, AWS, CI/CD, and more.',
     images: ['/og-image.png'],
   },
 };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,6 +13,7 @@ import { getAllAdventDays } from '@/lib/advent';
 import { getAllComparisons } from '@/lib/comparisons';
 import { getAllNewsletters } from '@/lib/newsletters';
 import { getAllHacktoberfestDays } from '@/lib/hacktoberfest';
+import { TOOLS } from '@/lib/tools';
 
 export const dynamic = 'force-static';
 
@@ -89,6 +90,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${baseUrl}/toolbox`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/tools`,
       lastModified: new Date(),
       changeFrequency: 'weekly' as const,
       priority: 0.7,
@@ -223,6 +230,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
+  // Tool routes (each tool has its own static page under /tools/<slug>)
+  const toolRoutes = TOOLS.map((tool) => ({
+    url: `${baseUrl}/tools/${tool.slug}`,
+    lastModified: new Date(),
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
   // Static content pages
   const contentPages = [
     '/about',
@@ -267,6 +282,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...hacktoberfestRoutes,
     ...comparisonRoutes,
     ...newsletterRoutes,
+    ...toolRoutes,
     ...contentPages,
   ];
 }

--- a/components/checklists/checklist-page-client.tsx
+++ b/components/checklists/checklist-page-client.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Clock, BarChart3, Tag } from 'lucide-react';
+import { ArrowLeft, Tag } from 'lucide-react';
 import Confetti from 'react-confetti';
 import { Checklist } from '@/lib/checklist-utils';
 import { ChecklistItemComponent } from '@/components/checklists/checklist-item';
@@ -83,8 +83,12 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
         Back to all checklists
       </Link>
 
+      {/* Title + description + estimated-time stats live in <PageHero>; we keep
+          only the richer category/difficulty/tag badges here so the page does
+          not render the same heading twice (Bing's SEO scanner flagged this
+          duplication as multiple H1s). */}
       <div className="mb-8">
-        <div className="flex flex-wrap items-center gap-2 mb-4">
+        <div className="flex flex-wrap items-center gap-2">
           <span className={`text-sm px-3 py-1 rounded-full font-semibold print:bg-gray-100 print:text-gray-900 ${
             categoryColors[checklist.category as keyof typeof categoryColors] || 'bg-gray-100 text-gray-700'
           }`}>
@@ -95,24 +99,6 @@ export function ChecklistPageClient({ checklist }: ChecklistPageClientProps) {
           }`}>
             {checklist.difficulty.charAt(0).toUpperCase() + checklist.difficulty.slice(1)}
           </span>
-        </div>
-
-        <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-          {checklist.title}
-        </h2>
-        <p className="text-lg text-gray-600 dark:text-gray-400 mb-4">
-          {checklist.description}
-        </p>
-
-        <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
-          <div className="flex items-center gap-1">
-            <Clock className="w-4 h-4" />
-            {checklist.estimatedTime}
-          </div>
-          <div className="flex items-center gap-1">
-            <BarChart3 className="w-4 h-4" />
-            {checklist.items.length} items
-          </div>
         </div>
 
         {checklist.tags.length > 0 && (

--- a/components/interview-questions/interview-question-page.tsx
+++ b/components/interview-questions/interview-question-page.tsx
@@ -38,16 +38,15 @@ export function InterviewQuestionPage({ question, tier }: InterviewQuestionPageP
         </Button>
       </div>
 
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex flex-wrap gap-2 mb-4">
-          <Badge className={tierColors[tier]}>{tier}</Badge>
-          <Badge className={difficultyColors[question.difficulty as keyof typeof difficultyColors]}>
-            {question.difficulty}
-          </Badge>
-          <Badge variant="outline">{question.category}</Badge>
-        </div>
-        <h2 className="text-4xl font-bold mb-4">{question.title}</h2>
+      {/* Title lives in <PageHero>; we keep only the badge row here so the
+          title does not render twice (Bing's SEO scanner counted the
+          large-text duplicate as a second H1). */}
+      <div className="mb-8 flex flex-wrap gap-2">
+        <Badge className={tierColors[tier]}>{tier}</Badge>
+        <Badge className={difficultyColors[question.difficulty as keyof typeof difficultyColors]}>
+          {question.difficulty}
+        </Badge>
+        <Badge variant="outline">{question.category}</Badge>
       </div>
 
       {/* Question */}

--- a/content/categories/docker.md
+++ b/content/categories/docker.md
@@ -1,8 +1,8 @@
 ---
 name: 'Docker'
 slug: 'docker'
-description: 'Containerization platform'
-longDescription: 'Learn containerization with Docker. From creating images to orchestrating containers, learn how to package and run applications consistently.'
+description: 'Docker articles, tutorials, and guides on DevOps Daily covering containers, images, Dockerfiles, Compose, volumes, networking, and production best practices.'
+longDescription: 'Docker articles, tutorials, and guides on DevOps Daily covering containers, images, Dockerfiles, Compose, volumes, networking, and production best practices.'
 icon: 'Container'
 color: 'bg-blue-500/10 text-blue-500'
 ---

--- a/content/comparisons/bitbucket-pipelines-vs-github-actions.json
+++ b/content/comparisons/bitbucket-pipelines-vs-github-actions.json
@@ -2,7 +2,7 @@
   "id": "bitbucket-pipelines-vs-github-actions",
   "slug": "bitbucket-pipelines-vs-github-actions",
   "title": "Bitbucket Pipelines vs GitHub Actions",
-  "description": "A focused comparison of Bitbucket Pipelines and GitHub Actions as CI/CD platforms. Covers YAML syntax, runner types, marketplace, pricing, build minutes, and workflow capabilities to help you choose the right CI/CD tool.",
+  "description": "Bitbucket Pipelines vs GitHub Actions compared as CI/CD platforms: YAML syntax, runner types, marketplace size, pricing, build minutes, and workflow features.",
   "category": "CI/CD",
   "tags": [
     "Bitbucket Pipelines",

--- a/content/guides/introduction-to-aws/01-account-setup.md
+++ b/content/guides/introduction-to-aws/01-account-setup.md
@@ -1,6 +1,6 @@
 ---
 title: 'Getting Started with Your AWS Account'
-description: 'Set up your AWS account, understand the console, and learn to navigate AWS like a pro.'
+description: 'Create your first AWS account and learn to find your way around the console without getting lost. Covers signup, billing alerts, root account safety, and regions.'
 order: 1
 ---
 

--- a/content/guides/introduction-to-aws/06-rds-databases.md
+++ b/content/guides/introduction-to-aws/06-rds-databases.md
@@ -1,6 +1,6 @@
 ---
 title: 'RDS - Managed Database Services'
-description: 'Set up reliable, scalable databases without the complexity of database administration.'
+description: 'Run MySQL, PostgreSQL, or SQL Server on AWS RDS without managing servers. Covers backups, patching, scaling, Multi-AZ failover, and choosing an instance class.'
 order: 6
 ---
 

--- a/content/guides/introduction-to-aws/index.md
+++ b/content/guides/introduction-to-aws/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Introduction to AWS'
-description: 'Learn AWS fundamentals step by step, from basic concepts to building your first cloud application.'
+description: 'Learn AWS step by step by building a real cloud application. Covers IAM, EC2, S3, VPC, RDS, load balancing, Lambda, CloudWatch, and cost control.'
 category:
   name: 'AWS'
   slug: 'aws'

--- a/content/guides/introduction-to-bash/10-bash-best-practices.md
+++ b/content/guides/introduction-to-bash/10-bash-best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: 'Bash Best Practices'
-description: 'Learn essential best practices for writing clean, maintainable, and robust Bash scripts'
+description: 'Bash scripting best practices for reliable scripts. Covers shebangs, set -euo pipefail, quoting, error handling, functions, and structuring larger scripts.'
 order: 10
 ---
 

--- a/content/guides/introduction-to-bash/index.md
+++ b/content/guides/introduction-to-bash/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Introduction to Bash'
-description: 'A guide to learning the basics of Bash scripting and command line usage.'
+description: 'Bash scripting and command line guide covering navigation, variables, control flow, functions, permissions, arguments, and best practices in 10 chapters.'
 category:
   name: 'Bash'
   slug: 'bash'

--- a/content/guides/introduction-to-docker/02-docker-installation.md
+++ b/content/guides/introduction-to-docker/02-docker-installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Docker
-description: Set up Docker on your system and verify it's working correctly
+description: 'Install Docker on Ubuntu, macOS, and Windows step by step. Covers repository setup, Docker Desktop, verifying the install, and required post-install tasks.'
 order: 2
 ---
 

--- a/content/guides/introduction-to-docker/04-creating-your-first-container.md
+++ b/content/guides/introduction-to-docker/04-creating-your-first-container.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Your First Container
-description: Learn how to run, manage, and interact with Docker containers
+description: 'Run your first Docker container and learn the commands that matter. Covers docker run, exec, logs, stop, ports, detached mode, and inspecting container state.'
 order: 4
 ---
 

--- a/content/guides/introduction-to-docker/05-building-custom-docker-images.md
+++ b/content/guides/introduction-to-docker/05-building-custom-docker-images.md
@@ -1,6 +1,6 @@
 ---
 title: Building Custom Docker Images
-description: Create your own Docker images with Dockerfiles to package your applications
+description: 'Build custom Docker images with Dockerfiles. Covers FROM, COPY, RUN, CMD, ENTRYPOINT, layer caching, multi-stage builds, and shrinking final image size.'
 order: 5
 ---
 

--- a/content/guides/introduction-to-docker/index.md
+++ b/content/guides/introduction-to-docker/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Docker
-description: Learn how to use Docker to build, ship, and run applications efficiently through containerization
+description: 'Beginner-friendly Docker guide covering containers, images, Dockerfiles, volumes, networking, Compose, and production best practices in 10 chapters.'
 category:
   name: Docker
   slug: docker

--- a/content/guides/introduction-to-git/01-fundamentals.md
+++ b/content/guides/introduction-to-git/01-fundamentals.md
@@ -1,7 +1,7 @@
 ---
 title: 'Understanding Git Fundamentals'
 order: 1
-description: 'Learn the core concepts of Git, how it works, and set up your environment'
+description: 'Git fundamentals explained: distributed version control, the working tree, staging area, and repository, plus the three file states and your first config.'
 ---
 
 Git is a distributed version control system that helps you track changes in your code, collaborate with others, and maintain a history of your project. Whether you're working alone or as part of a team, Git provides powerful tools to manage your codebase efficiently.

--- a/content/guides/introduction-to-git/04-branching.md
+++ b/content/guides/introduction-to-git/04-branching.md
@@ -1,7 +1,7 @@
 ---
 title: 'Branching Basics'
 order: 4
-description: 'Learn how to create and manage branches for parallel development'
+description: 'Create and manage Git branches for parallel development. Covers git branch, checkout, switch, isolating features, and the mental model behind branch pointers.'
 ---
 
 One of Git's most powerful features is its branching system. Branches allow you to diverge from the main line of development and work on different features or fixes in isolation, without affecting the main codebase.

--- a/content/guides/introduction-to-git/09-best-practices.md
+++ b/content/guides/introduction-to-git/09-best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: 'Git Best Practices'
 order: 9
-description: 'Adopt workflow standards and conventions for efficient Git usage'
+description: 'Git best practices for daily work: meaningful commit messages, branching strategy, .gitignore hygiene, code review flow, and keeping history clean over time.'
 ---
 
 While Git is flexible enough to accommodate many workflows, following established best practices will help you avoid common pitfalls and work more efficiently. This section outlines recommended practices for commits, branching, collaboration, and repository management.

--- a/content/guides/introduction-to-git/index.md
+++ b/content/guides/introduction-to-git/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Introduction to Git'
-description: 'A guide to understanding and learning Git version control'
+description: 'A 10-part guide to Git version control covering repos, branching, merging, remotes, collaboration workflows, history rewriting, and team best practices.'
 category:
   name: 'Git'
   slug: 'git'

--- a/content/guides/introduction-to-kubernetes/01-kubernetes-architecture-and-components.md
+++ b/content/guides/introduction-to-kubernetes/01-kubernetes-architecture-and-components.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Architecture and Components
-description: Understand the foundational architecture and key components that make up a Kubernetes cluster
+description: 'Kubernetes architecture explained: control plane parts (API server, etcd, scheduler, controller manager) and worker node pieces (kubelet, kube-proxy, runtime).'
 order: 1
 ---
 

--- a/content/guides/introduction-to-linux/01-understanding-linux-basics.md
+++ b/content/guides/introduction-to-linux/01-understanding-linux-basics.md
@@ -1,6 +1,6 @@
 ---
 title: 'Understanding Linux Basics'
-description: 'Learn what Linux is, its history, the philosophy behind it, and the ecosystem of distributions.'
+description: 'What Linux actually is: the kernel, distributions, the open-source philosophy, and a short history from Unix to today. Picks a distro that fits your goals.'
 order: 1
 ---
 

--- a/content/guides/introduction-to-linux/03-command-line-interface.md
+++ b/content/guides/introduction-to-linux/03-command-line-interface.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Linux Command Line Interface'
-description: 'Learn essential terminal commands and gain confidence working with the Linux command line.'
+description: 'Essential Linux terminal commands for getting comfortable on the command line. Covers ls, cd, cp, mv, grep, pipes, redirection, and reading man pages.'
 order: 3
 ---
 

--- a/content/guides/introduction-to-linux/05-package-management.md
+++ b/content/guides/introduction-to-linux/05-package-management.md
@@ -1,6 +1,6 @@
 ---
 title: 'Package Management'
-description: 'Learn how to install, update, and remove software on Linux using different package managers.'
+description: 'Install, update, and remove software on Linux with apt, dnf, pacman, and zypper. Covers repositories, dependencies, search, and keeping systems patched.'
 order: 5
 ---
 

--- a/content/guides/introduction-to-linux/08-networking.md
+++ b/content/guides/introduction-to-linux/08-networking.md
@@ -1,6 +1,6 @@
 ---
 title: 'Networking in Linux'
-description: 'Learn how to configure, monitor, and troubleshoot networks on Linux systems.'
+description: 'Configure and troubleshoot Linux networking with ip, ss, ping, traceroute, and dig. Covers interfaces, routing tables, DNS, and diagnosing connectivity issues.'
 order: 8
 ---
 

--- a/content/guides/introduction-to-packer/01-packer-fundamentals.md
+++ b/content/guides/introduction-to-packer/01-packer-fundamentals.md
@@ -1,6 +1,6 @@
 ---
 title: Understanding Packer Fundamentals
-description: Learn the core concepts behind Packer and how it automates machine image creation
+description: 'How Packer builds machine images. Covers builders, provisioners, post-processors, the workflow Packer automates, and why templates produce repeatable images.'
 order: 1
 ---
 

--- a/content/guides/introduction-to-packer/02-installation-and-setup.md
+++ b/content/guides/introduction-to-packer/02-installation-and-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Installation and Setup
-description: Install Packer and configure your environment for building machine images
+description: 'Install Packer on macOS, Linux, and Windows, set up your PATH, and configure cloud or local builder credentials. Verify the install with packer version.'
 order: 2
 ---
 

--- a/content/guides/introduction-to-packer/05-provisioners-in-depth.md
+++ b/content/guides/introduction-to-packer/05-provisioners-in-depth.md
@@ -1,6 +1,6 @@
 ---
 title: Provisioners in Depth
-description: Master Packer provisioners to customize your machine images
+description: 'Customize Packer images with provisioners. Covers shell, file, and Ansible provisioners, execution order, and targeting specific builders during the build.'
 order: 5
 ---
 

--- a/content/guides/introduction-to-packer/06-variables-and-best-practices.md
+++ b/content/guides/introduction-to-packer/06-variables-and-best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: Variables and Best Practices
-description: Learn how to use variables effectively and structure Packer projects for production
+description: 'Use Packer variables and project structure for production. Covers variable types, defaults, var-files, runtime overrides, directory layout, and image testing.'
 order: 6
 ---
 

--- a/content/guides/introduction-to-postgres/01-database-fundamentals.md
+++ b/content/guides/introduction-to-postgres/01-database-fundamentals.md
@@ -1,6 +1,6 @@
 ---
 title: Understanding Database Fundamentals
-description: Learn what databases are, why relational databases matter, and how they organize data
+description: 'Database fundamentals for developers: what relational databases solve, how tables, rows, and columns map to your data, and why integrity and ACID matter.'
 order: 1
 ---
 

--- a/content/guides/networking-fundamentals/01-network-fundamentals-and-protocols.md
+++ b/content/guides/networking-fundamentals/01-network-fundamentals-and-protocols.md
@@ -1,6 +1,6 @@
 ---
 title: 'Network Fundamentals and Protocols'
-description: 'Understanding how applications communicate over networks and the protocols that make it possible.'
+description: 'How applications talk over networks: the OSI model, TCP vs UDP, IP addressing, ports, and DNS resolution explained with traceable curl and tcpdump examples.'
 order: 1
 ---
 

--- a/content/guides/security-gates/02-vulnerability-gates.md
+++ b/content/guides/security-gates/02-vulnerability-gates.md
@@ -1,6 +1,6 @@
 ---
 title: "Vulnerability Gates"
-description: "Automated vulnerability scanning and threshold enforcement in CI/CD pipelines"
+description: "Vulnerability gates in CI/CD pipelines: scanning dependencies and container images, setting CVE severity thresholds, and blocking deploys when criticals appear."
 ---
 
 Vulnerability gates automatically scan dependencies, container images, and code for known security vulnerabilities, blocking deployments when critical issues are detected.

--- a/content/newsletters/2026-week-14.md
+++ b/content/newsletters/2026-week-14.md
@@ -1,5 +1,6 @@
 ---
 title: "DevOps Daily Newsletter - Week 14, 2026"
+description: "DevOps Daily Week 14, 2026 newsletter: Claude Code source leak via npm source maps, Axios supply chain attack lessons, Linux labs, and CI/CD comparisons."
 date: "2026-04-02"
 week: 14
 year: 2026

--- a/content/newsletters/2026-week-15.md
+++ b/content/newsletters/2026-week-15.md
@@ -1,5 +1,6 @@
 ---
 title: "DevOps Daily Newsletter - Week 15, 2026"
+description: "DevOps Daily Week 15, 2026 newsletter: Argo CD vs Flux GitOps comparison, a hands-on Kubernetes security checklist, and new posts to level up your skills."
 date: "2026-04-07"
 week: 15
 year: 2026

--- a/content/newsletters/2026-week-16.md
+++ b/content/newsletters/2026-week-16.md
@@ -1,5 +1,6 @@
 ---
 title: "DevOps Daily Newsletter - Week 16, 2026"
+description: "DevOps Daily Week 16, 2026 newsletter: best Claude Code plugins for DevOps, Argo CD vs Flux deep dive, and fresh content for Terraform, K8s, and CI/CD work."
 date: "2026-04-13"
 week: 16
 year: 2026

--- a/content/newsletters/2026-week-17.md
+++ b/content/newsletters/2026-week-17.md
@@ -1,5 +1,6 @@
 ---
 title: "DevOps Daily Newsletter - Week 17, 2026"
+description: "DevOps Daily Week 17, 2026 newsletter: caching strategies simulator, Kubernetes scheduler challenge, fresh quizzes, and evergreen DevOps reads worth revisiting."
 date: "2026-04-19"
 week: 17
 year: 2026

--- a/content/posts/conditional-attributes-in-terraform.md
+++ b/content/posts/conditional-attributes-in-terraform.md
@@ -1,6 +1,6 @@
 ---
 title: 'Conditional Attributes in Terraform'
-excerpt: 'Learn how to use conditional expressions to dynamically set resource attributes in Terraform.'
+excerpt: 'Set Terraform resource attributes conditionally with the ternary operator. Covers syntax, dynamic blocks, and switching values per environment cleanly.'
 category:
   name: 'Terraform'
   slug: 'terraform'

--- a/content/posts/copy-directory-using-add-command.md
+++ b/content/posts/copy-directory-using-add-command.md
@@ -1,6 +1,6 @@
 ---
 title: 'Copy Directory to Another Directory Using ADD Command'
-excerpt: 'Learn how to use the `ADD` command in Docker to copy directories during image builds.'
+excerpt: 'Copy directories into a Docker image with the ADD instruction. Covers ADD vs COPY, local paths, remote URLs, tar extraction, and practical Dockerfile examples.'
 category:
   name: 'Docker'
   slug: 'docker'

--- a/content/posts/docker-compose-wait-container.md
+++ b/content/posts/docker-compose-wait-container.md
@@ -1,6 +1,6 @@
 ---
 title: 'Docker Compose: Wait for Container X Before Starting Y'
-excerpt: 'Learn how to configure Docker Compose to ensure one container starts only after another is ready.'
+excerpt: 'Configure Docker Compose so a service waits for another container to be ready, using healthchecks and depends_on conditions with a working example.'
 category:
   name: 'Docker'
   slug: 'docker'

--- a/content/posts/how-to-delete-all-resources-from-kubernetes-one-time.md
+++ b/content/posts/how-to-delete-all-resources-from-kubernetes-one-time.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Delete All Resources from Kubernetes at One Time'
-excerpt: 'Learn how to delete all resources in a Kubernetes namespace or cluster using kubectl commands.'
+excerpt: 'Delete every resource in a Kubernetes namespace or whole cluster with kubectl. Covers kubectl delete all, namespace deletion, and cleaning up CRDs safely.'
 category:
   name: 'Kubernetes'
   slug: 'kubernetes'

--- a/content/posts/ps-command-not-working-docker.md
+++ b/content/posts/ps-command-not-working-docker.md
@@ -1,6 +1,6 @@
 ---
 title: "ps Command Doesn't Work in Docker Container"
-excerpt: 'Learn why the `ps` command might not work in Docker containers and how to resolve it.'
+excerpt: 'Why the ps command fails inside Docker containers and how to fix it. Covers minimal images missing procps, alternatives like /proc, and installing the package.'
 category:
   name: 'Docker'
   slug: 'docker'

--- a/content/posts/reference-resource-terraform-module.md
+++ b/content/posts/reference-resource-terraform-module.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Reference a Resource Created by a Terraform Module'
-excerpt: 'Learn how to reference resources created by a Terraform module in your configurations.'
+excerpt: 'Reference resources created inside a Terraform module from the parent config. Covers defining outputs, accessing module outputs by name, and chaining modules.'
 category:
   name: 'Terraform'
   slug: 'terraform'

--- a/content/posts/variable-keys-in-terraform-maps.md
+++ b/content/posts/variable-keys-in-terraform-maps.md
@@ -1,6 +1,6 @@
 ---
 title: 'Variable Keys in Terraform Maps'
-excerpt: 'Learn how to use variable keys in Terraform maps to create dynamic and flexible configurations.'
+excerpt: 'Use variable keys in Terraform maps to build dynamic, reusable configurations. Covers map syntax, dynamic lookups, and merging values across environments.'
 category:
   name: 'Terraform'
   slug: 'terraform'

--- a/content/quizzes/cicd-pipelines-quiz.json
+++ b/content/quizzes/cicd-pipelines-quiz.json
@@ -1,7 +1,7 @@
 {
   "id": "cicd-pipelines-quiz",
   "title": "CI/CD Pipelines Quiz",
-  "description": "Master continuous integration and deployment with practical pipeline scenarios and best practices",
+  "description": "Test your CI/CD pipeline knowledge with scenarios covering build stages, artifact promotion, environment strategy, deployment patterns, and rollbacks.",
   "category": "CI/CD",
   "icon": "Code",
   "totalPoints": 110,

--- a/content/quizzes/docker-quiz.json
+++ b/content/quizzes/docker-quiz.json
@@ -1,7 +1,7 @@
 {
   "id": "docker-quiz",
   "title": "Docker Fundamentals Quiz",
-  "description": "Test your knowledge of Docker containers, images, and orchestration concepts",
+  "description": "Test your Docker knowledge with questions on containers, images, Dockerfile instructions, volumes, networks, Compose, and basic orchestration concepts.",
   "category": "Docker",
   "icon": "Code",
   "totalPoints": 85,

--- a/content/quizzes/git-quiz.json
+++ b/content/quizzes/git-quiz.json
@@ -1,7 +1,7 @@
 {
   "id": "git-quiz",
   "title": "Git Command Quiz",
-  "description": "Learn Git through real-world scenarios and understand the commands that matter",
+  "description": "Test your Git command knowledge with real-world scenarios covering commits, branching, merging, rebasing, remotes, and recovering from common mistakes.",
   "category": "Git",
   "icon": "GitBranch",
   "totalPoints": 115,

--- a/content/quizzes/jenkins-quiz.json
+++ b/content/quizzes/jenkins-quiz.json
@@ -1,7 +1,7 @@
 {
   "id": "jenkins-quiz",
   "title": "Jenkins CI/CD Pipeline Quiz",
-  "description": "Master Jenkins pipelines, Groovy scripting, plugin ecosystem, and CI/CD automation",
+  "description": "Test your Jenkins skills with questions on declarative and scripted pipelines, Groovy syntax, agents, plugins, shared libraries, and CI/CD automation patterns.",
   "category": "CI/CD",
   "icon": "Workflow",
   "totalPoints": 228,

--- a/content/quizzes/system-design-quiz.json
+++ b/content/quizzes/system-design-quiz.json
@@ -1,7 +1,7 @@
 {
   "id": "system-design-quiz",
   "title": "System Design Fundamentals Quiz",
-  "description": "Master scalable architecture patterns and distributed systems design with real-world scenarios",
+  "description": "Test your system design skills with questions on load balancing, caching, sharding, replication, queues, consistency models, and distributed system tradeoffs.",
   "category": "System Design",
   "icon": "Code",
   "totalPoints": 118,

--- a/lib/newsletters.ts
+++ b/lib/newsletters.ts
@@ -9,6 +9,10 @@ const NEWSLETTERS_DIR = path.join(process.cwd(), 'content', 'newsletters');
 export interface Newsletter {
   slug: string;
   title: string;
+  /** Optional per-newsletter description used as the page meta description.
+   *  Falls back to a generic templated string in app/newsletters/[slug] when
+   *  not set in the markdown frontmatter. */
+  description?: string;
   date: string;
   week: number;
   year: number;
@@ -18,6 +22,7 @@ export interface Newsletter {
 export interface NewsletterMeta {
   slug: string;
   title: string;
+  description?: string;
   date: string;
   week: number;
   year: number;
@@ -52,6 +57,7 @@ async function loadNewsletters(): Promise<Newsletter[]> {
         newsletters.push({
           slug,
           title: data.title || `Newsletter ${slug}`,
+          description: typeof data.description === 'string' ? data.description : undefined,
           date: data.date || '',
           week: data.week || 0,
           year: data.year || 0,

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -38,7 +38,7 @@ export const TOOLS: Tool[] = [
     title: 'CIDR Subnet Calculator',
     shortTitle: 'CIDR Calculator',
     description:
-      'Calculate network range, usable IP count, subnet mask, and broadcast address from a CIDR block.',
+      'CIDR subnet calculator: parse a CIDR block to get network range, subnet mask, broadcast address, usable IPs, and check whether an IP belongs to the network.',
     tagline: 'Parse CIDR blocks, compute ranges, split into smaller subnets, and check whether an IP lives inside a network.',
     icon: Network,
     keywords: ['cidr', 'subnet', 'ip', 'vpc', 'networking', 'calculator'],
@@ -72,7 +72,7 @@ export const TOOLS: Tool[] = [
     title: 'JWT Decoder',
     shortTitle: 'JWT Decoder',
     description:
-      'Paste a JWT and see the header, payload, and signature, plus human-readable expiry and issued-at.',
+      'JWT decoder that parses the header, payload, and signature in your browser. Shows human-readable expiry and issued-at, with no token sent to any server.',
     tagline: 'Inspect any JWT in your browser. Nothing is sent to a server.',
     icon: KeyRound,
     keywords: ['jwt', 'json web token', 'decode', 'oauth', 'security'],
@@ -162,7 +162,7 @@ export const TOOLS: Tool[] = [
     title: 'Cron Expression Parser',
     shortTitle: 'Cron Parser',
     description:
-      'Translate cron expressions to human-readable schedules and preview the next run times.',
+      'Cron expression parser that translates schedules into plain English and previews the next 5 run times in your local timezone. Validates 5 and 6-field syntax.',
     tagline: 'Decode cron expressions with the next 5 run times, in your local timezone.',
     icon: Clock,
     keywords: ['cron', 'crontab', 'schedule', 'kubernetes cronjob'],


### PR DESCRIPTION
Fixes the three Bing recommendations:

1. **50 short meta descriptions** rewritten to 145-160 chars (flagged in `devops-daily.com_FailingUrls_5_3_2026.csv`). Covers 7 posts, 22 guides/chapters, 5 quizzes, 1 comparison, 4 newsletters, 3 tools, 4 index pages, and `/categories/docker`. No em dashes, no AI words, content-accurate.

2. **Sitemap missing tools**: `/tools`, `/tools/cidr-calculator`, `/tools/k8s-resources` (and the rest) were absent. Now rendered from `lib/tools.ts` so adding a new tool ships into the sitemap automatically.

3. **Multiple H1 tags** on `/checklists/high-availability`, `/interview-questions/mid/cicd-blue-green-deployment`, and `/interview-questions/senior/disaster-recovery-planning`. Root cause: `<PageHero>` renders the title as an `<h1>`, then both `checklist-page-client.tsx` and `interview-question-page.tsx` rendered the same title again as a large-text `<h2>`. Removed the inner duplicates (kept the badges/tags).

Newsletters needed a small code change to make their meta descriptions data-driven: added an optional `description` field to `Newsletter` / `NewsletterMeta` and made `app/newsletters/[slug]/page.tsx` prefer it over the templated fallback. Backwards compatible.

## Test plan
- [ ] `bun run build` cleanly
- [ ] Live: spot-check 3-5 of the rewritten URLs in `<meta name="description">`
- [ ] Live: confirm `/tools/cidr-calculator` appears in `/sitemap.xml`
- [ ] Live: confirm flagged checklist + interview-question pages show only 1 `<h1>`