### PR TITLE
feat(toolbox): add OpenChoreo to the developer tools list

### DIFF
--- a/app/toolbox/page.tsx
+++ b/app/toolbox/page.tsx
@@ -406,6 +406,20 @@ const tools: Tool[] = [
     ],
   },
   {
+    name: 'OpenChoreo',
+    description:
+      'Open-source Internal Developer Platform (IDP) for building cloud-native applications, with golden-path templates, environment promotion, and built-in observability. CNCF Sandbox project.',
+    href: 'https://github.com/openchoreo/openchoreo',
+    category: 'developer',
+    icon: Workflow,
+    isNew: true,
+    badges: [
+      { text: 'IDP', variant: 'outline' },
+      { text: 'CNCF Sandbox', variant: 'secondary' },
+      { text: 'Open Source', variant: 'default' },
+    ],
+  },
+  {
     name: 'Snyk',
     description:
       'Developer security platform to find and fix vulnerabilities in code, containers, and dependencies.',


### PR DESCRIPTION
## Summary

Adds OpenChoreo to `/toolbox` per the request in #1199.

OpenChoreo is an open-source Internal Developer Platform (IDP) and CNCF Sandbox project, slotted under the `developer` category alongside Backstage-style tooling.

Closes #1199

## Test plan

- [ ] Visit `/toolbox`, confirm OpenChoreo appears under Developer with the IDP / CNCF Sandbox / Open Source badges and the "New" indicator
- [ ] Card link points at https://github.com/openchoreo/openchoreo