### PR TITLE
fix(scripts): include quizzes + flashcards dirs in svg-to-png converter

### DIFF
--- a/scripts/convert-svg-to-png-parallel.ts
+++ b/scripts/convert-svg-to-png-parallel.ts
@@ -16,6 +16,8 @@ const DIRECTORIES = [
   { dir: path.join(PUBLIC_DIR, 'images', 'news'), type: 'news' },
   { dir: path.join(PUBLIC_DIR, 'images', 'checklists'), type: 'checklists' },
   { dir: path.join(PUBLIC_DIR, 'images', 'interview-questions'), type: 'interview-questions' },
+  { dir: path.join(PUBLIC_DIR, 'images', 'quizzes'), type: 'quizzes' },
+  { dir: path.join(PUBLIC_DIR, 'images', 'flashcards'), type: 'flashcards' },
 ];
 
 // Generate content hash for SVG file


### PR DESCRIPTION
## Summary

The parallel SVG-to-PNG converter walks a hardcoded list of directories. `quizzes/` (added in PR #1187) and `flashcards/` were never added to the list, so when the content pipeline produces a quiz or flashcard OG SVG, the matching PNG never gets generated and the pipeline's OG-image guard aborts the run before the PR is created.

This is what broke today's Tuesday quiz cron — see PR #1232 for the orphaned content I pushed manually.

## Fix

Add `quizzes` and `flashcards` to the `DIRECTORIES` list in `scripts/convert-svg-to-png-parallel.ts`.

## Test plan

- [ ] `bun run scripts/convert-svg-to-png-parallel.ts` picks up SVGs in both new directories on next run