### PR TITLE
fix(mobile): stop post pages scrolling horizontally on narrow viewports

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -314,6 +314,12 @@
 /* Inline code */
 .prose :not(pre) > code {
   @apply bg-muted px-1.5 py-0.5 rounded-md text-sm font-mono text-primary;
+  /* Long inline tokens like t.m-kosche.com:443/api/public/otel/v1/traces or
+   * karpenter.sh/capacity-type=on-demand:NoSchedule have no spaces to break on
+   * and push the line wider than the column on narrow viewports, causing
+   * the whole post to scroll horizontally. anywhere lets the browser break
+   * at any character when nothing else fits. */
+  overflow-wrap: anywhere;
 }
 
 /* Code block line numbers (optional) */

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -138,7 +138,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
       <div className="container px-4 py-8 mx-auto">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-          <div className="lg:col-span-9">
+          <div className="min-w-0 lg:col-span-9">
             <article className="prose dark:prose-invert max-w-none">
               <PostHeader
                 post={{


### PR DESCRIPTION
Two small CSS changes that together stop posts from wobbling left/right on mobile:

1. `overflow-wrap: anywhere` on inline `<code>` — long unbreakable tokens (URLs, k8s labels, hostnames) had no spaces to break on and pushed the column wider than the viewport.
2. `min-w-0` on the article grid column — CSS grid items default to `min-width: auto`, which lets a wide child blow out the column and force the whole row to scroll. With `min-w-0`, overflow stays contained in the child that owns it.

Verified by inspecting the rendered HTML of the AntV post — lots of long inline-code spans and the `lg:col-span-9` article column had no min-width pin.