### PR TITLE
chore: add Yandex Webmaster site verification file

### DIFF
--- a/public/yandex_4e3c1fd2200ee815.html
+++ b/public/yandex_4e3c1fd2200ee815.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>Verification: 4e3c1fd2200ee815</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the Yandex Webmaster verification HTML at `public/yandex_4e3c1fd2200ee815.html` so it gets served at `https://devops-daily.com/yandex_4e3c1fd2200ee815.html` and Yandex can complete domain ownership verification.

## Test plan

- [ ] After deploy, `curl https://devops-daily.com/yandex_4e3c1fd2200ee815.html` returns the verification HTML
- [ ] Click "Check" in Yandex Webmaster → site shows as verified