### PR TITLE
feat(newsletter): subscription-confirmation banner on /newsletters

### DIFF
--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { getAllNewsletters } from '@/lib/newsletters';
 import { Calendar, ArrowRight, Mail } from 'lucide-react';
 import { PageHero } from '@/components/page-hero';
 import { NewsletterForm } from '@/components/footer/newsletter-form';
+import { NewsletterConfirmationBanner } from '@/components/newsletter/newsletter-confirmation-banner';
 
 export const metadata: Metadata = {
   title: 'Newsletter Archive | DevOps Daily',
@@ -38,6 +40,13 @@ export default async function NewslettersPage() {
         description="Every week we send a roundup of new content, tools, and learning resources. Browse past issues or subscribe to get the next one in your inbox."
         breadcrumbs={[{ label: 'Newsletter Archive' }]}
       />
+
+      {/* Subscription-confirmation banner. Rendered only when the smtpfast
+       * double-opt-in redirect lands the user back here with ?confirmed=1.
+       * Suspense boundary is required because the banner reads useSearchParams. */}
+      <Suspense fallback={null}>
+        <NewsletterConfirmationBanner />
+      </Suspense>
 
       {/* Subscribe section */}
       <section className="container mx-auto px-4 -mt-4 mb-8 max-w-md">

--- a/components/newsletter/newsletter-confirmation-banner.tsx
+++ b/components/newsletter/newsletter-confirmation-banner.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { CheckCircle2, X } from 'lucide-react';
+
+/**
+ * Renders a one-off confirmation banner on the newsletters archive when
+ * a user has just confirmed their subscription via smtpfast. Point the
+ * smtpfast form's "confirmation redirect" at
+ * `https://devops-daily.com/newsletters?confirmed=1` (or any page that
+ * mounts this component) and they will see the banner above the archive
+ * list when they land.
+ *
+ * Self-clears the `confirmed` query param on dismiss so refresh doesn't
+ * re-show the banner. The router.replace runs without a scroll jump so
+ * the user's reading position is preserved.
+ */
+export function NewsletterConfirmationBanner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [dismissed, setDismissed] = useState(false);
+
+  const confirmed = searchParams.get('confirmed') === '1';
+
+  // Strip the param after 8s so the URL is clean even if the user does
+  // not dismiss. Eight seconds is long enough to read the banner and
+  // short enough that copy-paste of the page URL never goes around with
+  // a stale confirmation flag.
+  useEffect(() => {
+    if (!confirmed || dismissed) return;
+    const t = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('confirmed');
+      const next = params.toString();
+      router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+    }, 8000);
+    return () => clearTimeout(t);
+  }, [confirmed, dismissed, pathname, router, searchParams]);
+
+  if (!confirmed || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="container mx-auto px-4 max-w-3xl mt-4"
+    >
+      <div className="flex items-start gap-3 rounded-xl border border-emerald-500/30 bg-emerald-500/[0.08] px-4 py-3 sm:px-5 sm:py-4">
+        <CheckCircle2
+          className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-500"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            You&apos;re subscribed.
+          </p>
+          <p className="text-xs leading-5 text-emerald-700/80 dark:text-emerald-200/80 mt-0.5">
+            Thanks for confirming. Next Monday&apos;s issue is on the way.
+            Browse past issues below while you wait.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="flex-shrink-0 -m-1 p-1 rounded-md text-emerald-700/70 hover:text-emerald-700 dark:text-emerald-200/70 dark:hover:text-emerald-200 transition-colors"
+          aria-label="Dismiss confirmation message"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
After your subscribers click the confirmation link in the smtpfast double-opt-in email, they currently land on smtpfast's plain default page. This PR adds a friendly welcome banner on `/newsletters` so they land back on our site, see 'you're subscribed', and discover the issue archive in the same view.

**How it works:**
- New client component `NewsletterConfirmationBanner` reads `?confirmed=1` via `useSearchParams`.
- Renders an emerald banner above the existing subscribe form with copy + dismiss X.
- Auto-clears the query param after 8s via `router.replace` (no scroll jump) so refresh + share-the-URL stay clean.
- Wrapped in `<Suspense fallback={null}>` per Next 16's useSearchParams requirement.

**One config step on your side** after merging: in the smtpfast dashboard, set form `cmomznsaf0001utvb88nateg7`'s confirmation-redirect URL to `https://devops-daily.com/newsletters?confirmed=1`.

**Base branch is `feat/smtpfast-newsletter-signup`** (PR #1217) because that PR introduced the NewsletterForm mount on /newsletters that this banner sits above. Once #1217 merges, GitHub will retarget this PR at main automatically.