### PR TITLE
feat(seo): cross-content-type related sections on six slug pages

### DIFF
--- a/app/checklists/[slug]/page.tsx
+++ b/app/checklists/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { ListChecks } from 'lucide-react';
 import { truncateMetaDescription } from '@/lib/meta-description';
 import { pickRelatedItems } from '@/lib/related-content';
 import { RelatedContent } from '@/components/related-content';
+import { RelatedAcrossTypes } from '@/components/related-across-types';
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
 import { CarbonAds } from '@/components/carbon-ads';
 
 export async function generateStaticParams() {
@@ -88,6 +90,20 @@ export default async function ChecklistPage(
     { currentSlug: checklist.slug, limit: 3 },
   );
 
+  // Cross-content-type matches across posts/quizzes/exercises/flashcards/
+  // interview-questions for the same topic. Pairs with the within-type
+  // "More checklists" block above.
+  const crossTypeRelated = await getRelatedAcrossTypes({
+    current: {
+      type: 'checklist',
+      id: checklist.slug,
+      category: checklist.category,
+      tags: checklist.tags,
+      difficulty: checklist.difficulty,
+    },
+    limit: 3,
+  });
+
   return (
     <>
       <PageHero
@@ -115,7 +131,7 @@ export default async function ChecklistPage(
         </div>
       </div>
       {related.length > 0 && (
-        <div className="container mx-auto px-4 pb-16">
+        <div className="container mx-auto px-4 pb-8">
           <RelatedContent
             title="More checklists"
             items={related.map((c) => ({
@@ -127,6 +143,11 @@ export default async function ChecklistPage(
               meta: c.estimatedTime,
             }))}
           />
+        </div>
+      )}
+      {crossTypeRelated.length > 0 && (
+        <div className="container mx-auto px-4 pb-16">
+          <RelatedAcrossTypes items={crossTypeRelated} />
         </div>
       )}
     </>

--- a/app/exercises/[id]/page.tsx
+++ b/app/exercises/[id]/page.tsx
@@ -10,6 +10,8 @@ import { getSocialImagePath } from '@/lib/image-utils';
 import { truncateMetaDescription } from '@/lib/meta-description';
 import { pickRelatedItems } from '@/lib/related-content';
 import { RelatedContent } from '@/components/related-content';
+import { RelatedAcrossTypes } from '@/components/related-across-types';
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
 import type { Metadata } from 'next';
 
 export const dynamicParams = false;
@@ -115,6 +117,17 @@ export default async function ExerciseDetailPage({ params }: { params: Promise<{
     { currentSlug: exercise.id, limit: 3 },
   );
 
+  const crossTypeRelated = await getRelatedAcrossTypes({
+    current: {
+      type: 'exercise',
+      id: exercise.id,
+      category: exercise.category.slug,
+      tags: exercise.tags ?? [],
+      difficulty: exercise.difficulty,
+    },
+    limit: 3,
+  });
+
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
@@ -135,7 +148,7 @@ export default async function ExerciseDetailPage({ params }: { params: Promise<{
         />
       </div>
       {related.length > 0 && (
-        <div className="container mx-auto px-4 pb-16">
+        <div className="container mx-auto px-4 pb-8">
           <RelatedContent
             title="More exercises"
             items={related.map((r) => ({
@@ -147,6 +160,11 @@ export default async function ExerciseDetailPage({ params }: { params: Promise<{
               meta: r.estimatedTime,
             }))}
           />
+        </div>
+      )}
+      {crossTypeRelated.length > 0 && (
+        <div className="container mx-auto px-4 pb-16">
+          <RelatedAcrossTypes items={crossTypeRelated} />
         </div>
       )}
     </>

--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -12,6 +12,8 @@ import { PageHero } from '@/components/page-hero'
 import { truncateMetaDescription } from '@/lib/meta-description'
 import { pickRelatedItems } from '@/lib/related-content'
 import { RelatedContent } from '@/components/related-content'
+import { RelatedAcrossTypes } from '@/components/related-across-types'
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type'
 import { CarbonAds } from '@/components/carbon-ads'
 
 interface FlashcardPageProps {
@@ -148,8 +150,29 @@ export default async function FlashcardPage({ params }: FlashcardPageProps) {
       </section>
 
       <FlashcardRelated currentSet={flashcardSet} />
+      <FlashcardCrossTypeRelated currentSet={flashcardSet} />
     </div>
   )
+}
+
+async function FlashcardCrossTypeRelated({ currentSet }: { currentSet: FlashCardSet }) {
+  const items = await getRelatedAcrossTypes({
+    current: {
+      type: 'flashcard',
+      id: currentSet.id,
+      category: currentSet.category,
+      difficulty: currentSet.difficulty,
+    },
+    limit: 3,
+  });
+  if (items.length === 0) return null;
+  return (
+    <section className="container mx-auto px-4 pb-16">
+      <div className="max-w-4xl mx-auto">
+        <RelatedAcrossTypes items={items} />
+      </div>
+    </section>
+  );
 }
 
 // Sets do not carry top-level tags today, so we score on category + difficulty

--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -8,6 +8,8 @@ import { PageHero } from '@/components/page-hero';
 import { getSocialImagePath } from '@/lib/image-utils';
 import { truncateMetaDescription } from '@/lib/meta-description';
 import { CarbonAds } from '@/components/carbon-ads';
+import { RelatedAcrossTypes } from '@/components/related-across-types';
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
 import type { ExperienceTier } from '@/lib/interview-utils';
 
 const validTiers: ExperienceTier[] = ['junior', 'mid', 'senior'];
@@ -89,6 +91,16 @@ export default async function QuestionPage({ params }: PageProps) {
 
   const capitalizedTier = tier.charAt(0).toUpperCase() + tier.slice(1);
 
+  const crossTypeRelated = await getRelatedAcrossTypes({
+    current: {
+      type: 'interview-question',
+      id: `${question.tier}/${question.slug}`,
+      category: question.category,
+      tags: question.tags || [],
+    },
+    limit: 3,
+  });
+
   // Related questions - same category, any tier (not just this one), excluding
   // the current question. Sorted: same-tier first, then other tiers. Capped
   // to 5 so the section stays readable but still gives crawlers and readers
@@ -147,6 +159,11 @@ export default async function QuestionPage({ params }: PageProps) {
               </li>
             ))}
           </ul>
+        </section>
+      )}
+      {crossTypeRelated.length > 0 && (
+        <section className="container mx-auto px-4 max-w-4xl pb-12">
+          <RelatedAcrossTypes items={crossTypeRelated} />
         </section>
       )}
     </>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { getPostBySlug, getAllPosts, getRelatedPosts } from '@/lib/posts';
 import { notFound, redirect } from 'next/navigation';
 import { ArticleSchema, BreadcrumbSchema } from '@/components/schema-markup';
 import { RelatedPosts } from '@/components/related-posts';
+import { RelatedAcrossTypes } from '@/components/related-across-types';
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
 import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { ReportIssue } from '@/components/report-issue';
 import { GiscusComments } from '@/components/giscus-comments';
@@ -109,6 +111,20 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   const mainRelatedPosts = relatedPosts.slice(0, 3);
   const sidebarRelatedPosts = relatedPosts.slice(3, 6);
 
+  // Cross-content-type matches: shows up to 3 items from quizzes, checklists,
+  // exercises, flashcards, or interview questions on the same topic. The
+  // within-type "Related Posts" section above stays; this is the "also worth
+  // your time" mix that nudges readers between content kinds.
+  const crossTypeRelated = await getRelatedAcrossTypes({
+    current: {
+      type: 'post',
+      id: post.slug,
+      category: post.category?.slug,
+      tags: post.tags || [],
+    },
+    limit: 3,
+  });
+
   // Breadcrumb items for schema
   const breadcrumbItems = [
     { name: 'Home', url: '/' },
@@ -206,6 +222,10 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                   }))}
                   className="mt-12"
                 />
+              )}
+
+              {crossTypeRelated.length > 0 && (
+                <RelatedAcrossTypes items={crossTypeRelated} className="mt-12" />
               )}
             </article>
           </div>

--- a/app/quizzes/[slug]/page.tsx
+++ b/app/quizzes/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { RelatedPosts } from '@/components/related-posts';
+import { RelatedAcrossTypes } from '@/components/related-across-types';
+import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
 import { CarbonAds } from '@/components/carbon-ads';
 
 export const dynamicParams = false;
@@ -78,6 +80,16 @@ export default async function QuizPage({ params }: { params: Promise<{ slug: str
   }
 
   const relatedQuizzes = await getRelatedQuizzes(slug, quizConfig.category, 3);
+
+  const crossTypeRelated = await getRelatedAcrossTypes({
+    current: {
+      type: 'quiz',
+      id: slug,
+      category: quizConfig.category,
+      tags: (quizConfig.metadata?.tags || []).map((t) => String(t)),
+    },
+    limit: 3,
+  });
 
   // Breadcrumb items
   const breadcrumbItems = [
@@ -199,6 +211,12 @@ export default async function QuizPage({ params }: { params: Promise<{ slug: str
                 linkPrefix="/quizzes"
                 className=""
               />
+            </div>
+          )}
+
+          {crossTypeRelated.length > 0 && (
+            <div className="max-w-4xl mx-auto mt-12">
+              <RelatedAcrossTypes items={crossTypeRelated} />
             </div>
           )}
 

--- a/components/related-across-types.tsx
+++ b/components/related-across-types.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import {
+  TYPE_LABELS,
+  type CrossContentItem,
+} from '@/lib/related-cross-type';
+import {
+  FileText,
+  ListChecks,
+  Layers,
+  Wrench,
+  HelpCircle,
+  Briefcase,
+  type LucideIcon,
+} from 'lucide-react';
+
+interface RelatedAcrossTypesProps {
+  items: CrossContentItem[];
+  /** Section heading. Default "Also worth your time on this topic". */
+  title?: string;
+  className?: string;
+}
+
+const TYPE_ICONS: Record<CrossContentItem['type'], LucideIcon> = {
+  post: FileText,
+  checklist: ListChecks,
+  flashcard: Layers,
+  exercise: Wrench,
+  quiz: HelpCircle,
+  'interview-question': Briefcase,
+};
+
+export function RelatedAcrossTypes({
+  items,
+  title = 'Also worth your time on this topic',
+  className,
+}: RelatedAcrossTypesProps) {
+  if (!items.length) return null;
+
+  return (
+    <section className={cn('', className)}>
+      <h2 className="text-2xl font-bold mb-4">{title}</h2>
+      <div className="grid gap-4 md:grid-cols-3">
+        {items.map((item) => {
+          const Icon = TYPE_ICONS[item.type];
+          return (
+            <Link
+              key={`${item.type}:${item.id}`}
+              href={item.href}
+              className="group flex flex-col rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 text-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider">
+                  <Icon className="w-3 h-3" />
+                  {TYPE_LABELS[item.type]}
+                </span>
+              </div>
+              <h3 className="font-semibold line-clamp-2 group-hover:text-primary transition-colors">
+                {item.title}
+              </h3>
+              {item.description && (
+                <p className="mt-2 text-sm text-muted-foreground line-clamp-3">
+                  {item.description}
+                </p>
+              )}
+              {item.meta && (
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {item.meta}
+                </p>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/lib/related-cross-type.ts
+++ b/lib/related-cross-type.ts
@@ -1,0 +1,248 @@
+/**
+ * Cross-content-type related lookup. Within-type related sections
+ * (`pickRelatedItems` in lib/related-content.ts) only show siblings of the
+ * same kind. This module aggregates posts, checklists, flashcards, exercises,
+ * quizzes, and interview questions into a uniform shape and scores them all
+ * together so that a post about Istio can surface the matching quiz,
+ * checklist, and flashcard right under it.
+ *
+ * Scoring follows the same shape as `pickRelatedItems` (10 pts per matching
+ * tag, 5 pts for same category, 1 pt for matching difficulty), with one
+ * extra rule: items of the same content type as the current item are
+ * de-prioritized at tiebreak so cross-type matches surface first when scores
+ * tie. The page's existing within-type "Related <X>" section already covers
+ * same-type siblings; this section's value is the *other* kinds of content.
+ */
+
+import { getAllPosts } from './posts';
+import { getAllChecklists } from './checklists';
+import { getAllFlashCardSets } from './flashcard-loader';
+import { getAllExercises } from './exercises';
+import { getAllQuizzes } from './quiz-loader';
+import { interviewQuestions } from '@/content/interview-questions';
+
+export type CrossContentType =
+  | 'post'
+  | 'checklist'
+  | 'flashcard'
+  | 'exercise'
+  | 'quiz'
+  | 'interview-question';
+
+export interface CrossContentItem {
+  /** Unique identifier within its type. Combined with `type`, fully unique. */
+  id: string;
+  type: CrossContentType;
+  title: string;
+  description: string;
+  /** Absolute path on the site, ready to drop into a Link `href`. */
+  href: string;
+  category: string;
+  tags: string[];
+  difficulty?: string;
+  /** Optional small hint shown next to the item (estimated time, tier, etc.) */
+  meta?: string;
+}
+
+/**
+ * Loads every content item from every type into a single normalized array.
+ * Cached implicitly because each underlying loader has its own cache.
+ */
+async function loadAllCrossContent(): Promise<CrossContentItem[]> {
+  const [posts, checklists, flashcards, exercises, quizzes] = await Promise.all([
+    getAllPosts(),
+    getAllChecklists(),
+    getAllFlashCardSets(),
+    getAllExercises(),
+    getAllQuizzes(),
+  ]);
+
+  const items: CrossContentItem[] = [];
+
+  for (const post of posts) {
+    items.push({
+      id: post.slug,
+      type: 'post',
+      title: post.title,
+      description: post.excerpt || '',
+      href: `/posts/${post.slug}`,
+      category: post.category?.slug || '',
+      tags: (post.tags || []).map((t) => String(t)),
+    });
+  }
+
+  for (const c of checklists) {
+    items.push({
+      id: c.slug,
+      type: 'checklist',
+      title: c.title,
+      description: c.description,
+      href: `/checklists/${c.slug}`,
+      category: c.category,
+      tags: c.tags || [],
+      difficulty: c.difficulty,
+      meta: c.estimatedTime,
+    });
+  }
+
+  for (const f of flashcards) {
+    items.push({
+      id: f.id,
+      type: 'flashcard',
+      title: f.title,
+      description: f.description,
+      href: `/flashcards/${f.id}`,
+      category: f.category,
+      // Sets do not carry top-level tags today; category + difficulty still
+      // contribute to scoring so flashcards remain eligible.
+      tags: [],
+      difficulty: f.difficulty,
+      meta: f.estimatedTime,
+    });
+  }
+
+  for (const ex of exercises) {
+    items.push({
+      id: ex.id,
+      type: 'exercise',
+      title: ex.title,
+      description: ex.description,
+      href: `/exercises/${ex.id}`,
+      category: ex.category?.slug || '',
+      tags: ex.tags || [],
+      difficulty: ex.difficulty,
+      meta: ex.estimatedTime,
+    });
+  }
+
+  for (const q of quizzes) {
+    items.push({
+      id: q.id,
+      type: 'quiz',
+      title: q.title,
+      description: q.description || '',
+      href: `/quizzes/${q.id}`,
+      category: q.category,
+      tags: (q.metadata?.tags || []).map((t) => String(t)),
+      meta: q.metadata?.estimatedTime,
+    });
+  }
+
+  for (const iq of interviewQuestions) {
+    items.push({
+      id: `${iq.tier}/${iq.slug}`,
+      type: 'interview-question',
+      title: iq.title,
+      description: iq.question || '',
+      href: `/interview-questions/${iq.tier}/${iq.slug}`,
+      category: iq.category,
+      tags: iq.tags || [],
+      meta: iq.tier,
+    });
+  }
+
+  return items;
+}
+
+export interface RelatedAcrossTypesOptions {
+  /** Item to compute siblings for. */
+  current: {
+    type: CrossContentType;
+    id: string;
+    category?: string;
+    tags?: string[];
+    difficulty?: string;
+  };
+  /** How many items to return. Default 3. */
+  limit?: number;
+  /**
+   * If set, allow at most this many items of any single type. Default 1
+   * (so the section spans multiple types instead of three quizzes).
+   */
+  maxPerType?: number;
+}
+
+interface ScoredItem {
+  item: CrossContentItem;
+  score: number;
+}
+
+/**
+ * Returns up to `limit` items from any content type other than the current
+ * item, scored by tag/category/difficulty overlap. The same-type cap keeps
+ * the section visually mixed; pair this with the existing within-type
+ * "More <X>" section.
+ */
+export async function getRelatedAcrossTypes(
+  options: RelatedAcrossTypesOptions,
+): Promise<CrossContentItem[]> {
+  const { current, limit = 3, maxPerType = 1 } = options;
+  const all = await loadAllCrossContent();
+  const currentTags = (current.tags ?? []).map((t) => t.toLowerCase());
+  const currentCategory = current.category;
+  const currentDifficulty = current.difficulty;
+
+  // Exclude the current item by (type, id). Two items can share an id across
+  // types (e.g. a post slug == a quiz id) so we must compare both fields.
+  const candidates = all.filter(
+    (item) => !(item.type === current.type && item.id === current.id),
+  );
+
+  const scored: ScoredItem[] = candidates.map((item) => {
+    let score = 0;
+
+    if (currentTags.length > 0 && item.tags.length > 0) {
+      const itemTags = item.tags.map((t) => t.toLowerCase());
+      const matches = itemTags.filter((t) => currentTags.includes(t));
+      score += matches.length * 10;
+    }
+
+    if (currentCategory && item.category === currentCategory) {
+      score += 5;
+    }
+
+    if (currentDifficulty && item.difficulty === currentDifficulty) {
+      score += 1;
+    }
+
+    return { item, score };
+  });
+
+  // Drop zero-score noise; we'd rather show a shorter section than pad with
+  // unrelated items that hurt internal-link signal quality.
+  const positive = scored
+    .filter((s) => s.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Tiebreaker: prefer items whose type differs from `current.type` so
+      // mixed-type results outrank same-type ones at equal score.
+      const aSameType = a.item.type === current.type ? 1 : 0;
+      const bSameType = b.item.type === current.type ? 1 : 0;
+      if (aSameType !== bSameType) return aSameType - bSameType;
+      return a.item.id.localeCompare(b.item.id);
+    });
+
+  // Apply the same-type cap so the section reads as a mix instead of three
+  // items of one kind.
+  const selected: CrossContentItem[] = [];
+  const perType = new Map<CrossContentType, number>();
+  for (const { item } of positive) {
+    if (selected.length >= limit) break;
+    const used = perType.get(item.type) ?? 0;
+    if (used >= maxPerType) continue;
+    selected.push(item);
+    perType.set(item.type, used + 1);
+  }
+
+  return selected;
+}
+
+/** Display label for each content type. Used for the small chip on the card. */
+export const TYPE_LABELS: Record<CrossContentType, string> = {
+  post: 'Article',
+  checklist: 'Checklist',
+  flashcard: 'Flashcards',
+  exercise: 'Exercise',
+  quiz: 'Quiz',
+  'interview-question': 'Interview',
+};


### PR DESCRIPTION
## Summary

Within-type related sections (PR #1207 + #1240) only surface siblings of the same kind. A reader on `/posts/<istio-routing>` never sees the matching quiz, checklist, flashcard, or interview question on the same topic. This PR closes that loop by adding a cross-type **"Also worth your time on this topic"** block that mixes them.

## What ships

### 1. Generic cross-type loader + scorer
`lib/related-cross-type.ts` aggregates posts, checklists, flashcards, exercises, quizzes, and interview questions into a uniform shape and scores them with the same algorithm as `pickRelatedItems` (10 pts/tag, 5 pts/category, 1 pt/difficulty). Items with score 0 are filtered. A `maxPerType` cap (default 1) keeps the 3-card section visually mixed instead of three quizzes.

### 2. Component
`components/related-across-types.tsx` — three-up grid with a per-type chip + icon (Article / Quiz / Checklist / Flashcards / Exercise / Interview), reusing the hover/border treatment from `RelatedContent` for visual consistency.

### 3. Wired into six slug page templates
- `/posts/[slug]`
- `/checklists/[slug]`
- `/flashcards/[id]`
- `/exercises/[id]`
- `/quizzes/[slug]`
- `/interview-questions/[tier]/[slug]`

Within-type sections (`RelatedPosts`, "More checklists", etc.) stay — this block sits below them as a complement, not a replacement.

## Notes

- **Comparisons** are not yet a source because they don't carry tags in the current schema. Easy follow-up once we add a `tags` field.
- **Flashcards** contribute to scoring on category + difficulty only (no top-level tags) — same caveat documented in PR #1240.
- **Same-type cap (1)** means `/posts` won't show three other posts in this section even if same-type matches score highest. The within-type `RelatedPosts` already covers that.

## Test plan

- [ ] `/posts/copy-fail-cve-2026-31431-linux-container-escape` — cross-type block shows 3 mixed-type cards
- [ ] `/quizzes/git-quiz` — cross-type block shows post + checklist + interview question instead of three more quizzes
- [ ] `/checklists/<any>` — first "More checklists" (within-type), then cross-type below
- [ ] No new TS errors (verified locally; pre-existing errors in `lib/search.ts`, `components/interview-questions/*`, etc. unchanged)