### PR TITLE
Security: Unsafe Dynamic Import Without Error Handling

### DIFF
--- a/components/games/cicd-stack-generator.tsx
+++ b/components/games/cicd-stack-generator.tsx
@@ -14,13 +14,31 @@ const LoadingSpinner = () => (
 export default function CICDStackGeneratorWrapper() {
   // We'll use a state to defer import until the component is mounted (client-side)
   const [Component, setComponent] = useState<React.ComponentType | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     // Only import the component on the client side
-    import('./cicd-stack-generator-impl').then((mod) => {
-      setComponent(() => mod.default);
-    });
+    import('./cicd-stack-generator-impl')
+      .then((mod) => {
+        if (mod.default) {
+          setComponent(() => mod.default);
+        } else {
+          setError('Failed to load CICD Stack Generator: invalid module');
+        }
+      })
+      .catch(() => {
+        setError('Failed to load CICD Stack Generator');
+      });
   }, []);
+
+  // Show error state if import failed
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-96 w-full">
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+  }
 
   // Show loading state until the component is loaded
   if (!Component) {

--- a/components/games/cicd-stack-generator.tsx
+++ b/components/games/cicd-stack-generator.tsx
@@ -26,7 +26,8 @@ export default function CICDStackGeneratorWrapper() {
           setError('Failed to load CICD Stack Generator: invalid module');
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('Failed to load CICD Stack Generator', err);
         setError('Failed to load CICD Stack Generator');
       });
   }, []);


### PR DESCRIPTION
## Summary

Security: Unsafe Dynamic Import Without Error Handling

## Problem

**Severity**: `Low` | **File**: `components/games/cicd-stack-generator.tsx:L28`

In `components/games/cicd-stack-generator.tsx`, a dynamic import is used without any error handling. If the module fails to load (network error, missing file, syntax error), the component will remain in a loading state indefinitely and no error is surfaced to the user. Additionally, the imported module's default export is used without validation.

## Solution

Add .catch() handling to the dynamic import to set an error state and display an appropriate error message to the user. Validate that mod.default exists before setting it as the component.

## Changes

- `components/games/cicd-stack-generator.tsx` (modified)