### PR TITLE
chore(seo): wrap dates in <time> elements

### DIFF
--- a/app/advent-of-devops/[slug]/page.tsx
+++ b/app/advent-of-devops/[slug]/page.tsx
@@ -157,11 +157,13 @@ export default async function AdventDayPage({
                   {day.publishedAt && (
                     <div className="flex items-center gap-1">
                       <Clock className="h-4 w-4" />
-                      {new Date(day.publishedAt).toLocaleDateString('en-US', {
-                        month: 'long',
-                        day: 'numeric',
-                        year: 'numeric',
-                      })}
+                      <time dateTime={day.publishedAt}>
+                        {new Date(day.publishedAt).toLocaleDateString('en-US', {
+                          month: 'long',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </time>
                     </div>
                   )}
                   <div className="flex items-center gap-1">

--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -203,7 +203,12 @@ export default async function GuidePartPage({
 
                       {guide.updatedAt && (
                         <div>
-                          <span>Updated: {new Date(guide.updatedAt).toLocaleDateString()}</span>
+                          <span>
+                            Updated:{' '}
+                            <time dateTime={guide.updatedAt}>
+                              {new Date(guide.updatedAt).toLocaleDateString()}
+                            </time>
+                          </span>
                         </div>
                       )}
                     </div>

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -145,7 +145,14 @@ export default async function GuidePage({ params }: { params: Promise<{ slug: st
               {/* Add structured data for guide */}
               <div className="pt-8 mt-8 border-t border-border" id="article-end">
                 <div className="flex items-center text-sm text-muted-foreground">
-                  <span>Last updated: {guide.updatedAt || 'Recently'}</span>
+                  {guide.updatedAt ? (
+                    <span>
+                      Last updated:{' '}
+                      <time dateTime={guide.updatedAt}>{guide.updatedAt}</time>
+                    </span>
+                  ) : (
+                    <span>Last updated: Recently</span>
+                  )}
                 </div>
 
                 {guide.tags && guide.tags.length > 0 && (

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -113,11 +113,13 @@ export default async function NewsletterDetailPage({
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Calendar className="w-4 h-4" />
-                {new Date(newsletter.date).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
+                <time dateTime={newsletter.date}>
+                  {new Date(newsletter.date).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </time>
               </div>
             </div>
             <h1 className="text-3xl font-bold mb-2">{newsletter.title}</h1>

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -73,11 +73,13 @@ export default async function NewslettersPage() {
                       {newsletter.title}
                     </h3>
                     <p className="text-sm text-muted-foreground">
-                      {new Date(newsletter.date).toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
+                      <time dateTime={newsletter.date}>
+                        {new Date(newsletter.date).toLocaleDateString('en-US', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        })}
+                      </time>
                     </p>
                   </div>
                   <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors flex-shrink-0" />

--- a/components/comparisons/comparison-page-client.tsx
+++ b/components/comparisons/comparison-page-client.tsx
@@ -57,11 +57,14 @@ export function ComparisonPageClient({ comparison, allComparisons }: ComparisonP
               </div>
               <div className="flex items-center gap-1 text-sm text-muted-foreground">
                 <Calendar className="w-3.5 h-3.5" />
-                Updated {new Date(comparison.updatedDate).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
+                Updated{' '}
+                <time dateTime={comparison.updatedDate}>
+                  {new Date(comparison.updatedDate).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </time>
               </div>
             </div>
 

--- a/components/featured-posts.tsx
+++ b/components/featured-posts.tsx
@@ -46,7 +46,7 @@ export default async function FeaturedPosts({ className }: FeaturedPostsProps) {
               <p className="mt-2 text-muted-foreground line-clamp-3">{post.excerpt}</p>
               <div className="flex items-center mt-4 text-sm text-muted-foreground">
                 <Calendar className="w-4 h-4 mr-1" />
-                <span>{post.date}</span>
+                <time dateTime={post.date}>{post.date}</time>
                 <span className="mx-2">|</span>
                 <Clock className="w-4 h-4 mr-1" />
                 <span>{post.readingTime}</span>

--- a/components/latest-guides.tsx
+++ b/components/latest-guides.tsx
@@ -49,7 +49,13 @@ export default async function LatestGuides({ className, limit = 6 }: LatestGuide
               <p className="mt-2 text-muted-foreground line-clamp-3">{guide.description}</p>
               <div className="mt-4 flex items-center text-sm text-muted-foreground">
                 <Calendar className="mr-1 h-4 w-4" />
-                <span>{guide.publishedAt?.split('T')[0] ?? 'Unknown date'}</span>
+                {guide.publishedAt ? (
+                  <time dateTime={guide.publishedAt}>
+                    {guide.publishedAt.split('T')[0]}
+                  </time>
+                ) : (
+                  <span>Unknown date</span>
+                )}
                 <span className="mx-2">|</span>
                 <Clock className="mr-1 h-4 w-4" />
                 <span>{guide.readingTime ?? 'Quick read'}</span>

--- a/components/latest-posts.tsx
+++ b/components/latest-posts.tsx
@@ -36,7 +36,7 @@ export default async function LatestPosts({ className }: LatestPostsProps) {
             <p className="mt-2 text-muted-foreground line-clamp-3">{post.excerpt}</p>
             <div className="mt-4 flex items-center text-sm text-muted-foreground">
               <Calendar className="mr-1 h-4 w-4" />
-              <span>{post.date}</span>
+              <time dateTime={post.date}>{post.date}</time>
               <span className="mx-2">|</span>
               <Clock className="mr-1 h-4 w-4" />
               <span>{post.readingTime}</span>

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -28,7 +28,7 @@ export function PostHeader({ post, hasAffiliateLinks = false }: PostHeaderProps)
         </Badge>
         <div className="flex items-center text-sm text-muted-foreground">
           <Calendar className="mr-1 h-4 w-4" />
-          <span>{post.date}</span>
+          <time dateTime={post.date}>{post.date}</time>
         </div>
         <div className="flex items-center text-sm text-muted-foreground">
           <Clock className="mr-1 h-4 w-4" />

--- a/components/posts-list.tsx
+++ b/components/posts-list.tsx
@@ -103,7 +103,7 @@ export function PostsList({ posts, className, sponsorSlot, sponsorAfter = 6 }: P
                   </Badge>
                   <div className="flex items-center text-sm text-muted-foreground">
                     <Calendar className="mr-1 h-4 w-4" />
-                    <span>{post.date}</span>
+                    <time dateTime={post.date}>{post.date}</time>
                     <span className="mx-2">|</span>
                     <Clock className="mr-1 h-4 w-4" />
                     <span>{post.readingTime}</span>

--- a/components/related-posts.tsx
+++ b/components/related-posts.tsx
@@ -41,7 +41,7 @@ export function RelatedPosts({
             </h3>
             <div className="mt-2 flex items-center text-sm text-muted-foreground">
               <Calendar className="mr-1 h-4 w-4" />
-              <span>{post.date}</span>
+              <time dateTime={post.date}>{post.date}</time>
               <span className="mx-2">|</span>
               <Clock className="mr-1 h-4 w-4" />
               <span>{post.readingTime}</span>

--- a/components/search-page-client.tsx
+++ b/components/search-page-client.tsx
@@ -736,13 +736,16 @@ function SearchResultCard({ result, isSelected }: { result: SearchResult; isSele
                 </Badge>
               )}
               {result.date && (
-                <span className="text-xs text-muted-foreground ml-auto">
+                <time
+                  dateTime={result.date}
+                  className="text-xs text-muted-foreground ml-auto"
+                >
                   {new Date(result.date).toLocaleDateString('en-US', {
                     year: 'numeric',
                     month: 'short',
                     day: 'numeric',
                   })}
-                </span>
+                </time>
               )}
             </div>
 


### PR DESCRIPTION
Google's AI optimization guide calls out semantic HTML as a signal. The site was rendering published/updated dates inside `<span>` or plain text. Wrap them in `<time dateTime="ISO">` so AI crawlers and quality raters can reliably extract freshness/date metadata.

Per the audit from earlier — priority #2 from the three-priority list.

## Touched
- **Post chrome**: `post-header`, `latest-posts`, `featured-posts`, `related-posts`, `posts-list`
- **Guide chrome**: `latest-guides`, `/guides/[slug]/page`, `/guides/[slug]/[part]/page`
- **Other content surfaces**: `advent-of-devops`, `newsletters` list + detail, `comparison-page-client`, `search-page-client`

## Already correct (left alone)
- `<Footer>` already uses `<footer>` (the audit was wrong about that)
- `/news/[slug]/page.tsx` and `/news/page.tsx` already use `<time>`

## Verified
- `npx tsc --noEmit`: no new errors on touched files (pre-existing errors elsewhere unaffected)
- `npx vitest run`: 5004/5006 ✓ (2 were already skipped)