### PR TITLE
fix(seo): newsletter prev/next + RelatedContent for checklists/flashcards/exercises

### DIFF
--- a/app/checklists/[slug]/page.tsx
+++ b/app/checklists/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { ChecklistPageClient } from '@/components/checklists/checklist-page-clie
 import { PageHero } from '@/components/page-hero';
 import { ListChecks } from 'lucide-react';
 import { truncateMetaDescription } from '@/lib/meta-description';
+import { pickRelatedItems } from '@/lib/related-content';
+import { RelatedContent } from '@/components/related-content';
 
 export async function generateStaticParams() {
   const checklists = await getAllChecklists();
@@ -70,6 +72,21 @@ export default async function ChecklistPage(
     notFound();
   }
 
+  // Sibling checklists scored by tag overlap, category, and difficulty so the
+  // dedicated detail pages get inbound links from related siblings instead of
+  // only from the /checklists index. See lib/related-content.ts.
+  const all = await getAllChecklists();
+  const related = pickRelatedItems(
+    all,
+    {
+      slug: checklist.slug,
+      category: checklist.category,
+      tags: checklist.tags,
+      difficulty: checklist.difficulty,
+    },
+    { currentSlug: checklist.slug, limit: 3 },
+  );
+
   return (
     <>
       <PageHero
@@ -87,6 +104,21 @@ export default async function ChecklistPage(
         ].filter(s => s.value !== '')}
       />
       <ChecklistPageClient checklist={checklist} />
+      {related.length > 0 && (
+        <div className="container mx-auto px-4 pb-16">
+          <RelatedContent
+            title="More checklists"
+            items={related.map((c) => ({
+              slug: c.slug,
+              title: c.title,
+              description: c.description,
+              href: `/checklists/${c.slug}`,
+              label: c.category,
+              meta: c.estimatedTime,
+            }))}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/app/exercises/[id]/page.tsx
+++ b/app/exercises/[id]/page.tsx
@@ -8,6 +8,8 @@ import {
 import { ExerciseSeriesNav } from '@/components/exercise-series-nav';
 import { getSocialImagePath } from '@/lib/image-utils';
 import { truncateMetaDescription } from '@/lib/meta-description';
+import { pickRelatedItems } from '@/lib/related-content';
+import { RelatedContent } from '@/components/related-content';
 import type { Metadata } from 'next';
 
 export const dynamicParams = false;
@@ -88,6 +90,31 @@ export default async function ExerciseDetailPage({ params }: { params: Promise<{
     ? await getExercisesInSeries(exercise.series.id)
     : [];
 
+  // Score sibling exercises so each detail page links to 3 related ones
+  // (was 0 before this PR for the exercises Ahrefs flagged). Exercise
+  // category is an object here, so flatten the slug for scoring.
+  const allExercises = await getAllExercises();
+  const scorable = allExercises.map((ex) => ({
+    slug: ex.id,
+    title: ex.title,
+    description: ex.description,
+    category: ex.category.slug,
+    tags: ex.tags ?? [],
+    difficulty: ex.difficulty,
+    estimatedTime: ex.estimatedTime,
+    categoryName: ex.category.name,
+  }));
+  const related = pickRelatedItems(
+    scorable,
+    {
+      slug: exercise.id,
+      category: exercise.category.slug,
+      tags: exercise.tags ?? [],
+      difficulty: exercise.difficulty,
+    },
+    { currentSlug: exercise.id, limit: 3 },
+  );
+
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
@@ -107,6 +134,21 @@ export default async function ExerciseDetailPage({ params }: { params: Promise<{
           seriesExercises={seriesExercises}
         />
       </div>
+      {related.length > 0 && (
+        <div className="container mx-auto px-4 pb-16">
+          <RelatedContent
+            title="More exercises"
+            items={related.map((r) => ({
+              slug: r.slug,
+              title: r.title,
+              description: r.description,
+              href: `/exercises/${r.slug}`,
+              label: r.categoryName,
+              meta: r.estimatedTime,
+            }))}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getFlashCardSet, getAllFlashCardSets } from '@/lib/flashcard-loader'
+import type { FlashCardSet } from '@/lib/flashcard-loader'
 import { FlashCardDeck } from '@/components/flashcard-deck'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -9,6 +10,8 @@ import Link from 'next/link'
 import * as Icons from 'lucide-react'
 import { PageHero } from '@/components/page-hero'
 import { truncateMetaDescription } from '@/lib/meta-description'
+import { pickRelatedItems } from '@/lib/related-content'
+import { RelatedContent } from '@/components/related-content'
 
 interface FlashcardPageProps {
   params: Promise<{
@@ -136,6 +139,53 @@ export default async function FlashcardPage({ params }: FlashcardPageProps) {
           />
         </div>
       </section>
+
+      <FlashcardRelated currentSet={flashcardSet} />
     </div>
   )
+}
+
+// Sets do not carry top-level tags today, so we score on category + difficulty
+// alone. Card-level tags are not aggregated up to the set; doing so would mean
+// a schema change. The simpler scoring still gives every set ~2-3 inbound
+// links from siblings instead of only one from the /flashcards index.
+async function FlashcardRelated({ currentSet }: { currentSet: FlashCardSet }) {
+  const all = await getAllFlashCardSets();
+  const scorable = all.map((s) => ({
+    slug: s.id,
+    title: s.title,
+    description: s.description,
+    category: s.category,
+    difficulty: s.difficulty,
+    estimatedTime: s.estimatedTime,
+  }));
+  const related = pickRelatedItems(
+    scorable,
+    {
+      slug: currentSet.id,
+      category: currentSet.category,
+      difficulty: currentSet.difficulty,
+    },
+    { currentSlug: currentSet.id, limit: 3 },
+  );
+
+  if (related.length === 0) return null;
+
+  return (
+    <section className="container mx-auto px-4 pb-16">
+      <div className="max-w-4xl mx-auto">
+        <RelatedContent
+          title="More flashcard decks"
+          items={related.map((r) => ({
+            slug: r.slug,
+            title: r.title,
+            description: r.description,
+            href: `/flashcards/${r.slug}`,
+            label: r.category,
+            meta: r.estimatedTime,
+          }))}
+        />
+      </div>
+    </section>
+  );
 }

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -72,6 +72,17 @@ export default async function NewsletterDetailPage({
 
   if (!newsletter) notFound();
 
+  // Sibling newsletters. getAllNewsletters() returns newest-first, same as
+  // /news/[slug], so idx-1 is newer and idx+1 is older. Used for the prev/next
+  // nav at the bottom and the "Recent newsletters" block. Both feed real
+  // internal links to weeks that previously had only one inbound link from
+  // /newsletters (Ahrefs flagged 4 weekly issues with single-inlink status).
+  const all = await getAllNewsletters();
+  const idx = all.findIndex((n) => n.slug === newsletter.slug);
+  const newer = idx > 0 ? all[idx - 1] : null;
+  const older = idx >= 0 && idx < all.length - 1 ? all[idx + 1] : null;
+  const recent = all.filter((n) => n.slug !== newsletter.slug).slice(0, 5);
+
   const schemaItems = [
     { name: 'Home', url: '/' },
     { name: 'Newsletters', url: '/newsletters' },
@@ -121,6 +132,61 @@ export default async function NewsletterDetailPage({
               prose-img:rounded-lg prose-img:shadow-md"
             dangerouslySetInnerHTML={{ __html: newsletter.content }}
           />
+
+          {/* Prev / next newsletter nav. Mirrors the /news/[slug] pattern
+              from PR #1207 so each weekly issue has inbound links from at
+              least its sibling weeks. */}
+          {(newer || older) && (
+            <nav className="mt-12 pt-8 border-t grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {older ? (
+                <Link
+                  href={`/newsletters/${older.slug}`}
+                  className="rounded-lg border p-4 hover:bg-muted/40 transition-colors"
+                >
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Previous newsletter
+                  </p>
+                  <p className="font-medium">{older.title}</p>
+                </Link>
+              ) : (
+                <span />
+              )}
+              {newer && (
+                <Link
+                  href={`/newsletters/${newer.slug}`}
+                  className="rounded-lg border p-4 hover:bg-muted/40 transition-colors text-right sm:col-start-2"
+                >
+                  <p className="text-xs text-muted-foreground mb-1">
+                    Next newsletter
+                  </p>
+                  <p className="font-medium">{newer.title}</p>
+                </Link>
+              )}
+            </nav>
+          )}
+
+          {/* Recent newsletters - 5 most recent siblings, server-rendered so
+              every issue's links flow through to the index without waiting on
+              client interaction. */}
+          {recent.length > 0 && (
+            <div className="mt-10 pt-8 border-t">
+              <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+                Recent newsletters
+              </h3>
+              <ul className="space-y-2">
+                {recent.map((n) => (
+                  <li key={n.slug}>
+                    <Link
+                      href={`/newsletters/${n.slug}`}
+                      className="text-foreground hover:text-primary hover:underline"
+                    >
+                      {n.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {/* Subscribe CTA */}
           <div className="mt-12 p-6 rounded-xl border border-primary/20 bg-primary/5 text-center">

--- a/components/related-content.tsx
+++ b/components/related-content.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+export interface RelatedContentItem {
+  slug: string;
+  title: string;
+  description?: string;
+  href: string;
+  /** Optional small label displayed above the title (category name, etc.) */
+  label?: string;
+  /** Optional small label displayed in the bottom-right (difficulty, time) */
+  meta?: string;
+}
+
+interface RelatedContentProps {
+  items: RelatedContentItem[];
+  /** Section heading. Default "Related content". */
+  title?: string;
+  /** Wraps the section, gives the slug page room to set spacing. */
+  className?: string;
+}
+
+export function RelatedContent({
+  items,
+  title = 'Related content',
+  className,
+}: RelatedContentProps) {
+  if (!items.length) return null;
+
+  return (
+    <section className={cn('', className)}>
+      <h2 className="text-2xl font-bold mb-4">{title}</h2>
+      <div className="grid gap-4 md:grid-cols-3">
+        {items.map((item) => (
+          <Link
+            key={item.slug}
+            href={item.href}
+            className="group flex flex-col rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all"
+          >
+            {item.label && (
+              <p className="text-xs uppercase tracking-wider text-muted-foreground mb-2">
+                {item.label}
+              </p>
+            )}
+            <h3 className="font-semibold line-clamp-2 group-hover:text-primary transition-colors">
+              {item.title}
+            </h3>
+            {item.description && (
+              <p className="mt-2 text-sm text-muted-foreground line-clamp-3">
+                {item.description}
+              </p>
+            )}
+            {item.meta && (
+              <p className="mt-3 text-xs text-muted-foreground">{item.meta}</p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/lib/related-content.ts
+++ b/lib/related-content.ts
@@ -1,0 +1,82 @@
+/**
+ * Generic "pick related items" scorer used by /checklists/[slug],
+ * /flashcards/[id], /exercises/[id], and other within-content-type related
+ * sections. Same scoring shape as `getRelatedQuizzes` in lib/quiz-loader.ts:
+ *
+ *   - 10 points per matching tag
+ *   -  5 points for same category
+ *   -  1 point for matching difficulty
+ *
+ * Items must be normalized to `{ slug, category, tags, difficulty? }` before
+ * being passed in. Cross-type related content (e.g. surfacing a quiz next to
+ * a checklist on the same topic) is intentionally not handled here yet, since
+ * each content type's link shape differs and the simple within-type version
+ * already closes most of the dofollow-inlink gap Ahrefs flagged.
+ */
+
+export interface RelatedScorable {
+  slug: string;
+  category?: string;
+  tags?: string[];
+  difficulty?: string;
+}
+
+export interface PickRelatedOptions {
+  /** Slug of the current item; excluded from results. */
+  currentSlug: string;
+  /** How many items to return. Defaults to 3. */
+  limit?: number;
+  /** When two items tie on score, prefer this category. */
+  preferCategory?: string;
+}
+
+export function pickRelatedItems<T extends RelatedScorable>(
+  items: T[],
+  current: RelatedScorable,
+  options: PickRelatedOptions,
+): T[] {
+  const { currentSlug, limit = 3, preferCategory } = options;
+  const currentTags = current.tags ?? [];
+  const currentCategory = current.category;
+  const currentDifficulty = current.difficulty;
+
+  const candidates = items.filter((item) => item.slug !== currentSlug);
+
+  const scored = candidates.map((item) => {
+    let score = 0;
+
+    if (currentTags.length > 0 && item.tags && item.tags.length > 0) {
+      const itemTags = item.tags.map((t) => t.toLowerCase());
+      const lowered = currentTags.map((t) => t.toLowerCase());
+      const matches = itemTags.filter((t) => lowered.includes(t));
+      score += matches.length * 10;
+    }
+
+    if (currentCategory && item.category === currentCategory) {
+      score += 5;
+    }
+
+    if (currentDifficulty && item.difficulty === currentDifficulty) {
+      score += 1;
+    }
+
+    return { item, score };
+  });
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    // Tiebreaker: prefer the requested category, then alphabetical slug for
+    // determinism (so static rendering produces stable output).
+    if (preferCategory) {
+      const aPref = a.item.category === preferCategory ? 1 : 0;
+      const bPref = b.item.category === preferCategory ? 1 : 0;
+      if (bPref !== aPref) return bPref - aPref;
+    }
+    return a.item.slug.localeCompare(b.item.slug);
+  });
+
+  // Keep items that share at least one signal with the current item. Items
+  // with score 0 share nothing relevant and aren't worth surfacing as
+  // "related" - we'd rather show a shorter list than pad with noise.
+  return scored.filter((s) => s.score > 0).slice(0, limit).map((s) => s.item);
+}


### PR DESCRIPTION
## Summary

Second-pass cleanup of the "Page has only one dofollow incoming internal link" Ahrefs flag. PR #1207 took the count from 137 → 53 by adding related-content sections to `/interview-questions/`, `/news/`, and `/games/`. This PR closes the next 16-19 URLs (the groups #1207 explicitly punted).

## What changed

### 1. Generic scorer + component
- `lib/related-content.ts`: `pickRelatedItems` scores siblings the same way `getRelatedQuizzes` does (10 pts per matching tag, 5 pts for same category, 1 pt for matching difficulty, deterministic tiebreaker). Items with score 0 are dropped so we don't pad the section.
- `components/related-content.tsx`: three-up grid of cards with optional `label` + `meta`. Reused across the four pages below and ready for any future content type.

### 2. Page wiring

| Page | Before | After |
|------|--------|-------|
| `/checklists/[slug]` | 1 inlink (from `/checklists`) | + 3 inlinks from sibling checklists |
| `/flashcards/[id]` | 1 inlink (from `/flashcards`) | + up to 3 inlinks from sibling decks (category + difficulty match — sets carry no top-level tags today) |
| `/exercises/[id]` | 1 inlink (from `/exercises`) | + 3 inlinks from sibling exercises (tag + category + difficulty match) |
| `/newsletters/[slug]` | 1 inlink (from `/newsletters`) | + prev/next sibling weeks + 5-item "Recent newsletters" block (mirrors `/news/[slug]` from #1207) |

### 3. Notes

- Flashcard scoring is category + difficulty only because `FlashCardSet` doesn't carry tags at the set level (only individual cards do). Documented inline. A schema bump to add set-level tags would unlock tag-based scoring later.
- `lib/related-content.ts` is content-type agnostic, so adding it to a fifth content type later is a one-page change in the slug page.
- Cross-type linking (e.g. quiz next to checklist on the same topic) is still intentionally out of scope, per the wider note in #1207.

## Test plan

- [ ] `/checklists/<any>` renders "More checklists" with up to 3 cards
- [ ] `/flashcards/<any>` renders "More flashcard decks" (very-niche sets may legitimately render 0 — expected)
- [ ] `/exercises/<any>` renders "More exercises"
- [ ] `/newsletters/2026-week-17` shows prev (week-16) + next (week-18) + a 5-item "Recent newsletters" list
- [ ] No new TypeScript errors (verified locally; the 4 IconComponent / Fuse / categories errors are pre-existing on main)