### PR TITLE
chore: strip em dashes and AI-cadence words from blog posts

### DIFF
--- a/content/posts/3-infrastructure-decisions-engineering-velocity.md
+++ b/content/posts/3-infrastructure-decisions-engineering-velocity.md
@@ -36,7 +36,7 @@ tags:
 
 Engineering teams obsess over monitoring tools, service meshes, and database choices. They spend weeks evaluating container runtimes. They debate GitOps vs traditional CI/CD.
 
-These decisions matter, but they're **optimizations**. They affect developer experience and operational efficiency, but they don't fundamentally change your team's ability to ship quickly.
+These decisions matter, but they're **optimizations**. They affect developer experience and operational efficiency, but they don't change your team's ability to ship quickly.
 
 Three infrastructure decisions have outsized impact on velocity:
 
@@ -115,7 +115,7 @@ IaC:       7.5 hours = 0.047 FTE = $780/month
 Platform:  1.2 hours = 0.007 FTE = $120/month
 ```
 
-The difference between manual and IaC is **$24,220/month** in engineer time—nearly a senior engineer's salary.
+The difference between manual and IaC is **$24,220/month** in engineer time, nearly a senior engineer's salary.
 
 ### Choosing Your Provisioning Model
 
@@ -153,7 +153,7 @@ The difference between manual and IaC is **$24,220/month** in engineer time—ne
 
 Developers push directly to production. No staging environment. Works for:
 - Very early startups (<5 engineers)
-- Teams with comprehensive automated testing
+- Teams with thorough automated testing
 - Low-risk applications (internal tools, content sites)
 
 **Velocity impact**: Maximum speed. Feature branches merge to main, CI runs, production deploys. **Total time from merge to production: 5-15 minutes.**

--- a/content/posts/a-day-in-a-life-of-a-devops-engineer.md
+++ b/content/posts/a-day-in-a-life-of-a-devops-engineer.md
@@ -272,7 +272,7 @@ Option 2: Let Query Finish
 
 The choice is made to kill the query and create the missing database index. The index creation takes 45 minutes on the large table, but once it's complete, the batch job can restart and finish in just 20 minutes instead of hours.
 
-> **Key Insight**: Sometimes you have to make tough decisions with incomplete information. The ability to quickly assess risk and choose the least harmful option is crucial in DevOps.
+> **Key Insight**: Sometimes you have to make tough decisions with incomplete information. The ability to quickly assess risk and choose the least harmful option matters in DevOps.
 
 > **⚡ Late Night Wisdom**: The best decisions aren't always the easiest ones. Protecting tomorrow's users was worth the short-term pain of restarting the batch job.
 
@@ -297,7 +297,7 @@ Daily Impact Summary:
 
 Tomorrow will bring new challenges. The marketing campaign is getting closer, and the infrastructure scaling plan needs finalization. The dashboard feature needs performance optimization before it can be fully rolled out. The development team needs security training to prevent credential leaks. The monitoring system needs those new business metrics.
 
-But tonight, millions of users were able to make purchases, view their dashboards, and access the application without interruption. The infrastructure held up under pressure, the team collaborated effectively during crises, and the systems are more robust than they were this morning.
+But tonight, millions of users were able to make purchases, view their dashboards, and access the application without interruption. The infrastructure held up under pressure, the team collaborated effectively during crises, and the systems are more resilient than they were this morning.
 
 **Tomorrow's Action Items:**
 
@@ -333,7 +333,7 @@ The database performance fix at midnight wasn't just about query optimization - 
 
 ## Skills Beyond Technology
 
-While technical skills are essential, DevOps engineering requires much more. Communication skills are crucial for coordinating with development teams, explaining technical issues to business stakeholders, and writing clear documentation for on-call procedures.
+While technical skills are essential, DevOps engineering requires much more. Communication skills are essential for coordinating with development teams, explaining technical issues to business stakeholders, and writing clear documentation for on-call procedures.
 
 Problem-solving skills go beyond debugging code. They involve understanding complex systems, identifying root causes of issues, and designing solutions that prevent future problems. The ability to work under pressure while maintaining clear thinking is essential when production systems are down and customers are affected.
 
@@ -343,13 +343,13 @@ Risk assessment becomes second nature - every change, every deployment, every in
 
 The most rewarding aspect of DevOps work isn't the dramatic incident responses or the complex technical solutions. It's the quiet satisfaction of building systems that work consistently, day after day, serving users around the world without interruption.
 
-When a deployment goes smoothly, when monitoring catches an issue before it affects users, when an infrastructure upgrade happens without downtime - these moments of seamless operation represent the true success of DevOps practices.
+When a deployment goes smoothly, when monitoring catches an issue before it affects users, when an infrastructure upgrade happens without downtime - these moments of smooth operation represent the true success of DevOps practices.
 
-The tools and technologies will continue to evolve, but the core mission remains the same: bridge the gap between development and operations, automate repetitive tasks, monitor everything that matters, and respond quickly when things go wrong. It's challenging work, but for those who enjoy solving complex problems and working with cutting-edge technology, there's nothing quite like it.
+The tools and technologies will continue to evolve, but the core mission remains the same: bridge the gap between development and operations, automate repetitive tasks, monitor everything that matters, and respond quickly when things go wrong. It's challenging work, but for those who enjoy solving complex problems and working with the latest technology, there's nothing quite like it.
 
 The best DevOps engineers are those who can see the bigger picture - understanding how their technical decisions impact users, businesses, and teams. They're the ones who can remain calm during crises, think strategically about infrastructure improvements, and communicate effectively with both technical and non-technical stakeholders.
 
-This is what a day in the life of a DevOps engineer really looks like - not just managing servers and writing scripts, but being a crucial part of the technology ecosystem that powers modern business operations.
+This is what a day in the life of a DevOps engineer really looks like - not just managing servers and writing scripts, but being a key part of the technology ecosystem that powers modern business operations.
 
 ## Key Takeaways for Aspiring DevOps Engineers
 
@@ -383,7 +383,7 @@ If this day-in-the-life resonates with you, here are some next steps:
 
 **The Reality Check**: DevOps isn't just about tools and automation. It's about building reliable systems that let businesses focus on serving their customers. Every alert, every deployment, every optimization contributes to that mission.
 
-The most rewarding part? Knowing that somewhere in the world, users are seamlessly making purchases, accessing services, and getting value from applications - all because the infrastructure you built and maintain is working exactly as it should.
+The most rewarding part? Knowing that somewhere in the world, users are making purchases, accessing services, and getting value from applications - all because the infrastructure you built and maintain is working exactly as it should.
 
 Go over the following [DevOps Roadmap](/roadmap) to see how you can build your skills and career in this exciting field.
 

--- a/content/posts/advanced-docker-features.md
+++ b/content/posts/advanced-docker-features.md
@@ -44,7 +44,7 @@ These aren't theoretical improvements. Teams report build time reductions from 1
 
 ## 1. BuildKit: Next-Generation Image Builds
 
-BuildKit is Docker's modern build engine that replaces the legacy builder. It provides parallel builds, efficient caching, and advanced features like cache mounts and secret mounts. While it's now the default in recent Docker versions, many developers don't leverage its full capabilities.
+BuildKit is Docker's modern build engine that replaces the legacy builder. It provides parallel builds, efficient caching, and advanced features like cache mounts and secret mounts. While it's now the default in recent Docker versions, many developers don't use its full capabilities.
 
 ### Why BuildKit Matters
 
@@ -714,9 +714,9 @@ The Docker documentation has detailed guides for each feature. The BuildKit docu
 
 ## Related Resources
 
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — harden containers for production
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller, faster images
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on practice
-- [Docker Security Checklist](/checklists/docker-security) — verify your setup
-- [Introduction to Docker: Best Practices](/guides/introduction-to-docker) — comprehensive guide
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps learning path
+- [Docker Security Best Practices](/posts/docker-security-best-practices): harden containers for production
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller, faster images
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on practice
+- [Docker Security Checklist](/checklists/docker-security): verify your setup
+- [Introduction to Docker: Best Practices](/guides/introduction-to-docker): full guide
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps learning path

--- a/content/posts/antv-npm-shai-hulud-wave-may-2026.md
+++ b/content/posts/antv-npm-shai-hulud-wave-may-2026.md
@@ -85,7 +85,7 @@ The worm runs as the CI user, so the credentials it reaches are everything the C
 
 1. **npm publish tokens** first. If any package you maintain was on the CI runner's auth, the worm has already tried to use it. Rotate via `npm token revoke` and re-issue, then audit `npm token list` for unknown tokens.
 2. **GitHub Actions `GITHUB_TOKEN` and personal access tokens.** Revoke at `github.com/settings/tokens`. If the worker created a public repo under your account, find and delete it (search your repos for names matching `<dune>-<dune>-<digits>` or the marker string `niagA oG eW ereH :duluH-iahS`).
-3. **Cloud IAM keys** — AWS, GCP, Azure. The worm reads `~/.aws/credentials`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Rotate via the cloud console; do not just edit the env var.
+3. **Cloud IAM keys**: AWS, GCP, Azure. The worm reads `~/.aws/credentials`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Rotate via the cloud console; do not just edit the env var.
 4. **Kubernetes service-account tokens.** If the runner had a `KUBECONFIG`, that token can pull secrets from the cluster. Rotate the service account.
 5. **Vault tokens.** `VAULT_TOKEN` is in the targeted list. Revoke the token and audit the audit log for its recent use.
 6. **SSH keys.** The worm copies `~/.ssh/id_*` private keys. Rotate any key the CI runner had access to (deploy keys, signing keys).

--- a/content/posts/argument-list-too-long-error.md
+++ b/content/posts/argument-list-too-long-error.md
@@ -401,4 +401,4 @@ if [ $COUNT -gt $THRESHOLD ]; then
 fi
 ```
 
-The "argument list too long" error happens when wildcards expand to too many files. Use `find` with `-delete`, `-exec`, or pipe to `xargs` as robust alternatives that handle any number of files efficiently.
+The "argument list too long" error happens when wildcards expand to too many files. Use `find` with `-delete`, `-exec`, or pipe to `xargs` as reliable alternatives that handle any number of files efficiently.

--- a/content/posts/aws-cost-optimization.md
+++ b/content/posts/aws-cost-optimization.md
@@ -23,7 +23,7 @@ featured: true
 
 That was the message I received from our finance team last January that kicked off our cloud cost optimization journey. For privacy reasons, I won't disclose the name of our company, but we're a mid-sized SaaS provider with about 500,000 monthly active users.
 
-Six months later, we've reduced our AWS costs by 73% while simultaneously improving application performance. This wasn't through downsizing or reducing capabilities, but by making smarter architectural choices and leveraging AWS services in ways we hadn't considered before.
+Six months later, we've reduced our AWS costs by 73% while simultaneously improving application performance. This wasn't through downsizing or reducing capabilities, but by making smarter architectural choices and using AWS services in ways we hadn't considered before.
 
 Here's exactly how we did it, and how you can apply the same principles to your infrastructure.
 
@@ -289,7 +289,7 @@ Our six-month optimization journey resulted in:
 
 Based on our experience, here's a starting framework you can use:
 
-1. **Implement comprehensive tagging and monitoring**:
+1. **Implement thorough tagging and monitoring**:
 
    - Environment, Team, Project, Purpose at minimum
    - Set up detailed CloudWatch dashboards for utilization
@@ -321,6 +321,6 @@ Based on our experience, here's a starting framework you can use:
 
 Our cost optimization journey didn't end after six months. We've built ongoing optimization into our regular workflows. Each quarter, we review our infrastructure and look for new opportunities to optimize.
 
-The biggest lesson? Cost optimization done right doesn't compromise performance or reliability, it often improves them by forcing you to understand your workloads better and leverage AWS services more effectively.
+The biggest lesson? Cost optimization done right doesn't compromise performance or reliability, it often improves them by forcing you to understand your workloads better and use AWS services more effectively.
 
 By being methodical, data-driven, and willing to challenge our assumptions, we transformed our AWS bill from a growing concern to a competitive advantage, freeing up resources to invest in new features and growth opportunities instead of unnecessary cloud spend.

--- a/content/posts/aws-use1-az4-thermal-event-single-az-lessons.md
+++ b/content/posts/aws-use1-az4-thermal-event-single-az-lessons.md
@@ -61,7 +61,7 @@ Two technical observations worth pinning to a sticky note:
 2. The affected zone hosted parts of the matching engine and the Kafka messaging infrastructure.
 3. Backup systems "did not work as expected during the incident, extending the outage and forcing engineers to manually execute disaster recovery procedures."
 
-None of those choices are dumb on their own. A matching engine at exchange scale is genuinely latency-sensitive and there are real reasons to pin it to one AZ. The problem is that single-AZ-for-latency only survives an `use1-az4` event if the failover into another AZ is a battle-tested one-button operation that an SRE can trigger in the first five minutes of an alert. Coinbase had a backup. The backup did not work. That gap is what cost them five hours.
+None of those choices are dumb on their own. A matching engine at exchange scale is latency-sensitive and there are real reasons to pin it to one AZ. The problem is that single-AZ-for-latency only survives an `use1-az4` event if the failover into another AZ is a battle-tested one-button operation that an SRE can trigger in the first five minutes of an alert. Coinbase had a backup. The backup did not work. That gap is what cost them five hours.
 
 The pattern is general enough to be worth a name. Call it the *"we have a backup"* fallacy: the backup exists, but it has never been promoted to primary under real failure conditions, so nobody knows what breaks when it is. The fix is not to write a longer DR doc. The fix is to actually break things on purpose, on a schedule.
 

--- a/content/posts/bash-loop-through-file-content.md
+++ b/content/posts/bash-loop-through-file-content.md
@@ -19,7 +19,7 @@ tags:
   - Text Processing
 ---
 
-Reading file content line by line is a fundamental operation in Bash scripting. Whether you're processing log files, configuration files, or data sets, understanding the different approaches and their nuances will help you write more robust scripts.
+Reading file content line by line is a fundamental operation in Bash scripting. Whether you're processing log files, configuration files, or data sets, understanding the different approaches and their nuances will help you write more reliable scripts.
 
 ## The Standard while read Loop
 

--- a/content/posts/bash-redirect-append-stdout-stderr.md
+++ b/content/posts/bash-redirect-append-stdout-stderr.md
@@ -249,4 +249,4 @@ tail -f output.log    # Terminal 1
 tail -f errors.log    # Terminal 2
 ```
 
-These redirection techniques give you fine-grained control over how your scripts handle output and errors, making debugging easier and creating comprehensive audit trails for your automated processes.
+These redirection techniques give you fine-grained control over how your scripts handle output and errors, making debugging easier and creating complete audit trails for your automated processes.

--- a/content/posts/best-practices-when-using-terraform.md
+++ b/content/posts/best-practices-when-using-terraform.md
@@ -46,7 +46,7 @@ terraform workspace select dev
 
 ## Manage State Securely
 
-Terraform uses state files to keep track of your infrastructure. Managing these files securely is crucial to avoid conflicts and ensure consistency.
+Terraform uses state files to keep track of your infrastructure. Managing these files securely is important to avoid conflicts and ensure consistency.
 
 ### Use Remote Backends
 

--- a/content/posts/build-vs-buy-2026.md
+++ b/content/posts/build-vs-buy-2026.md
@@ -29,7 +29,7 @@ tags: [Engineering Leadership, Infrastructure, Cost Analysis, Platform Engineeri
 
 This statement, or variations of it, has burned millions of dollars and delayed countless product launches. I've watched teams of talented engineers spend 6 months building internal platforms that end up being **worse** than off-the-shelf solutions while costing 3-5× more to maintain.
 
-The decision to build vs buy infrastructure tooling is rarely about technical capability—you **can** build almost anything given enough time. The real questions are:
+The decision to build vs buy infrastructure tooling is rarely about technical capability; you **can** build almost anything given enough time. The real questions are:
 
 1. **What is this decision actually costing in engineer-months?**
 2. **What product features are we not building while we build infrastructure?**
@@ -552,10 +552,10 @@ At 15 engineers, every engineer-month counts. The "savings" from self-hosting wo
 
 At 60 engineers, you're in the gray zone. If:
 - You have 2-3 engineers excited to build/own this long-term
-- Your deployment process is genuinely complex and slowing teams down
+- Your deployment process is complex and slowing teams down
 - Leadership is committed for 3+ years
 
-Then it **might** make sense. But be honest about the productivity gains—most teams overestimate by 2-3×.
+Then it **might** make sense. But be honest about the productivity gains; most teams overestimate by 2-3×.
 
 ---
 
@@ -681,6 +681,6 @@ In 2026, the SaaS ecosystem is mature enough that **95% of engineering teams sho
 2. **Massive scale** (500+ engineers, $1M+/year spend on a single tool)
 3. **Unique compliance** (data sovereignty, extreme security requirements)
 
-For everyone else: Buy the infrastructure, build the product. Your customers don't care if you built your own CI/CD platform—they care about the product you're selling them.
+For everyone else: Buy the infrastructure, build the product. Your customers don't care if you built your own CI/CD platform; they care about the product you're selling them.
 
 **The best infrastructure is the infrastructure you don't have to think about.**

--- a/content/posts/can-two-sockets-share-tcp-port.md
+++ b/content/posts/can-two-sockets-share-tcp-port.md
@@ -364,4 +364,4 @@ else:
 - Internal vs external access on same port
 - Segregating traffic by network
 
-Two sockets can share a port in multiple ways - through accepting multiple connections on a listening socket, using `SO_REUSEPORT` for multi-process load balancing, or binding to different IP addresses. Understanding these mechanisms helps you build robust, high-performance network applications.
+Two sockets can share a port in multiple ways - through accepting multiple connections on a listening socket, using `SO_REUSEPORT` for multi-process load balancing, or binding to different IP addresses. Understanding these mechanisms helps you build reliable, high-performance network applications.

--- a/content/posts/cannot-connect-to-docker-daemon.md
+++ b/content/posts/cannot-connect-to-docker-daemon.md
@@ -349,7 +349,7 @@ The "Cannot connect to the Docker daemon" error is usually either a stopped serv
 
 ## Related Resources
 
-- [How to Fix Docker: Permission Denied](/posts/fix-docker-permission-denied-error) — related permissions troubleshooting
-- [Introduction to Docker: Installation](/guides/introduction-to-docker) — set up Docker properly from the start
-- [Docker Flashcards](/flashcards/docker-essentials) — review core Docker concepts
-- [DevOps Roadmap](/roadmap) — where Docker fits in your learning path
+- [How to Fix Docker: Permission Denied](/posts/fix-docker-permission-denied-error): related permissions troubleshooting
+- [Introduction to Docker: Installation](/guides/introduction-to-docker): set up Docker properly from the start
+- [Docker Flashcards](/flashcards/docker-essentials): review core Docker concepts
+- [DevOps Roadmap](/roadmap): where Docker fits in your learning path

--- a/content/posts/change-echo-output-color-linux.md
+++ b/content/posts/change-echo-output-color-linux.md
@@ -126,7 +126,7 @@ echo "${bold_green}This is bold green text${reset}"
 
 ## Creating a Color Library
 
-Here's a comprehensive color library for your scripts:
+Here's a color library for your scripts:
 
 ```bash
 #!/bin/bash
@@ -402,4 +402,4 @@ echo -e "${RED}This will be red if supported${RESET}"
 6. **Consider accessibility** - don't rely solely on color to convey information
 7. **Store colors in variables** for easy maintenance and consistency
 
-Adding colors to your terminal output enhances the user experience and makes your scripts more professional. Whether you use ANSI escape codes, tput commands, or create comprehensive color libraries, these techniques will help you create more engaging and informative command-line applications.
+Adding colors to your terminal output enhances the user experience and makes your scripts more professional. Whether you use ANSI escape codes, tput commands, or create color libraries, these techniques will help you create more engaging and informative command-line applications.

--- a/content/posts/check-directory-exists-bash-script.md
+++ b/content/posts/check-directory-exists-bash-script.md
@@ -311,7 +311,7 @@ backup_location="/backups/documents"
 create_backup "$source_directory" "$backup_location"
 ```
 
-This backup script demonstrates comprehensive directory validation before performing file operations.
+This backup script demonstrates directory validation before performing file operations.
 
 ## Directory Checking in Loops and Conditionals
 

--- a/content/posts/check-file-not-exist-bash.md
+++ b/content/posts/check-file-not-exist-bash.md
@@ -104,7 +104,7 @@ for path in "${test_paths[@]}"; do
 done
 ```
 
-This comprehensive check helps you understand exactly what you're dealing with when a file test fails.
+This check helps you understand exactly what you're dealing with when a file test fails.
 
 ## Using Double Bracket Syntax
 
@@ -147,7 +147,7 @@ Double brackets `[[ ]]` handle variables with spaces better and provide addition
 
 ## Creating Safety Checks for File Operations
 
-File non-existence checks are crucial for preventing accidental overwrites and ensuring safe operations:
+File non-existence checks help prevent accidental overwrites and ensuring safe operations:
 
 ```bash
 #!/bin/bash

--- a/content/posts/check-if-program-exists-bash-script.md
+++ b/content/posts/check-if-program-exists-bash-script.md
@@ -233,7 +233,7 @@ check_git_version() {
 }
 ```
 
-## Creating a Comprehensive Dependency Checker
+## Creating a Dependency Checker
 
 Here's a complete function that combines all the best practices:
 
@@ -321,4 +321,4 @@ fi
 5. **Consider version requirements** - Some scripts need specific versions
 6. **Group dependency checks** - Check all requirements before starting work
 
-Checking for program availability is a crucial part of writing robust Bash scripts. Using the right method for your specific needs ensures your scripts work reliably across different systems and provide helpful feedback when requirements aren't met.
+Checking for program availability is an important part of writing reliable Bash scripts. Using the right method for your specific needs ensures your scripts work reliably across different systems and provide helpful feedback when requirements aren't met.

--- a/content/posts/check-if-variable-set-bash.md
+++ b/content/posts/check-if-variable-set-bash.md
@@ -19,7 +19,7 @@ tags:
   - Shell
 ---
 
-Checking whether variables are set, unset, or empty is crucial for writing robust Bash scripts. Proper variable validation prevents errors, provides meaningful feedback to users, and ensures your scripts behave predictably in different environments.
+Checking whether variables are set, unset, or empty matters for writing reliable Bash scripts. Proper variable validation prevents errors, provides meaningful feedback to users, and ensures your scripts behave predictably in different environments.
 
 This guide covers various methods to test variable states, from basic existence checks to advanced parameter expansion techniques.
 
@@ -165,9 +165,9 @@ validate_required() {
 # validate_required
 ```
 
-## Comprehensive Variable Checking Function
+## Variable Checking Function
 
-Here's a robust function that checks various variable states:
+Here's a function that checks various variable states:
 
 ```bash
 #!/bin/bash
@@ -207,7 +207,7 @@ check_variable "undeclared_var"
 
 ## Environment Variable Validation
 
-Create a comprehensive environment variable checker:
+Create an environment variable checker:
 
 ```bash
 #!/bin/bash
@@ -467,4 +467,4 @@ echo "  Database Host: $DATABASE_HOST"
 9. **Use arrays for managing multiple related variables**
 10. **Document required and optional variables** in your scripts
 
-Variable checking is essential for creating robust Bash scripts. By properly validating variable states and providing appropriate defaults or error handling, your scripts will be more reliable and user-friendly.
+Variable checking is essential for creating reliable Bash scripts. By properly validating variable states and providing appropriate defaults or error handling, your scripts will be more reliable and user-friendly.

--- a/content/posts/check-string-contains-substring-bash.md
+++ b/content/posts/check-string-contains-substring-bash.md
@@ -374,7 +374,7 @@ Pattern matching with double brackets is typically the fastest for simple substr
 
 ## Advanced String Matching Functions
 
-Create a comprehensive string matching utility:
+Create a string matching utility:
 
 ```bash
 #!/bin/bash
@@ -456,7 +456,7 @@ echo "Ends with 'string.' (case-sensitive): $(ends_with "$test_string" "string."
 echo "Matches email pattern: $(matches_regex "$test_string" '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' && echo "YES" || echo "NO")"
 ```
 
-This utility library provides a comprehensive set of string matching functions for various use cases.
+This utility library provides a set of string matching functions for various use cases.
 
 ## Configuration File Processing
 

--- a/content/posts/checking-kubernetes-pod-cpu-and-memory-utilization.md
+++ b/content/posts/checking-kubernetes-pod-cpu-and-memory-utilization.md
@@ -87,7 +87,7 @@ This command provides detailed information, including resource requests and limi
 
 ## Conclusion
 
-Monitoring CPU and memory utilization of Kubernetes Pods is crucial for maintaining cluster performance. By using `kubectl top` and metrics-server, you can efficiently track resource usage and optimize your applications.
+Monitoring CPU and memory utilization of Kubernetes Pods is important for maintaining cluster performance. By using `kubectl top` and metrics-server, you can efficiently track resource usage and optimize your applications.
 
 
 ## Related Resources

--- a/content/posts/claude-code-hidden-features-you-probably-missed.md
+++ b/content/posts/claude-code-hidden-features-you-probably-missed.md
@@ -23,7 +23,7 @@ tags:
 
 Most people use Claude Code to write code, fix bugs, and maybe generate a commit message. That's fine, but you're leaving a lot on the table.
 
-Boris Cherny, the creator of Claude Code, recently shared a [thread on X](https://x.com/bcherny/status/2038454336355999749) about features that even daily users tend to overlook. Some of these genuinely changed how I work. Here's a rundown of the ones worth knowing about.
+Boris Cherny, the creator of Claude Code, recently shared a [thread on X](https://x.com/bcherny/status/2038454336355999749) about features that even daily users tend to overlook. Some of these changed how I work. Here's a rundown of the ones worth knowing about.
 
 ## TLDR
 

--- a/content/posts/close-vs-shutdown-socket.md
+++ b/content/posts/close-vs-shutdown-socket.md
@@ -1,6 +1,6 @@
 ---
 title: 'Close vs Shutdown Socket'
-excerpt: 'Understanding the difference between close() and shutdown() for sockets is crucial for proper connection handling. Learn when to use each, how shutdown enables half-closed connections, and how close releases file descriptors.'
+excerpt: 'Understanding the difference between close() and shutdown() for sockets matters for proper connection handling. Learn when to use each, how shutdown enables half-closed connections, and how close releases file descriptors.'
 category:
   name: 'Networking'
   slug: 'networking'

--- a/content/posts/cloud-bill-organizational-problem.md
+++ b/content/posts/cloud-bill-organizational-problem.md
@@ -24,7 +24,7 @@ tags:
 
 ## TLDR
 
-Most cloud cost optimization focuses on technical fixes: rightsizing instances, buying reserved capacity, cleaning up unused resources. These deliver 10-20% savings initially, then plateau. The real cost driver is organizational: unclear service ownership, no accountability for spend, and infrastructure treated as a shared resource pool instead of tied to product teams. Companies that tie cloud costs directly to service owners see 30-50% sustained cost reduction—not through better instance selection, but through different decision-making incentives.
+Most cloud cost optimization focuses on technical fixes: rightsizing instances, buying reserved capacity, cleaning up unused resources. These deliver 10-20% savings initially, then plateau. The real cost driver is organizational: unclear service ownership, no accountability for spend, and infrastructure treated as a shared resource pool instead of tied to product teams. Companies that tie cloud costs directly to service owners see 30-50% sustained cost reduction, not through better instance selection, but through different decision-making incentives.
 
 ---
 
@@ -61,7 +61,7 @@ Technical optimization is a one-time gain. Organizational structure is the ongoi
 
 ### Common Technical Cost Optimization Tactics
 
-These all work—initially:
+These all work, initially:
 
 **1. Rightsizing instances** (5-15% savings)
 - Identify over-provisioned EC2/RDS instances
@@ -356,7 +356,7 @@ When cost is visible during planning:
 
 ### "Engineers shouldn't have to think about cost"
 
-**Response**: Engineers already make cost decisions—instance size, architecture, scaling policies. Making cost **visible** helps them make **better** decisions. It's not about penny-pinching; it's about informed trade-offs.
+**Response**: Engineers already make cost decisions: instance size, architecture, scaling policies. Making cost **visible** helps them make **better** decisions. It's not about penny-pinching; it's about informed trade-offs.
 
 **Analogy**: You wouldn't design a product feature without knowing how it affects user experience. Why design infrastructure without knowing how it affects cost?
 
@@ -419,6 +419,6 @@ Technical fixes (rightsizing, reserved instances, cleanup) are necessary but ins
 3. Tie infrastructure cost to team budgets (Months 5-6)
 4. Let teams optimize their own services (Ongoing)
 
-The companies that treat cloud cost as an **organizational challenge** outperform those who treat it as a **technical problem**. Not because they have better FinOps tools—because they've aligned incentives with outcomes.
+The companies that treat cloud cost as an **organizational challenge** outperform those who treat it as a **technical problem**. Not because they have better FinOps tools, but because they've aligned incentives with outcomes.
 
 Your cloud bill isn't an AWS problem. It's a team structure problem.

--- a/content/posts/comment-in-dockerfile.md
+++ b/content/posts/comment-in-dockerfile.md
@@ -68,8 +68,8 @@ By following these practices, you can make your Dockerfiles more readable and ma
 
 ## Related Resources
 
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — choose the right instruction
-- [Docker Build Requires 1 Argument](/posts/docker-build-requires-1-argument) — fix common build errors
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — write secure Dockerfiles
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): choose the right instruction
+- [Docker Build Requires 1 Argument](/posts/docker-build-requires-1-argument): fix common build errors
+- [Docker Security Best Practices](/posts/docker-security-best-practices): write secure Dockerfiles
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/communication-multiple-docker-compose.md
+++ b/content/posts/communication-multiple-docker-compose.md
@@ -21,7 +21,7 @@ tags:
 
 ## TLDR
 
-To enable communication between multiple Docker-Compose projects, use shared networks by defining external networks in the `docker-compose.yml` files. This allows containers from different projects to interact seamlessly.
+To enable communication between multiple Docker-Compose projects, use shared networks by defining external networks in the `docker-compose.yml` files. This allows containers from different projects to interact directly.
 
 ---
 
@@ -137,12 +137,12 @@ Docker's internal DNS resolves container names to IP addresses, making it easy t
 - **Secure Communication**: Use firewalls or Docker's network settings to restrict access.
 - **Monitor Traffic**: Use tools like `docker network inspect` to monitor network configurations.
 
-By following these steps, you can enable seamless communication between multiple Docker-Compose projects, making it easier to manage complex containerized applications.
+By following these steps, you can enable communication between multiple Docker-Compose projects, making it easier to manage complex containerized applications.
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — understand port publishing vs internal communication
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — manage config across services
-- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker) — host-container networking
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking deep dive
-- [Docker Security Checklist](/checklists/docker-security) — secure your multi-service setup
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): understand port publishing vs internal communication
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): manage config across services
+- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker): host-container networking
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking deep dive
+- [Docker Security Checklist](/checklists/docker-security): secure your multi-service setup

--- a/content/posts/compare-two-directory-trees-by-content.md
+++ b/content/posts/compare-two-directory-trees-by-content.md
@@ -345,7 +345,7 @@ The `cmp` command compares files byte-by-byte and works well with binaries.
 
 ## Creating a Detailed Comparison Report
 
-Generate a comprehensive report:
+Generate a detailed report:
 
 ```bash
 #!/bin/bash

--- a/content/posts/conditional-resource-creation-in-terraform-using-vars.md
+++ b/content/posts/conditional-resource-creation-in-terraform-using-vars.md
@@ -461,7 +461,7 @@ resource "aws_instance" "app" {
 
 ## Real-World Example: Multi-Environment Application Stack
 
-Here's a comprehensive example showing how to build a flexible application stack:
+Here's a full example showing how to build a flexible application stack:
 
 ```terraform
 # variables.tf

--- a/content/posts/connect-to-host-localhost-from-docker.md
+++ b/content/posts/connect-to-host-localhost-from-docker.md
@@ -155,8 +155,8 @@ Happy containerizing!
 
 ## Related Resources
 
-- [Docker Access Host Port from Container](/posts/docker-access-host-port) — more on host-container networking
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — understand port publishing
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — Docker networking fundamentals
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [DevOps Roadmap](/roadmap) — where Docker fits in the bigger picture
+- [Docker Access Host Port from Container](/posts/docker-access-host-port): more on host-container networking
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): understand port publishing
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): Docker networking fundamentals
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [DevOps Roadmap](/roadmap): where Docker fits in the bigger picture

--- a/content/posts/connecting-to-postgresql-in-a-docker-container-from-outside.md
+++ b/content/posts/connecting-to-postgresql-in-a-docker-container-from-outside.md
@@ -214,8 +214,8 @@ With these patterns you can safely expose Postgres for local development, connec
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — when to publish ports vs keep them internal
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure your containers
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — manage database credentials safely
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — persist database data
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps learning
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): when to publish ports vs keep them internal
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure your containers
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): manage database credentials safely
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): persist database data
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps learning

--- a/content/posts/copy-docker-images-between-hosts-withouta-repository.md
+++ b/content/posts/copy-docker-images-between-hosts-withouta-repository.md
@@ -324,7 +324,7 @@ Happy containerizing!
 
 ## Related Resources
 
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — clean up images after transfers
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — reduce image sizes for faster transfers
-- [Introduction to Docker: Working with Images](/guides/introduction-to-docker) — image management fundamentals
-- [Docker Flashcards](/flashcards/docker-essentials) — review core Docker concepts
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): clean up images after transfers
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): reduce image sizes for faster transfers
+- [Introduction to Docker: Working with Images](/guides/introduction-to-docker): image management fundamentals
+- [Docker Flashcards](/flashcards/docker-essentials): review core Docker concepts

--- a/content/posts/copy-files-from-docker-container-to-host.md
+++ b/content/posts/copy-files-from-docker-container-to-host.md
@@ -224,7 +224,7 @@ Happy containerizing!
 
 ## Related Resources
 
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — persistent data management
-- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion) — control what goes into images
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — configure data paths
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): persistent data management
+- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion): control what goes into images
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): configure data paths
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/copy-with-docker-exclusion.md
+++ b/content/posts/copy-with-docker-exclusion.md
@@ -21,7 +21,7 @@ tags:
 
 ## TLDR
 
-To exclude files or directories when using the `COPY` instruction in Docker, leverage `.dockerignore` files. This ensures that unwanted files are not copied into your Docker image, optimizing build times and reducing image size.
+To exclude files or directories when using the `COPY` instruction in Docker, use `.dockerignore` files. This ensures that unwanted files are not copied into your Docker image, optimizing build times and reducing image size.
 
 ---
 
@@ -119,8 +119,8 @@ By following these steps, you can effectively use the `COPY` instruction in Dock
 
 ## Related Resources
 
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — Dockerfile instruction fundamentals
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller images
-- [Advanced Docker Features](/posts/advanced-docker-features) — multi-stage builds and BuildKit
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on practice
-- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker) — full Dockerfile guide
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): Dockerfile instruction fundamentals
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller images
+- [Advanced Docker Features](/posts/advanced-docker-features): multi-stage builds and BuildKit
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on practice
+- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker): full Dockerfile guide

--- a/content/posts/count-lines-of-code-recursively.md
+++ b/content/posts/count-lines-of-code-recursively.md
@@ -89,7 +89,7 @@ find . -type f \( -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx"
 
 ## Advanced Filtering with Detailed Output
 
-Create a script that provides comprehensive statistics:
+Create a script that provides detailed statistics:
 
 ```bash
 #!/bin/bash

--- a/content/posts/create-folder-in-s3-bucket.md
+++ b/content/posts/create-folder-in-s3-bucket.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Create a Folder in an AWS S3 Bucket Using Terraform'
-excerpt: 'Learn how to create a folder in an AWS S3 bucket using Terraform by leveraging the `aws_s3_object` resource.'
+excerpt: 'Learn how to create a folder in an AWS S3 bucket using Terraform with the `aws_s3_object` resource.'
 category:
   name: 'Terraform'
   slug: 'terraform'

--- a/content/posts/dast-integration-guide.md
+++ b/content/posts/dast-integration-guide.md
@@ -337,7 +337,7 @@ docker run -m 4g ghcr.io/zaproxy/zaproxy:stable \
 
 DAST is one layer of defense, not a silver bullet. It misses code-level flaws like buffer overflows and race conditions (use SAST for those). It struggles with complex multi-step business logic attacks. It cannot test endpoints behind authentication without proper setup. And it will not find client-side vulnerabilities in mobile or desktop apps.
 
-The best security testing strategy combines SAST for early detection during development, DAST for runtime validation in staging, and IAST for comprehensive coverage during testing. Add dependency scanning and infrastructure security on top and you have real defense in depth.
+The best security testing strategy combines SAST for early detection during development, DAST for runtime validation in staging, and IAST for broad coverage during testing. Add dependency scanning and infrastructure security on top and you have real defense in depth.
 
 ## Getting Started
 

--- a/content/posts/defining-variables-with-without-export-linux.md
+++ b/content/posts/defining-variables-with-without-export-linux.md
@@ -19,7 +19,7 @@ tags:
   - export command
 ---
 
-Understanding the difference between regular shell variables and exported environment variables is crucial for effective Linux shell scripting and system administration. The `export` command controls whether variables are available to child processes and external programs.
+Understanding the difference between regular shell variables and exported environment variables matters for effective Linux shell scripting and system administration. The `export` command controls whether variables are available to child processes and external programs.
 
 ## Prerequisites
 

--- a/content/posts/delete-all-local-docker-images.md
+++ b/content/posts/delete-all-local-docker-images.md
@@ -158,7 +158,7 @@ Clean up networks that containers no longer use:
 docker network prune
 ```
 
-For a comprehensive cleanup of everything unused:
+For a full cleanup of everything unused:
 
 ```bash
 # Nuclear option: remove everything unused
@@ -246,8 +246,8 @@ Cleaning up Docker images regularly keeps your development environment fast and 
 
 ## Related Resources
 
-- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers) — force fresh containers
-- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository) — transfer images without a registry
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — keep images lean
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
-- [Docker Flashcards](/flashcards/docker-essentials) — quick Docker review
+- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers): force fresh containers
+- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository): transfer images without a registry
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): keep images lean
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals
+- [Docker Flashcards](/flashcards/docker-essentials): quick Docker review

--- a/content/posts/delete-exported-environment-variables-linux.md
+++ b/content/posts/delete-exported-environment-variables-linux.md
@@ -162,7 +162,7 @@ You can list all environment variables to confirm removal using the `env` comman
 env | grep API_KEY
 ```
 
-If the variable was successfully removed, this command returns no output. For a more comprehensive check, you can compare the environment before and after:
+If the variable was successfully removed, this command returns no output. For a more thorough check, you can compare the environment before and after:
 
 ```bash
 env > before.txt

--- a/content/posts/devops-vs-sysadmin-vs-sre.md
+++ b/content/posts/devops-vs-sysadmin-vs-sre.md
@@ -32,10 +32,10 @@ If you're exploring a career in IT, you've probably seen job postings for "DevOp
 
 Understanding these roles helps you:
 
-- **Choose your career path** — Know which skills to develop
-- **Understand job postings** — Decode what companies actually want
-- **Communicate with teams** — Speak the same language as your colleagues
-- **Plan your learning** — Focus on the right tools and concepts
+- **Choose your career path**: Know which skills to develop
+- **Understand job postings**: Decode what companies actually want
+- **Communicate with teams**: Speak the same language as your colleagues
+- **Plan your learning**: Focus on the right tools and concepts
 
 Let's break down each role in plain English.
 
@@ -140,7 +140,7 @@ SRE was pioneered by Google and applies **software engineering principles to ope
 - Capacity planning and performance optimization
 - On-call rotations with a focus on sustainable practices
 
-**How SRE relates to DevOps:** There's significant overlap between the two disciplines. Some organizations use the terms interchangeably, while others see SRE as a specific implementation of DevOps principles with its own unique practices. Both aim for reliable, automated systems — they just approach it from slightly different angles.
+**How SRE relates to DevOps:** There's significant overlap between the two disciplines. Some organizations use the terms interchangeably, while others see SRE as a specific implementation of DevOps principles with its own unique practices. Both aim for reliable, automated systems, they just approach it from slightly different angles.
 
 ### A Day in the Life
 
@@ -154,7 +154,7 @@ A typical SRE might:
 - Work with a product team on their reliability requirements
 
 ### Key Skills
-SREs need strong **software engineering skills** (not just scripting—real coding), deep understanding of **distributed systems** (how large-scale applications work across many servers), expertise in **reliability measurement** (defining what "good enough" means with data), and skills in **incident management** (responding to and learning from outages).
+SREs need strong **software engineering skills** (not just scripting, real coding), deep understanding of **distributed systems** (how large-scale applications work across many servers), expertise in **reliability measurement** (defining what "good enough" means with data), and skills in **incident management** (responding to and learning from outages).
 
 ### The SRE Mindset
 
@@ -296,11 +296,11 @@ No matter which path interests you, here's how to begin:
 
 ### Foundation Skills (All Roles)
 
-1. **Learn Linux basics** — Command line, file system, processes
-2. **Understand networking** — IP addresses, DNS, ports, HTTP
-3. **Practice scripting** — Start with Bash, then Python
-4. **Use version control** — Git is essential
-5. **Set up a home lab** — Practice on virtual machines
+1. **Learn Linux basics**: Command line, file system, processes
+2. **Understand networking**: IP addresses, DNS, ports, HTTP
+3. **Practice scripting**: Start with Bash, then Python
+4. **Use version control**: Git is essential
+5. **Set up a home lab**: Practice on virtual machines
 
 ### Next Steps by Role
 

--- a/content/posts/difference-between-cmd-and-entrypoint-in-dockerfiles.md
+++ b/content/posts/difference-between-cmd-and-entrypoint-in-dockerfiles.md
@@ -18,7 +18,7 @@ tags:
   - Best Practices
 ---
 
-Understanding the difference between `CMD` and `ENTRYPOINT` instructions in a Dockerfile is crucial for creating flexible, usable Docker images. These instructions determine what process runs inside your container and how users can interact with it. This guide explains their differences, how they work together, and when to use each one.
+Understanding the difference between `CMD` and `ENTRYPOINT` instructions in a Dockerfile matters for creating flexible, usable Docker images. These instructions determine what process runs inside your container and how users can interact with it. This guide explains their differences, how they work together, and when to use each one.
 
 ## Prerequisites
 

--- a/content/posts/difference-between-pod-and-deployment.md
+++ b/content/posts/difference-between-pod-and-deployment.md
@@ -1,6 +1,6 @@
 ---
 title: 'What is the Difference Between a Pod and a Deployment?'
-excerpt: 'Understanding the difference between Pods and Deployments in Kubernetes is crucial for managing containerized applications effectively. Learn how they work and when to use each.'
+excerpt: 'Understanding the difference between Pods and Deployments in Kubernetes matters for managing containerized applications effectively. Learn how they work and when to use each.'
 category:
   name: 'Kubernetes'
   slug: 'kubernetes'
@@ -134,4 +134,4 @@ A Deployment can be visualized as follows:
 
 ## Conclusion
 
-Understanding the difference between Pods and Deployments is essential for effective Kubernetes management. Pods are the building blocks, while Deployments provide the tools to manage them at scale. By leveraging both, you can create robust and scalable containerized applications.
+Understanding the difference between Pods and Deployments is essential for effective Kubernetes management. Pods are the building blocks, while Deployments provide the tools to manage them at scale. By using both, you can create reliable and scalable containerized applications.

--- a/content/posts/difference-between-targetport-and-port-in-kubernetes-service-definition.md
+++ b/content/posts/difference-between-targetport-and-port-in-kubernetes-service-definition.md
@@ -20,7 +20,7 @@ tags:
 
 ## Introduction
 
-When defining a Service in Kubernetes, you often encounter two key properties: `port` and `targetPort`. These properties play a crucial role in how traffic is routed to your application, but their differences can sometimes be confusing. In this guide, you'll learn what each property does, how they interact, and when to use them.
+When defining a Service in Kubernetes, you often encounter two key properties: `port` and `targetPort`. These properties play a key role in how traffic is routed to your application, but their differences can sometimes be confusing. In this guide, you'll learn what each property does, how they interact, and when to use them.
 
 ## Prerequisites
 

--- a/content/posts/difference-run-cmd-dockerfile.md
+++ b/content/posts/difference-run-cmd-dockerfile.md
@@ -25,7 +25,7 @@ In a Dockerfile, `RUN` is used to execute commands during the image build proces
 
 ---
 
-When writing a Dockerfile, understanding the difference between `RUN` and `CMD` is crucial for building efficient and functional Docker images. While both are used to execute commands, they serve different purposes. This guide will explain the differences and provide examples to help you use them effectively.
+When writing a Dockerfile, understanding the difference between `RUN` and `CMD` matters for building efficient and functional Docker images. While both are used to execute commands, they serve different purposes. This guide will explain the differences and provide examples to help you use them effectively.
 
 ## What is `RUN`?
 
@@ -120,9 +120,9 @@ By understanding the differences between `RUN` and `CMD`, you can write more eff
 
 ## Related Resources
 
-- [How Do I Make a Comment in a Dockerfile?](/posts/comment-in-dockerfile) — write clearer Dockerfiles
-- [Advanced Docker Features](/posts/advanced-docker-features) — multi-stage builds, BuildKit, and more
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — harden your containers
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller, faster images
-- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker) — full guide to Dockerfiles
-- [Docker Flashcards](/flashcards/docker-essentials) — review Docker concepts
+- [How Do I Make a Comment in a Dockerfile?](/posts/comment-in-dockerfile): write clearer Dockerfiles
+- [Advanced Docker Features](/posts/advanced-docker-features): multi-stage builds, BuildKit, and more
+- [Docker Security Best Practices](/posts/docker-security-best-practices): harden your containers
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller, faster images
+- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker): full guide to Dockerfiles
+- [Docker Flashcards](/flashcards/docker-essentials): review Docker concepts

--- a/content/posts/docker-access-host-port.md
+++ b/content/posts/docker-access-host-port.md
@@ -87,14 +87,14 @@ In this mode, the container shares the host's network namespace, so it can acces
 - Avoid `--network host` in production unless absolutely necessary.
 - Document host-port dependencies in your project.
 
-By following these steps, you can enable seamless communication between Docker containers and host services.
+By following these steps, you can enable reliable communication between Docker containers and host services.
 
 Good luck with your project!
 
 ## Related Resources
 
-- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker) — more on host networking
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — port publishing fundamentals
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — Docker networking guide
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [DevOps Roadmap](/roadmap) — where Docker fits in your learning path
+- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker): more on host networking
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): port publishing fundamentals
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): Docker networking guide
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [DevOps Roadmap](/roadmap): where Docker fits in your learning path

--- a/content/posts/docker-alpine-use-bash.md
+++ b/content/posts/docker-alpine-use-bash.md
@@ -61,7 +61,7 @@ If your script uses bash features (like arrays or advanced syntax), make sure to
 
 ## Best Practices
 
-- Only install bash if you need it—stick with sh for simple scripts to keep images small
+- Only install bash if you need it; stick with sh for simple scripts to keep images small
 - For multi-stage builds, install bash only in build stages if possible
 - Document the shell requirements for your scripts
 
@@ -76,8 +76,8 @@ To use bash in Alpine-based Docker images, just install it with apk and use it a
 
 ## Related Resources
 
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — keep Alpine images small
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — minimal base images for security
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — Dockerfile instructions
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [Docker Flashcards](/flashcards/docker-essentials) — review core Docker concepts
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): keep Alpine images small
+- [Docker Security Best Practices](/posts/docker-security-best-practices): minimal base images for security
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): Dockerfile instructions
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [Docker Flashcards](/flashcards/docker-essentials): review core Docker concepts

--- a/content/posts/docker-assign-port-mapping.md
+++ b/content/posts/docker-assign-port-mapping.md
@@ -94,7 +94,7 @@ By understanding Docker's limitations and using these workarounds, you can manag
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — port publishing fundamentals
-- [Docker Access Host Port](/posts/docker-access-host-port) — host-container networking
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — Docker networking guide
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): port publishing fundamentals
+- [Docker Access Host Port](/posts/docker-access-host-port): host-container networking
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): Docker networking guide
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/docker-build-requires-1-argument.md
+++ b/content/posts/docker-build-requires-1-argument.md
@@ -24,7 +24,7 @@ The error `docker: "build" requires 1 argument. See 'docker build --help'` means
 
 ## Why Does This Error Happen?
 
-When you run `docker build`, Docker expects a build context—a directory containing your `Dockerfile` and any files needed for the build. If you don't provide this argument, Docker doesn't know what to build.
+When you run `docker build`, Docker expects a build context, a directory containing your `Dockerfile` and any files needed for the build. If you don't provide this argument, Docker doesn't know what to build.
 
 **Example of the error:**
 
@@ -68,12 +68,12 @@ docker build -t my-image .
 
 ## Conclusion
 
-The `docker: "build" requires 1 argument` error is a simple fix—just add the build context (like `.`) to your command. This ensures Docker knows where to find your `Dockerfile` and build resources.
+The `docker: "build" requires 1 argument` error is a simple fix: just add the build context (like `.`) to your command. This ensures Docker knows where to find your `Dockerfile` and build resources.
 
 ## Related Resources
 
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — Dockerfile instructions
-- [How Do I Make a Comment in a Dockerfile?](/posts/comment-in-dockerfile) — write clearer Dockerfiles
-- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion) — optimize build context
-- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker) — Dockerfile guide
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): Dockerfile instructions
+- [How Do I Make a Comment in a Dockerfile?](/posts/comment-in-dockerfile): write clearer Dockerfiles
+- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion): optimize build context
+- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker): Dockerfile guide
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/docker-cant-connect-to-docker-daemon.md
+++ b/content/posts/docker-cant-connect-to-docker-daemon.md
@@ -143,7 +143,7 @@ By following these steps, you can resolve the "Docker can't connect to Docker da
 
 ## Related Resources
 
-- [Cannot Connect to Docker Daemon at unix:/var/run/docker.sock](/posts/cannot-connect-to-docker-daemon) — in-depth troubleshooting for this error
-- [How to Fix Docker: Permission Denied](/posts/fix-docker-permission-denied-error) — solve permission issues
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Cannot Connect to Docker Daemon at unix:/var/run/docker.sock](/posts/cannot-connect-to-docker-daemon): in-depth troubleshooting for this error
+- [How to Fix Docker: Permission Denied](/posts/fix-docker-permission-denied-error): solve permission issues
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/docker-compose-always-recreate-containers.md
+++ b/content/posts/docker-compose-always-recreate-containers.md
@@ -85,8 +85,8 @@ To always get fresh containers from the latest images, combine `docker-compose p
 
 ## Related Resources
 
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — manage config across environments
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — container networking fundamentals
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — clean up stale images
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — comprehensive Docker learning path
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on build optimization
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): manage config across environments
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): container networking fundamentals
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): clean up stale images
+- [Introduction to Docker Guide](/guides/introduction-to-docker): full Docker learning path
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on build optimization

--- a/content/posts/docker-compose-environment-variables.md
+++ b/content/posts/docker-compose-environment-variables.md
@@ -128,9 +128,9 @@ Environment variables in docker-compose make your setups more secure, portable, 
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — understand container networking and port publishing
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — keep secrets out of images and more
-- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands) — chain commands in Compose services
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from the ground up
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [DevOps Roadmap](/roadmap) — see where Docker fits in the bigger picture
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): understand container networking and port publishing
+- [Docker Security Best Practices](/posts/docker-security-best-practices): keep secrets out of images and more
+- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands): chain commands in Compose services
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from the ground up
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [DevOps Roadmap](/roadmap): see where Docker fits in the bigger picture

--- a/content/posts/docker-compose-multiple-commands.md
+++ b/content/posts/docker-compose-multiple-commands.md
@@ -189,7 +189,7 @@ This approach separates complex logic from your Docker Compose file and makes it
 
 ## Running Background Processes with supervisord
 
-When you need to run multiple long-running processes within a single container, supervisord provides a robust solution for process management. This is useful for services that need multiple daemons or background tasks.
+When you need to run multiple long-running processes within a single container, supervisord provides a reliable solution for process management. This is useful for services that need multiple daemons or background tasks.
 
 Create a supervisord configuration (`config/supervisord.conf`):
 
@@ -265,7 +265,7 @@ This setup runs nginx, PHP-FPM, and queue workers simultaneously, with superviso
 
 ## Using Health Checks and Dependency Management
 
-For services that depend on other services being ready, combine multiple commands with health checks to create robust startup sequences. This approach is particularly useful for database-dependent applications.
+For services that depend on other services being ready, combine multiple commands with health checks to create reliable startup sequences. This approach is particularly useful for database-dependent applications.
 
 ```yaml
 version: '3.8'
@@ -441,8 +441,8 @@ You now have multiple approaches for executing multiple commands in Docker Compo
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — understand container networking
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — configure services without hardcoding
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — choose the right Dockerfile instruction
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from the ground up
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): understand container networking
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): configure services without hardcoding
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): choose the right Dockerfile instruction
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from the ground up
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge

--- a/content/posts/docker-compose-ports-vs-expose.md
+++ b/content/posts/docker-compose-ports-vs-expose.md
@@ -364,10 +364,10 @@ Consider using reverse proxies like nginx or Traefik to further control access t
 
 ## Related Resources
 
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — configure containers without hardcoding values
-- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands) — chain commands in your Compose services
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — deep dive into Docker networking fundamentals
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — harden containers for production
-- [Docker Security Checklist](/checklists/docker-security) — verify your Docker setup
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [DevOps Roadmap](/roadmap) — see where Docker fits in the bigger picture
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): configure containers without hardcoding values
+- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands): chain commands in your Compose services
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): deep dive into Docker networking fundamentals
+- [Docker Security Best Practices](/posts/docker-security-best-practices): harden containers for production
+- [Docker Security Checklist](/checklists/docker-security): verify your Docker setup
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [DevOps Roadmap](/roadmap): see where Docker fits in the bigger picture

--- a/content/posts/docker-compose-up-only-certain-containers.md
+++ b/content/posts/docker-compose-up-only-certain-containers.md
@@ -24,7 +24,7 @@ You don't have to start every service in your `docker-compose.yml` at once. Use 
 
 ## Why Start Only Certain Containers?
 
-In real-world projects, your `docker-compose.yml` might define several services—databases, caches, web apps, workers, and more. Sometimes you only want to run a subset, like just the API and database for local development, or a single worker for debugging.
+In real-world projects, your `docker-compose.yml` might define several services: databases, caches, web apps, workers, and more. Sometimes you only want to run a subset, like just the API and database for local development, or a single worker for debugging.
 
 ## How to Start Specific Services
 
@@ -92,12 +92,12 @@ This stops or removes just those containers, leaving others running.
 
 ## Conclusion
 
-Starting only the containers you need with `docker-compose up` is a great way to speed up development and save resources. Just specify the service names, and Docker Compose will handle dependencies for you. Check your service names in the YAML file, and use this trick to streamline your workflow.
+Starting only the containers you need with `docker-compose up` is a great way to speed up development and save resources. Just specify the service names, and Docker Compose will handle dependencies for you. Check your service names in the YAML file, and use this trick to simplify your workflow.
 
 ## Related Resources
 
-- [Docker Compose: Wait for Container X Before Starting Y](/posts/docker-compose-wait-container) — control startup order
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — networking between services
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — configure services
-- [Restart a Single Container in Docker Compose](/posts/restart-single-container-docker-compose) — manage individual services
-- [Introduction to Docker: Compose](/guides/introduction-to-docker) — Docker Compose guide
+- [Docker Compose: Wait for Container X Before Starting Y](/posts/docker-compose-wait-container): control startup order
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): networking between services
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): configure services
+- [Restart a Single Container in Docker Compose](/posts/restart-single-container-docker-compose): manage individual services
+- [Introduction to Docker: Compose](/guides/introduction-to-docker): Docker Compose guide

--- a/content/posts/docker-compose-vs-docker-compose.md
+++ b/content/posts/docker-compose-vs-docker-compose.md
@@ -48,7 +48,7 @@ You use it like this:
 docker compose up
 ```
 
-No need to install anything extra—just update Docker.
+No need to install anything extra; just update Docker.
 
 ## Key Differences
 
@@ -82,8 +82,8 @@ If you see a warning about Compose V1 being deprecated, it's time to switch.
 
 ## Related Resources
 
-- [Docker Compose vs Dockerfile](/posts/docker-compose-vs-dockerfile) — understand when to use each
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — choosing the right orchestration tool
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — configure Compose services
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [DevOps Roadmap](/roadmap) — where Docker fits in your learning path
+- [Docker Compose vs Dockerfile](/posts/docker-compose-vs-dockerfile): understand when to use each
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): choosing the right orchestration tool
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): configure Compose services
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [DevOps Roadmap](/roadmap): where Docker fits in your learning path

--- a/content/posts/docker-compose-vs-dockerfile.md
+++ b/content/posts/docker-compose-vs-dockerfile.md
@@ -137,9 +137,9 @@ By understanding the differences between Docker Compose and Dockerfile, you can 
 
 ## Related Resources
 
-- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile) — Dockerfile instruction details
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — orchestration comparison
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — Compose networking
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build efficient images
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — comprehensive Docker learning
-- [Docker Quiz](/quizzes/docker-quiz) — test your knowledge
+- [Difference Between RUN and CMD in a Dockerfile](/posts/difference-run-cmd-dockerfile): Dockerfile instruction details
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): orchestration comparison
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): Compose networking
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build efficient images
+- [Introduction to Docker Guide](/guides/introduction-to-docker): full Docker learning
+- [Docker Quiz](/quizzes/docker-quiz): test your knowledge

--- a/content/posts/docker-compose-vs-kubernetes-differences.md
+++ b/content/posts/docker-compose-vs-kubernetes-differences.md
@@ -69,7 +69,7 @@ Docker Compose excels at simplicity and ease of use for development environments
 
 ## Understanding Kubernetes
 
-Kubernetes is a comprehensive container orchestration platform designed for managing containerized applications across multiple hosts in a cluster. It provides advanced features like automatic scaling, rolling deployments, and self-healing capabilities:
+Kubernetes is a container orchestration platform designed for managing containerized applications across multiple hosts in a cluster. It provides advanced features like automatic scaling, rolling deployments, and self-healing capabilities:
 
 ```yaml
 # Deployment for web application
@@ -657,10 +657,10 @@ Both tools have their place in the container ecosystem, and understanding when t
 
 ## Related Resources
 
-- [Docker Compose vs Dockerfile](/posts/docker-compose-vs-dockerfile) — understand Docker build vs orchestration
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker fundamentals
-- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes) — learn Kubernetes from scratch
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [Kubernetes Quiz](/quizzes/kubernetes-quiz) — test your Kubernetes knowledge
-- [DevOps Roadmap](/roadmap) — see the full DevOps learning path
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps learning
+- [Docker Compose vs Dockerfile](/posts/docker-compose-vs-dockerfile): understand Docker build vs orchestration
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker fundamentals
+- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes): learn Kubernetes from scratch
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [Kubernetes Quiz](/quizzes/kubernetes-quiz): test your Kubernetes knowledge
+- [DevOps Roadmap](/roadmap): see the full DevOps learning path
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps learning

--- a/content/posts/docker-compose-wait-container.md
+++ b/content/posts/docker-compose-wait-container.md
@@ -120,7 +120,7 @@ By following these steps, you can ensure that Docker Compose starts containers i
 
 ## Related Resources
 
-- [Docker Compose: Up Only Certain Containers](/posts/docker-compose-up-only-certain-containers) — selective service startup
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — service networking
-- [Connecting to PostgreSQL in Docker from Outside](/posts/connecting-to-postgresql-in-a-docker-container-from-outside) — database readiness patterns
-- [Introduction to Docker: Compose](/guides/introduction-to-docker) — Docker Compose fundamentals
+- [Docker Compose: Up Only Certain Containers](/posts/docker-compose-up-only-certain-containers): selective service startup
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): service networking
+- [Connecting to PostgreSQL in Docker from Outside](/posts/connecting-to-postgresql-in-a-docker-container-from-outside): database readiness patterns
+- [Introduction to Docker: Compose](/guides/introduction-to-docker): Docker Compose fundamentals

--- a/content/posts/docker-data-loss-when-container-exits.md
+++ b/content/posts/docker-data-loss-when-container-exits.md
@@ -517,8 +517,8 @@ The key to preventing data loss is understanding that containers are temporary b
 
 ## Related Resources
 
-- [How to Add a Volume to an Existing Docker Container](/posts/how-to-add-a-volume-to-an-existing-docker-container) — add storage after creation
-- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases) — database-specific patterns
-- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers) — manage volumes
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — volume fundamentals
-- [Docker Security Checklist](/checklists/docker-security) — secure your data
+- [How to Add a Volume to an Existing Docker Container](/posts/how-to-add-a-volume-to-an-existing-docker-container): add storage after creation
+- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases): database-specific patterns
+- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers): manage volumes
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): volume fundamentals
+- [Docker Security Checklist](/checklists/docker-security): secure your data

--- a/content/posts/docker-edit-file-in-container.md
+++ b/content/posts/docker-edit-file-in-container.md
@@ -94,8 +94,8 @@ With these steps, you can quickly edit files inside containers and understand ho
 
 ## Related Resources
 
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — shell access methods
-- [Copy Files from Docker Container to Host](/posts/copy-files-from-docker-container-to-host) — extract files
-- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system) — navigate containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
-- [Docker Flashcards](/flashcards/docker-essentials) — review Docker concepts
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): shell access methods
+- [Copy Files from Docker Container to Host](/posts/copy-files-from-docker-container-to-host): extract files
+- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system): navigate containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals
+- [Docker Flashcards](/flashcards/docker-essentials): review Docker concepts

--- a/content/posts/docker-image-optimization-best-practices.md
+++ b/content/posts/docker-image-optimization-best-practices.md
@@ -21,7 +21,7 @@ tags:
 
 ## TLDR
 
-Optimize Docker images by using multi-stage builds, choosing minimal base images (Alpine, Distroless), leveraging layer caching, minimizing layers, removing build dependencies, and using `.dockerignore`. These practices can reduce image size by 70-90% and significantly improve build and deployment times.
+Optimize Docker images by using multi-stage builds, choosing minimal base images (Alpine, Distroless), using layer caching, minimizing layers, removing build dependencies, and using `.dockerignore`. These practices can reduce image size by 70-90% and significantly improve build and deployment times.
 
 ## Why Docker Image Optimization Matters
 
@@ -494,16 +494,16 @@ docker-slim build --http-probe myapp:latest
 
 ## Conclusion
 
-Docker image optimization is not optional—it's essential for production deployments. By following these best practices, you can reduce image sizes by 70-96%, improve build times, reduce costs, and enhance security. Start with multi-stage builds and minimal base images, then progressively apply other optimizations.
+Docker image optimization is not optional; it's essential for production deployments. By following these best practices, you can reduce image sizes by 70-96%, improve build times, reduce costs, and enhance security. Start with multi-stage builds and minimal base images, then progressively apply other optimizations.
 
-Remember: every megabyte saved is multiplied across your entire infrastructure—CI/CD pipelines, registries, and production deployments.
+Remember: every megabyte saved is multiplied across your entire infrastructure: CI/CD pipelines, registries, and production deployments.
 
 ## Related Resources
 
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit, health checks, and more
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure your optimized images
-- [COPY vs ADD in Dockerfiles](/posts/dockerfile-copy-vs-add-commands) — choose the right instruction
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on optimization
-- [Docker Security Checklist](/checklists/docker-security) — verify your setup
-- [Introduction to Docker: Best Practices](/guides/introduction-to-docker) — comprehensive guide
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps learning
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit, health checks, and more
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure your optimized images
+- [COPY vs ADD in Dockerfiles](/posts/dockerfile-copy-vs-add-commands): choose the right instruction
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on optimization
+- [Docker Security Checklist](/checklists/docker-security): verify your setup
+- [Introduction to Docker: Best Practices](/guides/introduction-to-docker): complete guide
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps learning

--- a/content/posts/docker-image-storage-locations.md
+++ b/content/posts/docker-image-storage-locations.md
@@ -278,7 +278,7 @@ Now you have a thorough understanding of where Docker stores its data and how to
 
 ## Related Resources
 
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — bulk cleanup
-- [Docker Image vs Container](/posts/docker-image-vs-container) — understand the fundamentals
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): bulk cleanup
+- [Docker Image vs Container](/posts/docker-image-vs-container): understand the fundamentals
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch

--- a/content/posts/docker-image-vs-container.md
+++ b/content/posts/docker-image-vs-container.md
@@ -144,7 +144,7 @@ Now you have four containers (including the production one) all running from the
 
 ## Practical Differences in Daily Development
 
-Understanding the image-container distinction becomes crucial in several scenarios:
+Understanding the image-container distinction matters in several scenarios:
 
 ### Debugging Application Issues
 
@@ -297,9 +297,9 @@ Understanding the image-container relationship is fundamental to working effecti
 
 ## Related Resources
 
-- [How to Run a Docker Image as a Container](/posts/docker-run-image-as-container) — put this knowledge into practice
-- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start) — container lifecycle commands
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build better images
-- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine) — deeper comparison
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — comprehensive learning path
-- [Docker Flashcards](/flashcards/docker-essentials) — review core concepts
+- [How to Run a Docker Image as a Container](/posts/docker-run-image-as-container): put this knowledge into practice
+- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start): container lifecycle commands
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build better images
+- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine): deeper comparison
+- [Introduction to Docker Guide](/guides/introduction-to-docker): complete learning path
+- [Docker Flashcards](/flashcards/docker-essentials): review core concepts

--- a/content/posts/docker-include-files-outside-build-context.md
+++ b/content/posts/docker-include-files-outside-build-context.md
@@ -102,7 +102,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion) — .dockerignore patterns
-- [COPY vs ADD in Dockerfiles](/posts/dockerfile-copy-vs-add-commands) — choose the right instruction
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit and multi-stage builds
-- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker) — Dockerfile guide
+- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion): .dockerignore patterns
+- [COPY vs ADD in Dockerfiles](/posts/dockerfile-copy-vs-add-commands): choose the right instruction
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit and multi-stage builds
+- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker): Dockerfile guide

--- a/content/posts/docker-list-containers.md
+++ b/content/posts/docker-list-containers.md
@@ -72,8 +72,8 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start) — container lifecycle commands
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — clean up stopped containers
-- [Docker Name Already in Use](/posts/docker-name-already-in-use) — resolve naming conflicts
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
-- [Docker Quiz](/quizzes/docker-quiz) — test your knowledge
+- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start): container lifecycle commands
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): clean up stopped containers
+- [Docker Name Already in Use](/posts/docker-name-already-in-use): resolve naming conflicts
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals
+- [Docker Quiz](/quizzes/docker-quiz): test your knowledge

--- a/content/posts/docker-mount-host-directory.md
+++ b/content/posts/docker-mount-host-directory.md
@@ -61,7 +61,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [How to Add a Volume to an Existing Container](/posts/how-to-add-a-volume-to-an-existing-docker-container) — add volumes after creation
-- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases) — database volume patterns
-- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits) — prevent data loss
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — volume fundamentals
+- [How to Add a Volume to an Existing Container](/posts/how-to-add-a-volume-to-an-existing-docker-container): add volumes after creation
+- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases): database volume patterns
+- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits): prevent data loss
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): volume fundamentals

--- a/content/posts/docker-name-already-in-use.md
+++ b/content/posts/docker-name-already-in-use.md
@@ -113,13 +113,13 @@ This will prompt you for confirmation before deleting stopped containers.
 
 - **Use Descriptive Names**: When naming containers, use descriptive names to avoid confusion.
 - **Monitor Container Usage**: Regularly check your containers with `docker ps -a` to identify unused ones.
-- **Leverage Docker Compose**: If you're managing multiple containers, use Docker Compose to handle naming and orchestration automatically.
+- **Use Docker Compose**: If you're managing multiple containers, use Docker Compose to handle naming and orchestration automatically.
 
 By following these steps, you can resolve the "name is already in use by container" error and manage your Docker containers more effectively.
 
 ## Related Resources
 
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — clean up stopped containers
-- [Docker List Containers](/posts/docker-list-containers) — find running and stopped containers
-- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers) — force fresh containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): clean up stopped containers
+- [Docker List Containers](/posts/docker-list-containers): find running and stopped containers
+- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers): force fresh containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/docker-no-space-left-cleanup.md
+++ b/content/posts/docker-no-space-left-cleanup.md
@@ -156,7 +156,7 @@ By following these steps, you can effectively manage Docker's disk usage and pre
 
 ## Related Resources
 
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — bulk image cleanup
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — container cleanup
-- [Where Docker Images Are Stored](/posts/docker-image-storage-locations) — understand storage locations
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller images
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): bulk image cleanup
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): container cleanup
+- [Where Docker Images Are Stored](/posts/docker-image-storage-locations): understand storage locations
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller images

--- a/content/posts/docker-persistent-storage-databases.md
+++ b/content/posts/docker-persistent-storage-databases.md
@@ -276,9 +276,9 @@ The combination of Docker's storage flexibility and database persistence opens u
 
 ## Related Resources
 
-- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits) — why data disappears
-- [Mount a Host Directory in Docker](/posts/docker-mount-host-directory) — bind mount patterns
-- [Connecting to PostgreSQL in Docker from Outside](/posts/connecting-to-postgresql-in-a-docker-container-from-outside) — database access
-- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers) — manage volumes
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — volume fundamentals
-- [Docker Security Checklist](/checklists/docker-security) — secure your data
+- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits): why data disappears
+- [Mount a Host Directory in Docker](/posts/docker-mount-host-directory): bind mount patterns
+- [Connecting to PostgreSQL in Docker from Outside](/posts/connecting-to-postgresql-in-a-docker-container-from-outside): database access
+- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers): manage volumes
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): volume fundamentals
+- [Docker Security Checklist](/checklists/docker-security): secure your data

--- a/content/posts/docker-push-denied-access.md
+++ b/content/posts/docker-push-denied-access.md
@@ -80,7 +80,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo) — private registry workflow
-- [Docker Rename Image Repository](/posts/docker-rename-image-repository) — fix image naming
-- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository) — transfer without a registry
-- [Introduction to Docker: Working with Images](/guides/introduction-to-docker) — image management guide
+- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo): private registry workflow
+- [Docker Rename Image Repository](/posts/docker-rename-image-repository): fix image naming
+- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository): transfer without a registry
+- [Introduction to Docker: Working with Images](/guides/introduction-to-docker): image management guide

--- a/content/posts/docker-remove-image.md
+++ b/content/posts/docker-remove-image.md
@@ -91,7 +91,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — bulk cleanup
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — container cleanup
-- [Docker Image vs Container](/posts/docker-image-vs-container) — understand the difference
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): bulk cleanup
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): container cleanup
+- [Docker Image vs Container](/posts/docker-image-vs-container): understand the difference

--- a/content/posts/docker-rename-image-repository.md
+++ b/content/posts/docker-rename-image-repository.md
@@ -74,7 +74,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo) — push renamed images
-- [Docker Push: Denied Access](/posts/docker-push-denied-access) — fix push errors
-- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository) — transfer images
-- [Introduction to Docker: Working with Images](/guides/introduction-to-docker) — image management
+- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo): push renamed images
+- [Docker Push: Denied Access](/posts/docker-push-denied-access): fix push errors
+- [Copy Docker Images Between Hosts](/posts/copy-docker-images-between-hosts-withouta-repository): transfer images
+- [Introduction to Docker: Working with Images](/guides/introduction-to-docker): image management

--- a/content/posts/docker-run-image-as-container.md
+++ b/content/posts/docker-run-image-as-container.md
@@ -108,9 +108,9 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start) — understand the difference
-- [Docker Image vs Container](/posts/docker-image-vs-container) — key concepts
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — port mapping
-- [Pass Environment Variables to Docker Containers](/posts/pass-environment-variables-docker-containers) — configure at runtime
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [Docker Quiz](/quizzes/docker-quiz) — test your knowledge
+- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start): understand the difference
+- [Docker Image vs Container](/posts/docker-image-vs-container): key concepts
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): port mapping
+- [Pass Environment Variables to Docker Containers](/posts/pass-environment-variables-docker-containers): configure at runtime
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [Docker Quiz](/quizzes/docker-quiz): test your knowledge

--- a/content/posts/docker-run-vs-docker-start.md
+++ b/content/posts/docker-run-vs-docker-start.md
@@ -79,9 +79,9 @@ docker start my-nginx # Start it again
 
 ## Related Resources
 
-- [How to Run a Docker Image as a Container](/posts/docker-run-image-as-container) — running containers in depth
-- [Docker Image vs Container](/posts/docker-image-vs-container) — understand the fundamentals
-- [Docker List Containers](/posts/docker-list-containers) — find your containers
-- [Why Docker Container Exits Immediately](/posts/why-docker-container-exits-immediately) — troubleshoot exits
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — comprehensive learning
-- [Docker Flashcards](/flashcards/docker-essentials) — review concepts
+- [How to Run a Docker Image as a Container](/posts/docker-run-image-as-container): running containers in depth
+- [Docker Image vs Container](/posts/docker-image-vs-container): understand the fundamentals
+- [Docker List Containers](/posts/docker-list-containers): find your containers
+- [Why Docker Container Exits Immediately](/posts/why-docker-container-exits-immediately): troubleshoot exits
+- [Introduction to Docker Guide](/guides/introduction-to-docker): full Docker course
+- [Docker Flashcards](/flashcards/docker-essentials): review concepts

--- a/content/posts/docker-runtime-performance-cost.md
+++ b/content/posts/docker-runtime-performance-cost.md
@@ -79,8 +79,8 @@ Good luck with your project!
 
 ## Related Resources
 
-- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine) — architecture comparison
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build efficient images
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps context
+- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine): architecture comparison
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build efficient images
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps context

--- a/content/posts/docker-security-best-practices.md
+++ b/content/posts/docker-security-best-practices.md
@@ -635,11 +635,11 @@ Container security is an ongoing process that requires attention at every stage 
 
 ## Related Resources
 
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller, more secure images
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit secrets and health checks
-- [Using SSH Keys in Docker](/posts/using-ssh-keys-in-docker-container) — secure key handling
-- [Docker Security Checklist](/checklists/docker-security) — verify your security setup
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on practice
-- [Introduction to Docker: Best Practices](/guides/introduction-to-docker) — comprehensive guide
-- [Docker Quiz](/quizzes/docker-quiz) — test your Docker knowledge
-- [DevOps Roadmap](/roadmap) — the full DevOps learning path
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller, more secure images
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit secrets and health checks
+- [Using SSH Keys in Docker](/posts/using-ssh-keys-in-docker-container): secure key handling
+- [Docker Security Checklist](/checklists/docker-security): verify your security setup
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on practice
+- [Introduction to Docker: Best Practices](/guides/introduction-to-docker): full guide
+- [Docker Quiz](/quizzes/docker-quiz): test your Docker knowledge
+- [DevOps Roadmap](/roadmap): the full DevOps learning path

--- a/content/posts/docker-see-image-contents.md
+++ b/content/posts/docker-see-image-contents.md
@@ -77,7 +77,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system) — browse container files
-- [Docker Image vs Container](/posts/docker-image-vs-container) — understand the difference
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller images
-- [Introduction to Docker: Working with Images](/guides/introduction-to-docker) — image management
+- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system): browse container files
+- [Docker Image vs Container](/posts/docker-image-vs-container): understand the difference
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller images
+- [Introduction to Docker: Working with Images](/guides/introduction-to-docker): image management

--- a/content/posts/docker-tty-error-fix.md
+++ b/content/posts/docker-tty-error-fix.md
@@ -360,7 +360,7 @@ Start with the simple solutions and progress to more advanced techniques only wh
 
 ## Related Resources
 
-- [Enter a Docker Container with a New TTY](/posts/enter-docker-container-new-tty) — attach to running containers
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — shell access methods
-- [Interactive Shell in Docker Compose](/posts/interactive-shell-docker-compose) — Compose shell access
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Enter a Docker Container with a New TTY](/posts/enter-docker-container-new-tty): attach to running containers
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): shell access methods
+- [Interactive Shell in Docker Compose](/posts/interactive-shell-docker-compose): Compose shell access
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/docker-ubuntu-ping-not-found.md
+++ b/content/posts/docker-ubuntu-ping-not-found.md
@@ -82,7 +82,7 @@ Good luck with your project!
 
 ## Related Resources
 
-- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash) — install tools in Alpine images
-- [PS Command Not Working in Docker](/posts/ps-command-not-working-docker) — install missing utilities
-- [How to Use Sudo in Docker Container](/posts/how-to-use-sudo-in-docker-container) — permissions in containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker basics
+- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash): install tools in Alpine images
+- [PS Command Not Working in Docker](/posts/ps-command-not-working-docker): install missing utilities
+- [How to Use Sudo in Docker Container](/posts/how-to-use-sudo-in-docker-container): permissions in containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker basics

--- a/content/posts/dockerfile-copy-vs-add-commands.md
+++ b/content/posts/dockerfile-copy-vs-add-commands.md
@@ -231,8 +231,8 @@ Happy containerizing!
 
 ## Related Resources
 
-- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion) — .dockerignore patterns
-- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile) — more Dockerfile instructions
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller images
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure Dockerfiles
-- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build) — hands-on practice
+- [COPY with Docker Exclusion](/posts/copy-with-docker-exclusion): .dockerignore patterns
+- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile): more Dockerfile instructions
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller images
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure Dockerfiles
+- [Docker Multi-Stage Build Exercise](/exercises/docker-multi-stage-build): hands-on practice

--- a/content/posts/dockerfile-update-path.md
+++ b/content/posts/dockerfile-update-path.md
@@ -90,11 +90,11 @@ The script executed successfully, demonstrating that the custom directory was ad
 - Use absolute paths for custom directories.
 - Document PATH changes in your Dockerfile for clarity.
 
-By updating the PATH in your Dockerfile, you can streamline container workflows and make custom tools easily accessible.
+By updating the PATH in your Dockerfile, you can simplify container workflows and make custom tools easily accessible.
 
 ## Related Resources
 
-- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile) — Dockerfile instruction fundamentals
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — environment config
-- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash) — shell configuration in containers
-- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker) — Dockerfile guide
+- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile): Dockerfile instruction fundamentals
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): environment config
+- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash): shell configuration in containers
+- [Introduction to Docker: Building Custom Images](/guides/introduction-to-docker): Dockerfile guide

--- a/content/posts/enter-docker-container-new-tty.md
+++ b/content/posts/enter-docker-container-new-tty.md
@@ -114,8 +114,8 @@ By following these steps, you can easily interact with running Docker containers
 
 ## Related Resources
 
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — more shell access methods
-- [Docker TTY Error Fix](/posts/docker-tty-error-fix) — troubleshoot TTY issues
-- [How to Attach and Detach Docker Process](/posts/how-to-attach-detach-docker-process) — manage attached sessions
-- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system) — browse container files
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): more shell access methods
+- [Docker TTY Error Fix](/posts/docker-tty-error-fix): troubleshoot TTY issues
+- [How to Attach and Detach Docker Process](/posts/how-to-attach-detach-docker-process): manage attached sessions
+- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system): browse container files
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/execute-terraform-actions-without-prompt.md
+++ b/content/posts/execute-terraform-actions-without-prompt.md
@@ -100,4 +100,4 @@ This approach is useful for environments where you want to enforce non-interacti
 - **Combine with `terraform plan`**: Run `terraform plan` to preview changes before applying them.
 - **Secure Variable Files**: If using `.tfvars` files, ensure they are not exposed in version control.
 
-By automating Terraform actions and bypassing interactive prompts, you can streamline your workflows and integrate Terraform into your CI/CD pipelines effectively.
+By automating Terraform actions and bypassing interactive prompts, you can simplify your workflows and integrate Terraform into your CI/CD pipelines effectively.

--- a/content/posts/exploring-docker-container-file-system.md
+++ b/content/posts/exploring-docker-container-file-system.md
@@ -318,8 +318,8 @@ Exploring Docker container file systems is a fundamental debugging skill. Whethe
 
 ## Related Resources
 
-- [Copy Files from Docker Container to Host](/posts/copy-files-from-docker-container-to-host) — extract files
-- [Docker Edit File in Container](/posts/docker-edit-file-in-container) — modify files in-place
-- [How to See Docker Image Contents](/posts/docker-see-image-contents) — inspect images before running
-- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty) — interactive debugging
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Copy Files from Docker Container to Host](/posts/copy-files-from-docker-container-to-host): extract files
+- [Docker Edit File in Container](/posts/docker-edit-file-in-container): modify files in-place
+- [How to See Docker Image Contents](/posts/docker-see-image-contents): inspect images before running
+- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty): interactive debugging
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/expose-multiple-ports-docker.md
+++ b/content/posts/expose-multiple-ports-docker.md
@@ -137,7 +137,7 @@ By following these steps, you can effectively expose and manage multiple ports i
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — port publishing in Compose
-- [Expose vs Publish in Docker](/posts/expose-vs-publish-docker) — understand the difference
-- [Forward Host Port to Docker Container](/posts/forward-host-port-to-docker-container) — port forwarding patterns
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking guide
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): port publishing in Compose
+- [Expose vs Publish in Docker](/posts/expose-vs-publish-docker): understand the difference
+- [Forward Host Port to Docker Container](/posts/forward-host-port-to-docker-container): port forwarding patterns
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking guide

--- a/content/posts/expose-port-on-live-docker-container.md
+++ b/content/posts/expose-port-on-live-docker-container.md
@@ -82,7 +82,7 @@ You can't expose a new port on a live Docker container, but you have workarounds
 
 ## Related Resources
 
-- [Docker Assign Port Mapping to Existing Container](/posts/docker-assign-port-mapping) — more workarounds
-- [Expose Multiple Ports in Docker](/posts/expose-multiple-ports-docker) — multi-port setup
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — Compose networking
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Assign Port Mapping to Existing Container](/posts/docker-assign-port-mapping): more workarounds
+- [Expose Multiple Ports in Docker](/posts/expose-multiple-ports-docker): multi-port setup
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): Compose networking
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/expose-vs-publish-docker.md
+++ b/content/posts/expose-vs-publish-docker.md
@@ -1,6 +1,6 @@
 ---
 title: 'What is the Difference Between "Expose" and "Publish" in Docker?'
-excerpt: "Understanding the difference between 'expose' and 'publish' in Docker is crucial for managing container networking effectively. Learn how these concepts work and when to use them."
+excerpt: "Understanding the difference between 'expose' and 'publish' in Docker is important for managing container networking effectively. Learn how these concepts work and when to use them."
 category:
   name: 'Docker'
   slug: 'docker'
@@ -114,7 +114,7 @@ By understanding these concepts, you can better manage your containerized applic
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — the Compose perspective
-- [Expose Multiple Ports in Docker](/posts/expose-multiple-ports-docker) — multi-port setups
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — minimize attack surface
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking deep dive
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): the Compose perspective
+- [Expose Multiple Ports in Docker](/posts/expose-multiple-ports-docker): multi-port setups
+- [Docker Security Best Practices](/posts/docker-security-best-practices): minimize attack surface
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking deep dive

--- a/content/posts/extract-filename-extension-bash.md
+++ b/content/posts/extract-filename-extension-bash.md
@@ -56,7 +56,7 @@ Here's how these patterns work:
 
 ## Creating Reusable Functions
 
-Here's a comprehensive function that extracts all components:
+Here's a function that extracts all components:
 
 ```bash
 parse_filepath() {
@@ -336,4 +336,4 @@ extract_version_info "app_v2.1-beta.zip"
 5. **Use quotes** around variables to handle paths with spaces
 6. **Consider special files** like hidden files starting with dots
 
-Extracting filename and extension information is fundamental to file processing in Bash. These techniques provide robust methods for parsing file paths, whether you're building file processors, backup systems, or general automation scripts.
+Extracting filename and extension information is fundamental to file processing in Bash. These techniques provide reliable methods for parsing file paths, whether you're building file processors, backup systems, or general automation scripts.

--- a/content/posts/find-files-with-wildcards-linux.md
+++ b/content/posts/find-files-with-wildcards-linux.md
@@ -19,7 +19,7 @@ tags:
   - bash
 ---
 
-When managing files across multiple directories, you often need to locate files based on name patterns rather than exact names. Linux provides robust wildcard matching capabilities through the `find` command, allowing you to search recursively through directory structures using flexible pattern matching.
+When managing files across multiple directories, you often need to locate files based on name patterns rather than exact names. Linux provides flexible wildcard matching through the `find` command, allowing you to search recursively through directory structures using flexible pattern matching.
 
 ## Prerequisites
 

--- a/content/posts/fix-docker-permission-denied-error.md
+++ b/content/posts/fix-docker-permission-denied-error.md
@@ -148,7 +148,7 @@ Once you get familiar with the patterns, solving these becomes second nature.
 
 ## Related Resources
 
-- [Cannot Connect to Docker Daemon](/posts/cannot-connect-to-docker-daemon) — related daemon issues
-- [How to Use Sudo in Docker Container](/posts/how-to-use-sudo-in-docker-container) — container permissions
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — run as non-root
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — proper Docker setup
+- [Cannot Connect to Docker Daemon](/posts/cannot-connect-to-docker-daemon): related daemon issues
+- [How to Use Sudo in Docker Container](/posts/how-to-use-sudo-in-docker-container): container permissions
+- [Docker Security Best Practices](/posts/docker-security-best-practices): run as non-root
+- [Introduction to Docker Guide](/guides/introduction-to-docker): proper Docker setup

--- a/content/posts/fix-echo-newline-bash-literal-n.md
+++ b/content/posts/fix-echo-newline-bash-literal-n.md
@@ -314,7 +314,7 @@ debug_echo
 
 Run this debugging function to understand how your system handles different echo variations.
 
-## Building a Robust Output Function
+## Building a Reliable Output Function
 
 Create a utility function that handles newlines reliably across different scenarios:
 

--- a/content/posts/fix-error-acquiring-the-state-lock-conditionalcheckfailedexception.md
+++ b/content/posts/fix-error-acquiring-the-state-lock-conditionalcheckfailedexception.md
@@ -81,7 +81,7 @@ When you run `terraform plan` or `terraform apply`:
 
 ### Step 1: Check Who Has the Lock
 
-The error message provides crucial information:
+The error message provides useful information:
 
 ```
 Lock Info:

--- a/content/posts/force-docker-clean-build.md
+++ b/content/posts/force-docker-clean-build.md
@@ -115,7 +115,7 @@ Happy building!
 
 ## Related Resources
 
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build efficient images
-- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose) — Compose rebuild patterns
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit cache mounts
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build efficient images
+- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose): Compose rebuild patterns
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit cache mounts
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space

--- a/content/posts/forward-host-port-to-docker-container.md
+++ b/content/posts/forward-host-port-to-docker-container.md
@@ -468,7 +468,7 @@ Port forwarding is fundamental to using Docker effectively. Whether you're runni
 
 ## Related Resources
 
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — Compose port mapping
-- [Docker Access Host Port](/posts/docker-access-host-port) — reverse direction networking
-- [Expose vs Publish in Docker](/posts/expose-vs-publish-docker) — understand the terminology
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking fundamentals
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): Compose port mapping
+- [Docker Access Host Port](/posts/docker-access-host-port): reverse direction networking
+- [Expose vs Publish in Docker](/posts/expose-vs-publish-docker): understand the terminology
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking fundamentals

--- a/content/posts/get-current-date-time-and-custom-commands.md
+++ b/content/posts/get-current-date-time-and-custom-commands.md
@@ -430,4 +430,4 @@ Then source the file:
 source ~/.bashrc
 ```
 
-The `date` command is flexible enough for any date/time formatting you need, and creating custom aliases or functions makes your common formats just a short command away. Whether you're creating timestamped backups, logging events, or just checking the time in different formats, these techniques streamline your workflow.
+The `date` command is flexible enough for any date/time formatting you need, and creating custom aliases or functions makes your common formats just a short command away. Whether you're creating timestamped backups, logging events, or just checking the time in different formats, these techniques speed up your workflow.

--- a/content/posts/get-directory-bash-script-location.md
+++ b/content/posts/get-directory-bash-script-location.md
@@ -45,7 +45,7 @@ The `dirname` command extracts the directory portion from a file path, while `$0
 
 ## Handling Symbolic Links Properly
 
-If your script might be called through a symbolic link, you need a more robust approach that resolves the actual location:
+If your script might be called through a symbolic link, you need a more reliable approach that resolves the actual location:
 
 ```bash
 #!/bin/bash
@@ -250,7 +250,7 @@ else
 fi
 ```
 
-This approach includes comprehensive error checking and fallback strategies.
+This approach includes thorough error checking and fallback strategies.
 
 ## Creating a Reusable Library
 

--- a/content/posts/github-actions-fast.md
+++ b/content/posts/github-actions-fast.md
@@ -82,7 +82,7 @@ While this worked initially, as our codebase grew, each step became slower:
 - Test suites took longer to run (45+ minutes)
 - Builds became more complex (30+ minutes)
 - Deployments had more steps (45+ minutes)
-- Integration tests became more comprehensive (30+ minutes)
+- Integration tests became more thorough (30+ minutes)
 
 The worst part? If anything failed late in the process, developers would have to start over after fixing the issue, wasting hours of time.
 
@@ -91,7 +91,7 @@ The worst part? If anything failed late in the process, developers would have to
 We redesigned our workflow with three key principles:
 
 1. Run independent tasks in parallel
-2. Use GitHub Actions' dependency management to orchestrate steps
+2. Use GitHub Actions' dependency management to coordinate steps
 3. Cache everything that can be cached
 
 Here's the optimized workflow:
@@ -423,7 +423,7 @@ deploy-frontend:
 
 In the GitHub repository settings, we configured the "production" environment to require approvals from specific team members before the deployment can proceed.
 
-This added a crucial safety check without significantly impacting automation for non-production environments, which we configured separately with different workflows.
+This added an important safety check without significantly impacting automation for non-production environments, which we configured separately with different workflows.
 
 ## Key Optimization #4: Strategic Caching
 
@@ -507,7 +507,7 @@ deploy-prod:
 ### 4. Optimize for Developer Experience
 
 - Make failure messages clear and actionable
-- Add comprehensive notifications (we use Slack)
+- Add detailed notifications (we use Slack)
 - Ensure logs are detailed enough to debug issues without re-running
 
 ```yaml

--- a/content/posts/gitops-deploy-docker-containers-github-actions-argocd.md
+++ b/content/posts/gitops-deploy-docker-containers-github-actions-argocd.md
@@ -433,7 +433,7 @@ Or better yet, create a pull request for production changes to require team appr
 
 ## Rollback with Git
 
-GitOps makes rollbacks trivial—just revert the Git commit:
+GitOps makes rollbacks trivial: just revert the Git commit:
 
 ```bash
 cd my-app-gitops
@@ -544,12 +544,12 @@ With this GitOps setup, you have:
 - **Audit trail**: Git history shows who deployed what and when
 - **Self-healing**: Cluster automatically reverts unauthorized changes
 
-GitOps is the industry standard for Kubernetes deployments. No more SSH scripts or manual kubectl commands—your Git repository becomes the single source of truth, and your cluster stays in sync automatically.
+GitOps is the industry standard for Kubernetes deployments. No more SSH scripts or manual kubectl commands. Your Git repository becomes the single source of truth, and your cluster stays in sync automatically.
 
 
 ## Related Resources
 
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — when to use each
-- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes) — learn K8s from scratch
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure your images
-- [DevOps Roadmap](/roadmap) — the full DevOps learning path
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): when to use each
+- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes): learn K8s from scratch
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure your images
+- [DevOps Roadmap](/roadmap): the full DevOps learning path

--- a/content/posts/heroku-vs-self-hosting-cost-analysis.md
+++ b/content/posts/heroku-vs-self-hosting-cost-analysis.md
@@ -24,7 +24,7 @@ tags:
 
 ## TLDR
 
-Heroku's convenience comes at a premium: typical production workloads cost $500-2,000/month. Self-hosting equivalent infrastructure on [DigitalOcean](https://m.do.co/c/2a9bba940f39) runs $24-100/month. But the real cost difference isn't just dollars—it's engineer time, operational complexity, and risk. This guide breaks down actual costs, hidden expenses, and provides a framework to determine if self-hosting makes sense for your specific situation. Includes transparent Total Cost of Ownership (TCO) calculations and honest tradeoff analysis.
+Heroku's convenience comes at a premium: typical production workloads cost $500-2,000/month. Self-hosting equivalent infrastructure on [DigitalOcean](https://m.do.co/c/2a9bba940f39) runs $24-100/month. But the real cost difference isn't just dollars; it's engineer time, operational complexity, and risk. This guide breaks down actual costs, hidden expenses, and provides a framework to determine if self-hosting makes sense for your specific situation. Includes transparent Total Cost of Ownership (TCO) calculations and honest tradeoff analysis.
 
 ---
 
@@ -491,7 +491,7 @@ Don't migrate everything at once. Use this staged approach:
 ### Phase 4: Optimization (ongoing)
 
 - Tune database performance
-- Set up comprehensive monitoring
+- Set up full monitoring
 - Automate backups and test restores
 - Document runbooks
 - Implement disaster recovery procedures
@@ -506,7 +506,7 @@ Don't migrate everything at once. Use this staged approach:
 
 **Self-hosting is cheaper.** But not 90% cheaper when you factor in engineer time.
 
-**The real question isn't cost**—it's whether you want to own your infrastructure. 
+**The real question isn't cost.** It's whether you want to own your infrastructure. 
 
 **Choose Heroku if**:
 - You want to focus on product, not infrastructure

--- a/content/posts/hidden-cost-overengineering-first-50-engineers.md
+++ b/content/posts/hidden-cost-overengineering-first-50-engineers.md
@@ -385,7 +385,7 @@ If metrics improve, expand gradually. If not, abandon without sunk cost fallacy.
 
 ## The Cost of Getting This Wrong
 
-Over-engineering does not just waste money—it compounds into organizational debt:
+Over-engineering does not just waste money; it compounds into organizational debt:
 
 1. **Talent drain**: Your best engineers leave because they joined to build products, not manage infrastructure
 2. **Slowed hiring**: Complex tech stack means longer onboarding, harder to hire, narrower candidate pool
@@ -411,7 +411,7 @@ Boring technology:
 Examples: PostgreSQL, Redis, nginx, monolithic applications, Docker, managed Kubernetes.
 
 Exciting technology:
-- Cutting-edge features and capabilities
+- New features and capabilities
 - Smaller community, evolving best practices
 - Requires specialist knowledge
 - Solves emerging problems
@@ -434,6 +434,6 @@ Use boring technology for 90% of your infrastructure. Reserve exciting technolog
 
 5. **The cost of waiting is usually low**. If you are not sure whether you need a new system, you probably do not. Adopt it when the pain of not having it is obvious.
 
-Engineering leadership is about making tradeoffs. The best CTOs are not the ones who build the most sophisticated infrastructure—they are the ones who build just enough infrastructure to enable their teams to ship great products.
+Engineering leadership is about making tradeoffs. The best CTOs are not the ones who build the most sophisticated infrastructure; they are the ones who build just enough infrastructure to enable their teams to ship great products.
 
 At 50 engineers, your competitive advantage is not your service mesh. It is your ability to ship features faster than competitors. Keep infrastructure boring, keep teams focused, and save the sophisticated architecture for when you have earned the scale to justify it.

--- a/content/posts/how-do-i-run-a-command-on-an-already-existing-docker-container.md
+++ b/content/posts/how-do-i-run-a-command-on-an-already-existing-docker-container.md
@@ -379,7 +379,7 @@ Once you're comfortable with `docker exec`, you'll find debugging containers muc
 
 ## Related Resources
 
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — more shell methods
-- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty) — TTY sessions
-- [Docker Edit File in Container](/posts/docker-edit-file-in-container) — modify files in-place
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): more shell methods
+- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty): TTY sessions
+- [Docker Edit File in Container](/posts/docker-edit-file-in-container): modify files in-place
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-docker-differs-from-a-virtual-machine.md
+++ b/content/posts/how-docker-differs-from-a-virtual-machine.md
@@ -161,8 +161,8 @@ Happy coding!
 
 ## Related Resources
 
-- [Docker Image vs Container](/posts/docker-image-vs-container) — understand Docker internals
-- [Docker Runtime Performance Cost](/posts/docker-runtime-performance-cost) — performance comparison
-- [Vagrant vs Docker](/posts/vagrant-vs-docker-for-isolated-environments) — another comparison
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker from scratch
-- [DevOps Survival Guide](/books/devops-survival-guide) — broader DevOps context
+- [Docker Image vs Container](/posts/docker-image-vs-container): understand Docker internals
+- [Docker Runtime Performance Cost](/posts/docker-runtime-performance-cost): performance comparison
+- [Vagrant vs Docker](/posts/vagrant-vs-docker-for-isolated-environments): another comparison
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker from scratch
+- [DevOps Survival Guide](/books/devops-survival-guide): broader DevOps context

--- a/content/posts/how-i-finally-understood-docker-and-kubernetes.md
+++ b/content/posts/how-i-finally-understood-docker-and-kubernetes.md
@@ -750,8 +750,8 @@ The tools themselves matter less than understanding the problems they solve. Onc
 
 ## Related Resources
 
-- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine) — deeper comparison
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — choosing the right tool
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — hands-on Docker learning
-- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes) — hands-on K8s learning
-- [DevOps Roadmap](/roadmap) — the full learning path
+- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine): deeper comparison
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): choosing the right tool
+- [Introduction to Docker Guide](/guides/introduction-to-docker): hands-on Docker learning
+- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes): hands-on K8s learning
+- [DevOps Roadmap](/roadmap): the full learning path

--- a/content/posts/how-to-access-docker-container-shell.md
+++ b/content/posts/how-to-access-docker-container-shell.md
@@ -272,8 +272,8 @@ Happy containerizing!
 
 ## Related Resources
 
-- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty) — attach to running containers
-- [Interactive Shell in Docker Compose](/posts/interactive-shell-docker-compose) — Compose shell access
-- [Docker TTY Error Fix](/posts/docker-tty-error-fix) — troubleshoot TTY issues
-- [Docker Edit File in Container](/posts/docker-edit-file-in-container) — modify files
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty): attach to running containers
+- [Interactive Shell in Docker Compose](/posts/interactive-shell-docker-compose): Compose shell access
+- [Docker TTY Error Fix](/posts/docker-tty-error-fix): troubleshoot TTY issues
+- [Docker Edit File in Container](/posts/docker-edit-file-in-container): modify files
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-to-add-a-volume-to-an-existing-docker-container.md
+++ b/content/posts/how-to-add-a-volume-to-an-existing-docker-container.md
@@ -203,8 +203,8 @@ Recreating a container is the safe, repeatable way to add volumes. Once the patt
 
 ## Related Resources
 
-- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits) — why volumes matter
-- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases) — database patterns
-- [Mount a Host Directory in Docker](/posts/docker-mount-host-directory) — bind mounts
-- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers) — manage volumes
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — volume fundamentals
+- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits): why volumes matter
+- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases): database patterns
+- [Mount a Host Directory in Docker](/posts/docker-mount-host-directory): bind mounts
+- [How to List Docker Volumes](/posts/how-to-list-docker-volumes-in-containers): manage volumes
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): volume fundamentals

--- a/content/posts/how-to-artificially-create-connection-timeout-error.md
+++ b/content/posts/how-to-artificially-create-connection-timeout-error.md
@@ -20,7 +20,7 @@ tags:
   - Debugging
 ---
 
-Testing how your application handles connection timeouts is crucial for building resilient software. Whether you're implementing retry logic, circuit breakers, or simply want to verify your error handling works correctly, you'll need to simulate timeout scenarios in a controlled way.
+Testing how your application handles connection timeouts matters for building resilient software. Whether you're implementing retry logic, circuit breakers, or simply want to verify your error handling works correctly, you'll need to simulate timeout scenarios in a controlled way.
 
 Connection timeouts occur when a client can't establish a connection to a server within a specified time limit. Unlike read timeouts (which happen during data transfer), connection timeouts happen at the initial handshake phase. Let's explore several practical methods to create these scenarios for testing.
 

--- a/content/posts/how-to-attach-detach-docker-process.md
+++ b/content/posts/how-to-attach-detach-docker-process.md
@@ -84,7 +84,7 @@ Attaching and detaching from Docker containers is a handy way to interact with r
 
 ## Related Resources
 
-- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty) — interactive sessions
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — shell methods
-- [Docker TTY Error Fix](/posts/docker-tty-error-fix) — troubleshoot TTY issues
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty): interactive sessions
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): shell methods
+- [Docker TTY Error Fix](/posts/docker-tty-error-fix): troubleshoot TTY issues
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-to-change-uri-url-for-remote-git-repository.md
+++ b/content/posts/how-to-change-uri-url-for-remote-git-repository.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Change the URI (URL) for a Remote Git Repository'
-excerpt: 'Learn how to update remote repository URLs in Git when repositories are moved, renamed, or migrated. Learn remote management commands for seamless workflow continuation.'
+excerpt: 'Learn how to update remote repository URLs in Git when repositories are moved, renamed, or migrated. Learn remote management commands to keep your workflow going.'
 category:
   name: 'Git'
   slug: 'git'
@@ -19,7 +19,7 @@ tags:
   - GitHub
 ---
 
-Your Git repository has been moved to a new location, your organization changed its name, or you need to switch from HTTPS to SSH authentication. When remote repository URLs change, you need to update your local Git configuration to continue pushing and pulling changes seamlessly.
+Your Git repository has been moved to a new location, your organization changed its name, or you need to switch from HTTPS to SSH authentication. When remote repository URLs change, you need to update your local Git configuration to continue pushing and pulling changes.
 
 In this guide, you'll learn how to update remote repository URLs and manage multiple remotes effectively.
 
@@ -365,4 +365,4 @@ git config --list | grep remote > remote-backup.txt
 cp .git/config .git/config.backup
 ```
 
-Now you understand how to manage and update Git remote URLs effectively. Whether you're dealing with repository migrations, organization changes, or authentication method switches, these techniques will help you maintain seamless connectivity to your remote repositories.
+Now you understand how to manage and update Git remote URLs effectively. Whether you're dealing with repository migrations, organization changes, or authentication method switches, these techniques will help you maintain connectivity to your remote repositories.

--- a/content/posts/how-to-clear-docker-container-logs-properly.md
+++ b/content/posts/how-to-clear-docker-container-logs-properly.md
@@ -186,7 +186,7 @@ With these patterns you can reset container logs when needed and keep them under
 
 ## Related Resources
 
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — container cleanup
-- [Docker List Containers](/posts/docker-list-containers) — find containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): container cleanup
+- [Docker List Containers](/posts/docker-list-containers): find containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-to-determine-the-url-that-a-local-git-repository-was-originally-cloned-from.md
+++ b/content/posts/how-to-determine-the-url-that-a-local-git-repository-was-originally-cloned-from.md
@@ -173,7 +173,7 @@ git remote
 git remote show origin
 ```
 
-The `git remote show` command provides comprehensive information:
+The `git remote show` command provides detailed information:
 
 ```
 * remote origin

--- a/content/posts/how-to-for-each-through-a-list-objects-in-terraform.md
+++ b/content/posts/how-to-for-each-through-a-list-objects-in-terraform.md
@@ -89,6 +89,6 @@ Terraform will create an S3 bucket for each object in the list.
 
 - Use descriptive keys in your `for_each` maps to make your configuration easier to understand.
 - Validate your input data to ensure it meets your requirements.
-- Keep your Terraform code DRY (Don't Repeat Yourself) by leveraging constructs like `for_each`.
+- Keep your Terraform code DRY (Don't Repeat Yourself) by using constructs like `for_each`.
 
 By using `for_each`, you can efficiently manage multiple resources in Terraform, making your infrastructure code more maintainable and scalable.

--- a/content/posts/how-to-get-docker-container-ip-from-host.md
+++ b/content/posts/how-to-get-docker-container-ip-from-host.md
@@ -129,7 +129,7 @@ If you find yourself needing container IPs regularly, it might be time to rethin
 
 ## Related Resources
 
-- [How to Get Docker Host IP from Container](/posts/how-to-get-docker-host-ip-from-container) — reverse direction
-- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker) — host networking
-- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose) — networking concepts
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking guide
+- [How to Get Docker Host IP from Container](/posts/how-to-get-docker-host-ip-from-container): reverse direction
+- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker): host networking
+- [Docker Compose: Ports vs Expose](/posts/docker-compose-ports-vs-expose): networking concepts
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking guide

--- a/content/posts/how-to-get-docker-host-ip-from-container.md
+++ b/content/posts/how-to-get-docker-host-ip-from-container.md
@@ -24,7 +24,7 @@ To access the Docker host from inside a container, you can use special DNS names
 
 ## Why Would You Need the Host IP?
 
-Sometimes, a container needs to connect to a service running on the Docker host—maybe a database, a local API, or a debugging tool. Since containers run in their own network namespace, they can't just use `localhost` to reach the host. Instead, you need to know the host's IP address or use a special DNS name.
+Sometimes, a container needs to connect to a service running on the Docker host, maybe a database, a local API, or a debugging tool. Since containers run in their own network namespace, they can't just use `localhost` to reach the host. Instead, you need to know the host's IP address or use a special DNS name.
 
 ## The Easy Way: `host.docker.internal` (Docker Desktop)
 
@@ -114,7 +114,7 @@ curl http://$HOST_IP:5000
 ## Caveats and Security Notes
 
 - Exposing host services to containers can be risky. Only do this for trusted containers or during development.
-- The `--network host` mode removes network isolation—avoid in production unless you know the risks.
+- The `--network host` mode removes network isolation; avoid in production unless you know the risks.
 - The gateway IP trick may not work with custom Docker networks or in Kubernetes pods.
 
 ## Conclusion
@@ -124,7 +124,7 @@ Accessing the Docker host from inside a container is easy with the right approac
 
 ## Related Resources
 
-- [Get Docker Container IP from Host](/posts/how-to-get-docker-container-ip-from-host) — reverse direction
-- [Docker Access Host Port](/posts/docker-access-host-port) — host access patterns
-- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker) — host networking
-- [Introduction to Docker: Networking](/guides/introduction-to-docker) — networking guide
+- [Get Docker Container IP from Host](/posts/how-to-get-docker-container-ip-from-host): reverse direction
+- [Docker Access Host Port](/posts/docker-access-host-port): host access patterns
+- [Connect to Host Localhost from Docker](/posts/connect-to-host-localhost-from-docker): host networking
+- [Introduction to Docker: Networking](/guides/introduction-to-docker): networking guide

--- a/content/posts/how-to-get-local-ip-address.md
+++ b/content/posts/how-to-get-local-ip-address.md
@@ -144,7 +144,7 @@ print(f"Your local IP address is: {ip_address}")
 
 This method works by creating a socket connection to an external address and checking what local address the system would use for that connection. It's reliable because it doesn't depend on parsing command output.
 
-For a more comprehensive approach that lists all network interfaces:
+For an approach that lists all network interfaces:
 
 ```python
 import socket
@@ -302,7 +302,7 @@ The Python one-liner is particularly useful because it's cross-platform and does
 
 ## Scripting for Automation
 
-When you need to get the local IP in scripts, create reusable functions. Here's a robust shell script that works across different Unix-like systems:
+When you need to get the local IP in scripts, create reusable functions. Here's a shell script that works across different Unix-like systems:
 
 ```bash
 #!/bin/bash

--- a/content/posts/how-to-list-docker-volumes-in-containers.md
+++ b/content/posts/how-to-list-docker-volumes-in-containers.md
@@ -21,7 +21,7 @@ tags:
 
 **TLDR:** List all Docker volumes with `docker volume ls`. To see which volumes a specific container uses, run `docker inspect <container>` and look at the "Mounts" section, or use `docker inspect -f '{{ .Mounts }}' <container>` for direct output. For running containers, `docker ps` with custom format shows volume information. Use `docker volume inspect` to see detailed volume information including the host filesystem path.
 
-Understanding what volumes are attached to your containers is crucial for managing persistent data, debugging storage issues, and cleaning up unused resources.
+Understanding what volumes are attached to your containers helps you manage persistent data, debug storage issues, and clean up unused resources.
 
 ## List All Volumes
 
@@ -455,7 +455,7 @@ Understanding how to list and inspect volumes helps you manage persistent data, 
 
 ## Related Resources
 
-- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases) — database volumes
-- [How to Add a Volume to an Existing Container](/posts/how-to-add-a-volume-to-an-existing-docker-container) — add volumes
-- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits) — why volumes matter
-- [Introduction to Docker: Volumes](/guides/introduction-to-docker) — volume fundamentals
+- [Docker Persistent Storage for Databases](/posts/docker-persistent-storage-databases): database volumes
+- [How to Add a Volume to an Existing Container](/posts/how-to-add-a-volume-to-an-existing-docker-container): add volumes
+- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits): why volumes matter
+- [Introduction to Docker: Volumes](/guides/introduction-to-docker): volume fundamentals

--- a/content/posts/how-to-make-git-forget-tracked-file-in-gitignore.md
+++ b/content/posts/how-to-make-git-forget-tracked-file-in-gitignore.md
@@ -54,7 +54,7 @@ The solution is to remove the file from Git's tracking index while keeping it in
 git rm --cached config/database.yml
 ```
 
-This command removes the file from Git's index (staging area) but leaves the actual file untouched in your working directory. The `--cached` flag is crucial - without it, `git rm` would delete the file entirely.
+This command removes the file from Git's index (staging area) but leaves the actual file untouched in your working directory. The `--cached` flag matters - without it, `git rm` would delete the file entirely.
 
 After running this command, commit the change:
 
@@ -253,7 +253,7 @@ git rm --cached config/database.yml
 
 ## Best Practices
 
-Add comprehensive `.gitignore` rules before committing files to avoid this situation:
+Add thorough `.gitignore` rules before committing files to avoid this situation:
 
 ```bash
 # Start with a good .gitignore template

--- a/content/posts/how-to-manage-multiple-environments-in-kubernetes.md
+++ b/content/posts/how-to-manage-multiple-environments-in-kubernetes.md
@@ -19,7 +19,7 @@ tags:
   - Production
 ---
 
-Managing multiple environments is a common requirement for teams running applications on Kubernetes. Whether you're supporting development, QA, staging, or production, keeping these environments isolated and consistent helps you catch issues early and deploy with confidence. In this guide, you'll learn how to structure your Kubernetes setup to support multiple environments, avoid common pitfalls, and streamline your deployment process.
+Managing multiple environments is a common requirement for teams running applications on Kubernetes. Whether you're supporting development, QA, staging, or production, keeping these environments isolated and consistent helps you catch issues early and deploy with confidence. In this guide, you'll learn how to structure your Kubernetes setup to support multiple environments, avoid common pitfalls, and simplify your deployment process.
 
 ## Prerequisites
 
@@ -102,7 +102,7 @@ For strict isolation, especially in regulated industries, you might use a separa
 
 ## Next Steps
 
-Explore tools like Kustomize, Helm, or ArgoCD to further streamline environment management. As your team grows, consider policies and access controls to keep your environments secure and maintainable.
+Explore tools like Kustomize, Helm, or ArgoCD to further simplify environment management. As your team grows, consider policies and access controls to keep your environments secure and maintainable.
 
 
 ## Related Resources

--- a/content/posts/how-to-publish-helm-chart.md
+++ b/content/posts/how-to-publish-helm-chart.md
@@ -268,7 +268,7 @@ ChartMuseum supports multiple storage backends including S3, GCS, Azure Blob, an
 
 ### Document Your Chart
 
-Include a comprehensive `README.md` in your chart directory:
+Include a thorough `README.md` in your chart directory:
 
 ```markdown
 # MyChart

--- a/content/posts/how-to-resolve-git-merge-conflicts.md
+++ b/content/posts/how-to-resolve-git-merge-conflicts.md
@@ -446,4 +446,4 @@ git log --merges --oneline -10
 git log --name-only --pretty=format: --merges | sort | uniq -c | sort -nr
 ```
 
-Now you have comprehensive knowledge for handling Git merge conflicts. Remember that conflicts are opportunities to understand your codebase better and improve team coordination. With practice, conflict resolution becomes a routine part of collaborative development.
+Now you have the knowledge for handling Git merge conflicts. Remember that conflicts are opportunities to understand your codebase better and improve team coordination. With practice, conflict resolution becomes a routine part of collaborative development.

--- a/content/posts/how-to-restart-container-within-pod.md
+++ b/content/posts/how-to-restart-container-within-pod.md
@@ -74,6 +74,6 @@ This can lead to downtime and configuration drift, especially as your workloads 
 
 ## Next Steps
 
-For more robust operations, automate restarts using health checks such as liveness and readiness probes. These probes let Kubernetes detect and recover from unhealthy containers automatically, reducing the need for manual intervention. You can also integrate restart logic into your CI/CD pipeline to handle updates and rollbacks efficiently.
+For more reliable operations, automate restarts using health checks such as liveness and readiness probes. These probes let Kubernetes detect and recover from unhealthy containers automatically, reducing the need for manual intervention. You can also integrate restart logic into your CI/CD pipeline to handle updates and rollbacks efficiently.
 
 As your infrastructure grows, explore Kubernetes controllers and operators to manage pod lifecycles, scaling, and recovery in a more automated and reliable way. Learning these patterns will help you build resilient, production-ready systems.

--- a/content/posts/how-to-run-cron-job-in-docker.md
+++ b/content/posts/how-to-run-cron-job-in-docker.md
@@ -24,7 +24,7 @@ To run a cron job inside a Docker container, install cron, add your job to the c
 
 ## Why Run Cron in a Container?
 
-Running cron jobs in containers is handy for scheduled tasks like backups, data syncs, or periodic scripts—especially when you want to package everything as a single deployable unit. But containers don't run background daemons by default, so you need to set things up carefully.
+Running cron jobs in containers is handy for scheduled tasks like backups, data syncs, or periodic scripts, especially when you want to package everything as a single deployable unit. But containers don't run background daemons by default, so you need to set things up carefully.
 
 ## Basic Example: Cron in a Dockerfile
 
@@ -107,7 +107,7 @@ Running cron jobs in Docker is straightforward with the right setup. Keep cron i
 
 ## Related Resources
 
-- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands) — multi-command patterns
-- [How to Clear Docker Container Logs](/posts/how-to-clear-docker-container-logs-properly) — log management
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — secure containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands): multi-command patterns
+- [How to Clear Docker Container Logs](/posts/how-to-clear-docker-container-logs-properly): log management
+- [Docker Security Best Practices](/posts/docker-security-best-practices): secure containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-to-set-multiple-commands-in-one-yaml-file-with-kubernetes.md
+++ b/content/posts/how-to-set-multiple-commands-in-one-yaml-file-with-kubernetes.md
@@ -136,7 +136,7 @@ This can be visualized as follows:
 
 ## Next Steps
 
-You can expand on this by using Kubernetes Init Containers for pre-start tasks, or by orchestrating more advanced workflows with Jobs and CronJobs. Try experimenting with different shell scripting techniques to make your container startup logic robust and maintainable.
+You can expand on this by using Kubernetes Init Containers for pre-start tasks, or by building more advanced workflows with Jobs and CronJobs. Try experimenting with different shell scripting techniques to make your container startup logic reliable and maintainable.
 
 
 ## Related Resources

--- a/content/posts/how-to-set-up-aws-cost-explorer-and-budgets-for-teams.md
+++ b/content/posts/how-to-set-up-aws-cost-explorer-and-budgets-for-teams.md
@@ -76,7 +76,7 @@ Configure the report to show relevant data:
 
 ### Use Tags for Better Cost Allocation
 
-Tags are crucial for tracking costs by team, project, or environment. Set up a tagging strategy:
+Tags are essential for tracking costs by team, project, or environment. Set up a tagging strategy:
 
 1. Define required tags (e.g., `Team`, `Project`, `Environment`)
 2. Apply tags to all AWS resources

--- a/content/posts/how-to-use-sudo-in-docker-container.md
+++ b/content/posts/how-to-use-sudo-in-docker-container.md
@@ -72,7 +72,7 @@ This works just like on a regular Linux system.
 ## Best Practices
 
 - Avoid running production containers as root unless required.
-- Only install `sudo` if you need it—otherwise, keep images minimal.
+- Only install `sudo` if you need it; otherwise, keep images minimal.
 - Use the `USER` directive in your Dockerfile to specify a non-root user.
 - For one-off commands, you can override the user at runtime:
 
@@ -93,7 +93,7 @@ You rarely need `sudo` in Docker containers, since most run as root by default. 
 
 ## Related Resources
 
-- [Fix Docker Permission Denied](/posts/fix-docker-permission-denied-error) — host-level permissions
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — run as non-root
-- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash) — install tools in containers
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Fix Docker Permission Denied](/posts/fix-docker-permission-denied-error): host-level permissions
+- [Docker Security Best Practices](/posts/docker-security-best-practices): run as non-root
+- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash): install tools in containers
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/how-to-view-git-commit-history.md
+++ b/content/posts/how-to-view-git-commit-history.md
@@ -393,4 +393,4 @@ git log --graph --oneline main feature-branch
 git log --left-right --graph --cherry-pick --oneline main...feature-branch
 ```
 
-Now you have comprehensive knowledge of viewing and analyzing Git commit history. These techniques will help you understand your project's evolution, track down issues, and collaborate more effectively with your team by providing insights into how your codebase has changed over time.
+Now you know how to view and analyze Git commit history. These techniques will help you understand your project's evolution, track down issues, and collaborate more effectively with your team by providing insights into how your codebase has changed over time.

--- a/content/posts/increasing-the-maximum-number-of-tcp-ip-connections-in-linux.md
+++ b/content/posts/increasing-the-maximum-number-of-tcp-ip-connections-in-linux.md
@@ -350,7 +350,7 @@ net.ipv4.tcp_max_orphans = 65536
 
 ## Complete sysctl Configuration
 
-Here's a comprehensive `/etc/sysctl.conf` for high-connection servers:
+Here's a complete `/etc/sysctl.conf` for high-connection servers:
 
 ```bash
 # File system limits

--- a/content/posts/initial-setup-of-terraform-backend-using-terraform.md
+++ b/content/posts/initial-setup-of-terraform-backend-using-terraform.md
@@ -18,7 +18,7 @@ tags:
   - DevOps
 ---
 
-Setting up a Terraform backend is a crucial step for managing your state files securely and collaboratively. A backend allows you to store state files remotely, enabling features like state locking and versioning.
+Setting up a Terraform backend is an important step for managing your state files securely and collaboratively. A backend allows you to store state files remotely, enabling features like state locking and versioning.
 
 ## Why Use a Backend?
 

--- a/content/posts/inspect-filesystem-of-failed-docker-build.md
+++ b/content/posts/inspect-filesystem-of-failed-docker-build.md
@@ -20,7 +20,7 @@ tags:
 
 ## TLDR
 
-To inspect the file system of a failed Docker build, use multi-stage builds to save intermediate images, add debug steps (like `sleep` or `tail`), or leverage BuildKit's `--target` and `--output` features. This lets you start a shell in the failed state and debug interactively.
+To inspect the file system of a failed Docker build, use multi-stage builds to save intermediate images, add debug steps (like `sleep` or `tail`), or use BuildKit's `--target` and `--output` features. This lets you start a shell in the failed state and debug interactively.
 
 ## Why Is This Useful?
 
@@ -113,7 +113,7 @@ Inspecting the file system of a failed Docker build is easy with debug steps, mu
 
 ## Related Resources
 
-- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system) — browse container files
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit debugging
-- [Force Docker Clean Build](/posts/force-docker-clean-build) — rebuild from scratch
-- [Introduction to Docker: Building Images](/guides/introduction-to-docker) — Dockerfile guide
+- [Exploring Docker Container File System](/posts/exploring-docker-container-file-system): browse container files
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit debugging
+- [Force Docker Clean Build](/posts/force-docker-clean-build): rebuild from scratch
+- [Introduction to Docker: Building Images](/guides/introduction-to-docker): Dockerfile guide

--- a/content/posts/interactive-shell-docker-compose.md
+++ b/content/posts/interactive-shell-docker-compose.md
@@ -114,7 +114,7 @@ By following these steps, you can effectively use Docker Compose to start an int
 
 ## Related Resources
 
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — more shell methods
-- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands) — Compose commands
-- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty) — TTY sessions
-- [Introduction to Docker: Compose](/guides/introduction-to-docker) — Compose guide
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): more shell methods
+- [Docker Compose: Running Multiple Commands](/posts/docker-compose-multiple-commands): Compose commands
+- [Enter Docker Container with New TTY](/posts/enter-docker-container-new-tty): TTY sessions
+- [Introduction to Docker: Compose](/guides/introduction-to-docker): Compose guide

--- a/content/posts/invalid-for-each-argument-in-terraform.md
+++ b/content/posts/invalid-for-each-argument-in-terraform.md
@@ -125,4 +125,4 @@ This helps identify issues with the input data.
 - **Use Default Values**: Provide sensible defaults to avoid null or empty values.
 - **Test Iterations**: Use `terraform console` to test your `for_each` logic before applying changes.
 
-By understanding and addressing the root cause of the "Invalid for_each argument" error, you can create more robust and error-free Terraform configurations.
+By understanding and addressing the root cause of the "Invalid for_each argument" error, you can create more reliable and error-free Terraform configurations.

--- a/content/posts/istio-traffic-management-routing-retries-circuit-breaking.md
+++ b/content/posts/istio-traffic-management-routing-retries-circuit-breaking.md
@@ -52,8 +52,8 @@ kubectl label namespace default istio-injection=enabled
 
 Istio's traffic policies live in two CRDs:
 
-- **VirtualService** — defines *how* requests are routed. Match on host, path, header, weight.
-- **DestinationRule** — defines *what happens after* the route is picked. Subsets, load balancing, connection pools, outlier detection.
+- **VirtualService**: defines *how* requests are routed. Match on host, path, header, weight.
+- **DestinationRule**: defines *what happens after* the route is picked. Subsets, load balancing, connection pools, outlier detection.
 
 A common mistake is putting circuit breaker settings in a VirtualService. They don't belong there. Circuit breakers are a property of the destination, not the route.
 
@@ -193,9 +193,9 @@ Some details that matter:
 
 The values you almost always want in `retryOn`:
 
-- `gateway-error` — 502, 503, 504
-- `connect-failure` — TCP connect failed
-- `refused-stream` — HTTP/2 stream was refused (usually from overload)
+- `gateway-error`: 502, 503, 504
+- `connect-failure`: TCP connect failed
+- `refused-stream`: HTTP/2 stream was refused (usually from overload)
 
 Things you almost never want to retry:
 
@@ -261,11 +261,11 @@ spec:
 
 What this does:
 
-- **maxConnections / http2MaxRequests** — caps the in-flight request count. Once exceeded, new requests fail fast with a 503. This is the actual "circuit" being broken.
-- **consecutive5xxErrors: 5** — a host that returns five 5xx responses in a row gets ejected.
-- **interval: 30s** — how often Istio scans for unhealthy hosts.
-- **baseEjectionTime: 30s** — how long the host stays ejected. Doubles on repeat offenses.
-- **maxEjectionPercent: 50** — never eject more than half the hosts. Otherwise you can take the whole pool offline and have nothing left to serve traffic.
+- **maxConnections / http2MaxRequests**: caps the in-flight request count. Once exceeded, new requests fail fast with a 503. This is the actual "circuit" being broken.
+- **consecutive5xxErrors: 5**: a host that returns five 5xx responses in a row gets ejected.
+- **interval: 30s**: how often Istio scans for unhealthy hosts.
+- **baseEjectionTime: 30s**: how long the host stays ejected. Doubles on repeat offenses.
+- **maxEjectionPercent: 50**: never eject more than half the hosts. Otherwise you can take the whole pool offline and have nothing left to serve traffic.
 
 That last one is the safety valve. Without it, a regional outage of a downstream dependency can cause Istio to eject every backend pod, leaving you with zero capacity even when the dependency recovers.
 

--- a/content/posts/karpenter-spot-storm-fallback-gap.md
+++ b/content/posts/karpenter-spot-storm-fallback-gap.md
@@ -211,10 +211,10 @@ This is not a substitute for workarounds 1 and 2. It is what you build when narr
 
 Karpenter exposes a useful set of cloudprovider metrics. The ones that matter during a storm:
 
-- `karpenter_cloudprovider_errors_total` — label `error` carries `InsufficientInstanceCapacity`, `UnfulfillableCapacity`, `MaxSpotInstanceCountExceeded`. A spike is the storm starting.
-- `karpenter_cloudprovider_instance_type_offering_available` — gauge per `instance_type` / `capacity_type` / `zone`. Watch the sum drop.
-- `karpenter_nodeclaims_created_total`, `karpenter_nodeclaims_terminated_total`, `karpenter_nodeclaims_disrupted_total{reason="interruption"}` — when `disrupted{reason=interruption}` rate approaches `created` rate, you are churning.
-- `karpenter_interruption_received_messages_total{message_type="SpotInterruptionKind"}` — spot 2-minute warnings from the SQS queue.
+- `karpenter_cloudprovider_errors_total`: label `error` carries `InsufficientInstanceCapacity`, `UnfulfillableCapacity`, `MaxSpotInstanceCountExceeded`. A spike is the storm starting.
+- `karpenter_cloudprovider_instance_type_offering_available`: gauge per `instance_type` / `capacity_type` / `zone`. Watch the sum drop.
+- `karpenter_nodeclaims_created_total`, `karpenter_nodeclaims_terminated_total`, `karpenter_nodeclaims_disrupted_total{reason="interruption"}`: when `disrupted{reason=interruption}` rate approaches `created` rate, you are churning.
+- `karpenter_interruption_received_messages_total{message_type="SpotInterruptionKind"}`: spot 2-minute warnings from the SQS queue.
 - `karpenter_voluntary_disruption_decisions_total`, `karpenter_voluntary_disruption_queue_failures_total`.
 
 A working Prometheus alert that has caught real storms in production:
@@ -253,7 +253,7 @@ A few sharp edges worth knowing about before you build a dashboard on these:
 
 As of writing, none of the obvious "automatic fallback" feature requests are scheduled. Issue `#8298` was closed without implementation. Issue `#2275` was closed as working-as-intended in January 2026. The configurable cache TTL and NodePool-aware metrics in `#8224` are still open with no design doc attached.
 
-This is not because the maintainers don't care. It is because the architectural answer they are committed to (wide requirements plus `minValues` plus weighted NodePools) genuinely covers most cases. The cases it does not cover (narrow-constraint workloads, regional storms) are real, but rare enough that the project has not prioritized building the fallback machinery.
+This is not because the maintainers don't care. It is because the architectural answer they are committed to (wide requirements plus `minValues` plus weighted NodePools) covers most cases. The cases it does not cover (narrow-constraint workloads, regional storms) are real, but rare enough that the project has not prioritized building the fallback machinery.
 
 Practically, this means the production posture is yours to design. Plan for the storm.
 

--- a/content/posts/kubectl-apply-vs-create-differences.md
+++ b/content/posts/kubectl-apply-vs-create-differences.md
@@ -19,7 +19,7 @@ tags:
   - DevOps
 ---
 
-Understanding the difference between `kubectl apply` and `kubectl create` is crucial for effective Kubernetes resource management. While both commands can create resources, they behave differently when resources already exist and handle updates in distinct ways that affect your deployment workflow.
+Understanding the difference between `kubectl apply` and `kubectl create` matters for effective Kubernetes resource management. While both commands can create resources, they behave differently when resources already exist and handle updates in distinct ways that affect your deployment workflow.
 
 ## Prerequisites
 

--- a/content/posts/kubernetes-1-36-user-namespaces-pod-resize.md
+++ b/content/posts/kubernetes-1-36-user-namespaces-pod-resize.md
@@ -68,7 +68,7 @@ spec:
       command: ["sleep", "infinity"]
 ```
 
-Inside the container, `id` will report `uid=0(root)`. From a debug shell on the node, `ps -ef` for that PID will show a non-zero, non-host UID — typically something in the 65536+ range mapped per-pod. A `cat /proc/<pid>/uid_map` on the host shows the mapping range.
+Inside the container, `id` will report `uid=0(root)`. From a debug shell on the node, `ps -ef` for that PID will show a non-zero, non-host UID, typically something in the 65536+ range mapped per-pod. A `cat /proc/<pid>/uid_map` on the host shows the mapping range.
 
 ### What you can't do with `hostUsers: false`
 
@@ -84,18 +84,18 @@ For a typical web service this list is uncontroversial. For privileged DaemonSet
 
 ### Rollout pattern
 
-The kubelet doesn't automatically opt every workload in — you set `hostUsers: false` per pod template. A reasonable rollout sequence:
+The kubelet doesn't automatically opt every workload in; you set `hostUsers: false` per pod template. A reasonable rollout sequence:
 
 1. Pick one stateless deployment in staging. Add `hostUsers: false`. Confirm the pod schedules, the volumes mount, and the app reads its ConfigMap.
 2. Spot-check `crictl inspect <containerID>` on the node and verify the runtime reports the user namespace mapping.
 3. Roll the same change to a low-blast-radius prod workload (a doc site, a webhook receiver) before going broader.
-4. PSAA or Kyverno policy enforcement comes last — once you have evidence multiple workloads work without surprises, you can codify "no `hostUsers: true` for new pods unless explicitly waived".
+4. PSAA or Kyverno policy enforcement comes last. Once you have evidence multiple workloads work without surprises, you can codify "no `hostUsers: true` for new pods unless explicitly waived".
 
 ## Pod-level in-place resize: what's actually new
 
-Per-container resize landed in 1.33 alpha and graduated through 1.35. In 1.36 the resize subresource also accepts changes to **`spec.resources`** — the pod-level aggregate that 1.32 introduced as an upper bound on the sum of container limits.
+Per-container resize landed in 1.33 alpha and graduated through 1.35. In 1.36 the resize subresource also accepts changes to **`spec.resources`**, the pod-level aggregate that 1.32 introduced as an upper bound on the sum of container limits.
 
-The semantics matter: pod-level resources are enforced at the pod's cgroup, not by the application runtime inside containers. That's why this resize never restarts the pod — bumping the pod-level cgroup memory limit is just a `cgroup.memory.max` write to a file that already exists. There's nothing to coordinate with the application.
+The semantics matter: pod-level resources are enforced at the pod's cgroup, not by the application runtime inside containers. That's why this resize never restarts the pod: bumping the pod-level cgroup memory limit is just a `cgroup.memory.max` write to a file that already exists. There's nothing to coordinate with the application.
 
 ### Pod with both per-container and pod-level resources
 
@@ -147,7 +147,7 @@ kubectl get pod pod-resize-demo -o yaml | yq '.status.resize'
 
 The kubelet refuses the resize and surfaces an event when:
 
-- The new request can't fit on the node — same admission rules as initial scheduling.
+- The new request can't fit on the node (same admission rules as initial scheduling).
 - The container runtime doesn't implement `UpdateContainerResources` for the requested change. `containerd ≤ 1.7` and older CRI-O versions hit this.
 - You try to lower memory below currently-used memory. The kubelet errs on the side of safety here: a memory shrink that would force OOM-kill the container is rejected.
 
@@ -185,11 +185,11 @@ None of these change your day in the way that user namespaces and pod resize do,
 
 ## Summary
 
-The headline of 1.36 isn't a new abstraction — it's two long-running features that finally feel safe to put under load:
+The headline of 1.36 isn't a new abstraction; it's two long-running features that finally feel safe to put under load:
 
 - **User namespaces (GA)** flips the security baseline for stateless workloads. Add `hostUsers: false` to pods that don't need host network/PID/IPC, and a chunk of the container-escape attack surface goes away.
 - **Pod-level in-place resize (beta on by default)** turns vertical autoscaling into a non-disruptive operation. The kubelet patches the cgroup, the application doesn't restart, and PDBs stay green.
 
-Both depend on infrastructure you should already have — cgroup v2, kernel 6.3+, containerd 2.0+ — but it's worth running through the prerequisites checklist before you flip the field on a production deployment. The feature gates are gone, but the kernel and runtime requirements aren't.
+Both depend on infrastructure you should already have (cgroup v2, kernel 6.3+, containerd 2.0+), but it's worth running through the prerequisites checklist before you flip the field on a production deployment. The feature gates are gone, but the kernel and runtime requirements aren't.
 
 Worth bookmarking the official posts: the [user namespaces GA announcement](https://kubernetes.io/blog/2026/04/23/kubernetes-v1-36-userns-ga/), the [pod-level resize beta](https://kubernetes.io/blog/2026/04/30/kubernetes-v1-36-inplace-pod-level-resources-beta/), and the [v1.36 release notes](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/).

--- a/content/posts/kubernetes-service-types-clusterip-nodeport-loadbalancer.md
+++ b/content/posts/kubernetes-service-types-clusterip-nodeport-loadbalancer.md
@@ -20,7 +20,7 @@ tags:
   - LoadBalancer
 ---
 
-Kubernetes provides different service types to expose applications running in pods. Understanding the differences between ClusterIP, NodePort, and LoadBalancer services is crucial for designing proper network architecture and choosing the right exposure method for your applications.
+Kubernetes provides different service types to expose applications running in pods. Understanding the differences between ClusterIP, NodePort, and LoadBalancer services matters for designing proper network architecture and choosing the right exposure method for your applications.
 
 ## Prerequisites
 

--- a/content/posts/list-files-in-commit-git.md
+++ b/content/posts/list-files-in-commit-git.md
@@ -304,7 +304,7 @@ git show --name-status abc123 | grep '^D'
 
 ## Getting Detailed File Info
 
-For comprehensive file information:
+For detailed file information:
 
 ```bash
 # Detailed changes with context

--- a/content/posts/local-docker-images-minikube.md
+++ b/content/posts/local-docker-images-minikube.md
@@ -148,7 +148,7 @@ By following these steps, you can efficiently use local Docker images with Minik
 
 ## Related Resources
 
-- [Use Local Docker Images with Minikube](/posts/use-local-docker-images-minikube) — updated methods
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — choosing the right tool
-- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes) — learn K8s
-- [DevOps Roadmap](/roadmap) — the full learning path
+- [Use Local Docker Images with Minikube](/posts/use-local-docker-images-minikube): updated methods
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): choosing the right tool
+- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes): learn K8s
+- [DevOps Roadmap](/roadmap): the full learning path

--- a/content/posts/loop-through-array-strings-bash.md
+++ b/content/posts/loop-through-array-strings-bash.md
@@ -238,7 +238,7 @@ echo "Other files (${#other_files[@]}): ${other_files[*]}"
 
 ## Error Handling in Array Loops
 
-Implement robust error handling:
+Implement reliable error handling:
 
 ```bash
 #!/bin/bash
@@ -430,7 +430,7 @@ done
 2. **Use meaningful variable names** for better code readability
 3. **Handle empty arrays gracefully** - Check array length before processing
 4. **Consider performance** for large arrays - use batch processing when needed
-5. **Implement error handling** for robust scripts
+5. **Implement error handling** for reliable scripts
 6. **Use associative arrays** for key-value data structures
 7. **Prefer readarray/mapfile** for creating arrays from command output
 8. **Test with various data types** including strings with spaces and special characters

--- a/content/posts/looping-through-file-content-bash.md
+++ b/content/posts/looping-through-file-content-bash.md
@@ -39,7 +39,7 @@ The `IFS=` prevents the shell from trimming whitespace, and `-r` prevents backsl
 
 ## Processing Files with Error Handling
 
-Adding error handling makes your scripts more robust. This example checks if the file exists before processing:
+Adding error handling makes your scripts more reliable. This example checks if the file exists before processing:
 
 ```bash
 filename="data.txt"
@@ -203,7 +203,7 @@ This approach splits large files into smaller chunks and processes them simultan
 
 ## Error Recovery and Logging
 
-For production scripts, implement comprehensive error handling and logging:
+For production scripts, implement thorough error handling and logging:
 
 ```bash
 log_file="processing.log"

--- a/content/posts/migrating-from-heroku-to-digitalocean.md
+++ b/content/posts/migrating-from-heroku-to-digitalocean.md
@@ -311,13 +311,13 @@ doctl apps update $APP_ID --set-env="DATABASE_URL=postgresql://..." --encrypt
 
 ### Alternative: Coolify Self-Hosted Setup
 
-If you're willing to manage your own server in exchange for dramatically lower costs, Coolify offers a compelling path. This open-source platform runs entirely on a single DigitalOcean Droplet and can host multiple applications for as little as $24/month — a fraction of what you'd pay on Heroku or even App Platform.
+If you're willing to manage your own server in exchange for dramatically lower costs, Coolify offers a compelling path. This open-source platform runs entirely on a single DigitalOcean Droplet and can host multiple applications for as little as $24/month, a fraction of what you'd pay on Heroku or even App Platform.
 
 #### What is Coolify?
 
 Think of Coolify as a self-hosted Heroku. It gives you the same git-push deployment experience you're used to, but everything runs on infrastructure you control. Behind the scenes, it uses Docker for containerization, Traefik for routing and SSL termination, and provides a clean web UI for managing everything.
 
-The platform supports GitHub, GitLab, and Bitbucket repositories with automatic deployments on push. SSL certificates are handled automatically through Let's Encrypt, and you get built-in support for PostgreSQL, MySQL, MongoDB, and Redis databases. Whether you're deploying static sites, APIs, or full-stack applications, Coolify handles the orchestration while you maintain full control over the underlying infrastructure.
+The platform supports GitHub, GitLab, and Bitbucket repositories with automatic deployments on push. SSL certificates are handled automatically through Let's Encrypt, and you get built-in support for PostgreSQL, MySQL, MongoDB, and Redis databases. Whether you're deploying static sites, APIs, or full-stack applications, Coolify handles the deployment coordination while you maintain full control over the underlying infrastructure.
 
 #### Setting Up Coolify
 
@@ -345,7 +345,7 @@ doctl compute droplet create coolify-server \\
 
 **Installing Coolify**
 
-Once your Droplet is running, SSH in and run Coolify's installer. The script handles all dependencies — Docker, Docker Compose, and the Coolify control plane. Installation takes 5-10 minutes depending on your connection speed.
+Once your Droplet is running, SSH in and run Coolify's installer. The script handles all dependencies: Docker, Docker Compose, and the Coolify control plane. Installation takes 5-10 minutes depending on your connection speed.
 
 ```bash
 # SSH into Droplet
@@ -372,13 +372,13 @@ coolify.yourdomain.com  →  your-droplet-ip
 *.coolify.yourdomain.com  →  your-droplet-ip
 ```
 
-The wildcard record is optional but recommended — it lets you deploy multiple apps on different subdomains without manually creating DNS records each time.
+The wildcard record is optional but recommended; it lets you deploy multiple apps on different subdomains without manually creating DNS records each time.
 
 **Deploying Your First Application**
 
 The deployment flow in Coolify feels familiar if you've used Heroku. Start by creating a project (think of it as a workspace), then add a new application. Connect your GitHub, GitLab, or Bitbucket repository, and Coolify will analyze your code to detect the framework.
 
-For most frameworks, Coolify uses Nixpacks (similar to Heroku's buildpacks) to automatically detect and build your app. If you have a Dockerfile, it'll use that instead. Set your environment variables, specify your custom domain, and hit deploy. Coolify pulls your code, builds it, starts the container, and provisions an SSL certificate — all automatically.
+For most frameworks, Coolify uses Nixpacks (similar to Heroku's buildpacks) to automatically detect and build your app. If you have a Dockerfile, it'll use that instead. Set your environment variables, specify your custom domain, and hit deploy. Coolify pulls your code, builds it, starts the container, and provisions an SSL certificate, all automatically.
 
 **Example deployment (Node.js)**:
 
@@ -495,15 +495,15 @@ Add this to cron with `0 2 * * * /root/backup-to-spaces.sh` to run at 2 AM daily
 
 **Lock down your server** with UFW firewall. Only expose SSH (port 22), HTTP (80), and HTTPS (443). Keep Coolify updated with `coolify update` every month or when security patches are released. Use strong, randomly generated passwords for all database credentials.
 
-**Plan your exit strategy**. When you outgrow a single Droplet — typically around 10K-50K requests/minute or when you need multi-region deployment — you can migrate to App Platform or Kubernetes. The containerized nature of Coolify makes this transition straightforward.
+**Plan your exit strategy**. When you outgrow a single Droplet (typically around 10K-50K requests/minute or when you need multi-region deployment), you can migrate to App Platform or Kubernetes. The containerized nature of Coolify makes this transition straightforward.
 
 #### When Coolify is the Right Choice
 
-Coolify shines in specific scenarios. It's ideal when you're running multiple applications and want to consolidate them on shared infrastructure — the cost savings compound quickly. You'll need basic Linux comfort (SSH, Docker concepts, reading logs), but you don't need to be a sysadmin. If you're currently spending $500+/month on Heroku across several apps, Coolify can cut that to $24-$96/month.
+Coolify shines in specific scenarios. It's ideal when you're running multiple applications and want to consolidate them on shared infrastructure, since the cost savings compound quickly. You'll need basic Linux comfort (SSH, Docker concepts, reading logs), but you don't need to be a sysadmin. If you're currently spending $500+/month on Heroku across several apps, Coolify can cut that to $24-$96/month.
 
 The traffic sweet spot is 1K-10K requests/minute on an 8GB Droplet. Beyond that, you'll want to either scale vertically to 16GB+ or consider moving to App Platform for horizontal scaling.
 
-**Avoid Coolify if** you need enterprise SLAs, 24/7 vendor support, or multi-region redundancy out of the box. It's also not the right choice if you've never SSH'd into a server before — there's a learning curve. And while you can vertically scale Droplets quickly, instant horizontal auto-scaling isn't available like it is with App Platform.
+**Avoid Coolify if** you need enterprise SLAs, 24/7 vendor support, or multi-region redundancy out of the box. It's also not the right choice if you've never SSH'd into a server before; there's a learning curve. And while you can vertically scale Droplets quickly, instant horizontal auto-scaling isn't available like it is with App Platform.
 
 #### Coolify + App Platform Hybrid
 
@@ -1386,7 +1386,7 @@ config.active_storage.service = :digitalocean
 
 ## The Bottom Line
 
-Migrating from Heroku to DigitalOcean isn't about abandoning managed services — it's about **choosing better-priced managed services**. With App Platform, you keep the developer experience (git push deployments, managed databases, zero-config SSL) while cutting costs by 60-80%. With Coolify self-hosted, you can achieve 90%+ savings for multi-app setups on a single $24/month Droplet.
+Migrating from Heroku to DigitalOcean isn't about abandoning managed services; it's about **choosing better-priced managed services**. With App Platform, you keep the developer experience (git push deployments, managed databases, zero-config SSL) while cutting costs by 60-80%. With Coolify self-hosted, you can achieve 90%+ savings for multi-app setups on a single $24/month Droplet.
 
 The migration itself takes 3-4 weeks with minimal downtime when done incrementally. For most teams spending >$200/month on Heroku, the savings justify the effort within 2-3 months.
 

--- a/content/posts/nuke-all-aws-resources.md
+++ b/content/posts/nuke-all-aws-resources.md
@@ -54,7 +54,7 @@ This command terminates all EC2 instances in the account.
 
 ### Using `aws-nuke`
 
-`aws-nuke` is a third-party tool designed to delete all resources in an AWS account. It is more comprehensive and easier to use than scripting with AWS CLI.
+`aws-nuke` is a third-party tool designed to delete all resources in an AWS account. It covers more resource types and is easier to use than scripting with AWS CLI.
 
 #### Step 1: Install `aws-nuke`
 

--- a/content/posts/parse-command-line-arguments-bash.md
+++ b/content/posts/parse-command-line-arguments-bash.md
@@ -188,7 +188,7 @@ echo "  Remaining arguments: ${remaining_args[*]}"
 
 ## Advanced Argument Parser Function
 
-Here's a comprehensive argument parser that handles both short and long options:
+Here's a full argument parser that handles both short and long options:
 
 ```bash
 #!/bin/bash
@@ -537,4 +537,4 @@ echo "  Debug: $debug"
 9. **Implement the `--` separator** to handle filenames starting with dashes
 10. **Test edge cases** like empty arguments and special characters
 
-Proper argument parsing makes your Bash scripts more professional and user-friendly. Choose the method that best fits your script's complexity, from simple positional parameters for basic scripts to comprehensive parsers for complex command-line tools.
+Proper argument parsing makes your Bash scripts more professional and user-friendly. Choose the method that best fits your script's complexity, from simple positional parameters for basic scripts to full parsers for complex command-line tools.

--- a/content/posts/pass-environment-variables-docker-containers.md
+++ b/content/posts/pass-environment-variables-docker-containers.md
@@ -127,7 +127,7 @@ Happy shipping!
 
 ## Related Resources
 
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — Compose env vars
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — keep secrets safe
-- [Dockerfile: Update PATH](/posts/dockerfile-update-path) — set env vars in builds
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): Compose env vars
+- [Docker Security Best Practices](/posts/docker-security-best-practices): keep secrets safe
+- [Dockerfile: Update PATH](/posts/dockerfile-update-path): set env vars in builds
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/pipe-clipboard-bash-script.md
+++ b/content/posts/pipe-clipboard-bash-script.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Pipe to and from Clipboard in Bash Scripts'
-excerpt: 'Learn how to integrate clipboard functionality into your Bash scripts using xclip, xsel, pbcopy, and pbpaste for seamless data transfer between terminal and GUI applications.'
+excerpt: 'Learn how to integrate clipboard functionality into your Bash scripts using xclip, xsel, pbcopy, and pbpaste for easy data transfer between terminal and GUI applications.'
 category:
   name: 'Linux'
   slug: 'linux'
@@ -20,7 +20,7 @@ tags:
   - productivity
 ---
 
-Integrating clipboard functionality into Bash scripts allows you to seamlessly transfer data between command-line tools and GUI applications. This capability is essential for automation scripts, data processing workflows, and productivity tools.
+Integrating clipboard functionality into Bash scripts allows you to transfer data between command-line tools and GUI applications. This capability is essential for automation scripts, data processing workflows, and productivity tools.
 
 ## Prerequisites
 

--- a/content/posts/postgres-k8s.md
+++ b/content/posts/postgres-k8s.md
@@ -95,7 +95,7 @@ These workarounds essentially recreate dedicated VMs, negating much of Kubernete
 
 ### Complex Backup and Recovery Procedures
 
-Databases require robust backup solutions. Here's the reality with Kubernetes:
+Databases require reliable backup solutions. Here's the reality with Kubernetes:
 
 1. Volume snapshots are provider-specific and may not be consistent
 2. Logical backups require careful coordination with Postgres
@@ -132,7 +132,7 @@ But wait:
 3. What happens to existing connections during failover?
 4. How do you verify database integrity after version upgrades?
 
-These questions are easily answered in traditional setups but become complex orchestration challenges in Kubernetes.
+These questions are easily answered in traditional setups but become complex coordination challenges in Kubernetes.
 
 ## Where Things Go Wrong: Real-World Scenarios
 

--- a/content/posts/profile-cpp-code-performance-linux.md
+++ b/content/posts/profile-cpp-code-performance-linux.md
@@ -111,7 +111,7 @@ Valgrind's Cachegrind tool analyzes memory access patterns and cache performance
 valgrind --tool=cachegrind ./myprogram
 ```
 
-This shows cache miss rates and memory access patterns, which is crucial for optimizing data structures and memory layout in performance-critical applications.
+This shows cache miss rates and memory access patterns, which matters for optimizing data structures and memory layout in performance-critical applications.
 
 ## Heap Profiling for Memory Usage
 

--- a/content/posts/prompt-yes-no-cancel-input-linux-shell-script.md
+++ b/content/posts/prompt-yes-no-cancel-input-linux-shell-script.md
@@ -418,6 +418,6 @@ Visual cues help users understand the importance and potential impact of their c
 
 ## Next Steps
 
-You can now create interactive shell scripts with robust user input handling. Consider exploring more advanced techniques like creating full-screen terminal interfaces with tools like `dialog` or `whiptail`, implementing configuration file-based defaults, or building command-line argument parsing that can override interactive prompts.
+You can now create interactive shell scripts with reliable user input handling. Consider exploring more advanced techniques like creating full-screen terminal interfaces with tools like `dialog` or `whiptail`, implementing configuration file-based defaults, or building command-line argument parsing that can override interactive prompts.
 
 Good luck building user-friendly scripts!

--- a/content/posts/ps-command-not-working-docker.md
+++ b/content/posts/ps-command-not-working-docker.md
@@ -118,7 +118,7 @@ By following these steps, you can resolve issues with the `ps` command in Docker
 
 ## Related Resources
 
-- [Docker Ubuntu: Ping Not Found](/posts/docker-ubuntu-ping-not-found) — install missing tools
-- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash) — shell tools in Alpine
-- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell) — shell access
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Ubuntu: Ping Not Found](/posts/docker-ubuntu-ping-not-found): install missing tools
+- [Docker Alpine: How to Use Bash](/posts/docker-alpine-use-bash): shell tools in Alpine
+- [How to Access Docker Container Shell](/posts/how-to-access-docker-container-shell): shell access
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/push-docker-image-private-repo.md
+++ b/content/posts/push-docker-image-private-repo.md
@@ -109,7 +109,7 @@ By following these steps, you can securely push Docker images to a private repos
 
 ## Related Resources
 
-- [Docker Push: Denied Access](/posts/docker-push-denied-access) — fix push errors
-- [Docker Rename Image Repository](/posts/docker-rename-image-repository) — tag images correctly
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — optimize before pushing
-- [Introduction to Docker: Working with Images](/guides/introduction-to-docker) — image management
+- [Docker Push: Denied Access](/posts/docker-push-denied-access): fix push errors
+- [Docker Rename Image Repository](/posts/docker-rename-image-repository): tag images correctly
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): optimize before pushing
+- [Introduction to Docker: Working with Images](/guides/introduction-to-docker): image management

--- a/content/posts/python-open-does-not-create-file.md
+++ b/content/posts/python-open-does-not-create-file.md
@@ -235,7 +235,7 @@ The design is intentional:
 
 - Read mode (`'r'`) implies you expect the file to exist and want to read its content
 - If Python silently created an empty file, reading from it would always succeed but give you empty content
-- This would hide bugs where you mistyped a filename or the file genuinely doesn't exist
+- This would hide bugs where you mistyped a filename or the file doesn't exist
 - Failing fast with `FileNotFoundError` alerts you to the problem immediately
 
 Compare these scenarios:

--- a/content/posts/real-world-k8s.md
+++ b/content/posts/real-world-k8s.md
@@ -447,7 +447,7 @@ Moving to production Kubernetes is an ongoing process, not a destination. Even m
 
 Start with these production-focused practices:
 
-1. Implement comprehensive resource management
+1. Implement resource management
 2. Configure proper health probes
 3. Secure your cluster with network policies
 4. Plan your storage strategy carefully

--- a/content/posts/rebuild-docker-container-compose.md
+++ b/content/posts/rebuild-docker-container-compose.md
@@ -131,7 +131,7 @@ By following these steps, you can efficiently rebuild Docker containers in a `do
 
 ## Related Resources
 
-- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers) — force fresh containers
-- [Force Docker Clean Build](/posts/force-docker-clean-build) — no-cache builds
-- [Restart Single Container in Docker Compose](/posts/restart-single-container-docker-compose) — restart without rebuilding
-- [Introduction to Docker: Compose](/guides/introduction-to-docker) — Compose guide
+- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers): force fresh containers
+- [Force Docker Clean Build](/posts/force-docker-clean-build): no-cache builds
+- [Restart Single Container in Docker Compose](/posts/restart-single-container-docker-compose): restart without rebuilding
+- [Introduction to Docker: Compose](/guides/introduction-to-docker): Compose guide

--- a/content/posts/reference-resource-terraform-module.md
+++ b/content/posts/reference-resource-terraform-module.md
@@ -99,4 +99,4 @@ resource "aws_security_group_rule" "allow_ssh" {
 - **Document Outputs**: Provide clear documentation for module outputs.
 - **Validate Outputs**: Ensure outputs are correctly defined and used.
 
-By following these steps, you can effectively reference resources created by Terraform modules, enabling seamless integration and modular configurations.
+By following these steps, you can effectively reference resources created by Terraform modules, enabling clean integration and modular configurations.

--- a/content/posts/remove-old-docker-containers.md
+++ b/content/posts/remove-old-docker-containers.md
@@ -127,7 +127,7 @@ Make cleanup part of your local workflow, or script it as part of your CI/CD mai
 
 ## Related Resources
 
-- [Remove Old Unused Docker Images](/posts/remove-old-unused-docker-images) — image cleanup
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — bulk cleanup
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
-- [Docker List Containers](/posts/docker-list-containers) — find containers to remove
+- [Remove Old Unused Docker Images](/posts/remove-old-unused-docker-images): image cleanup
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): bulk cleanup
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space
+- [Docker List Containers](/posts/docker-list-containers): find containers to remove

--- a/content/posts/remove-old-unused-docker-images.md
+++ b/content/posts/remove-old-unused-docker-images.md
@@ -444,12 +444,12 @@ echo "---" >> $LOG_FILE
 
 Run this script daily to build a picture of your storage usage patterns and identify when cleanup is needed.
 
-Managing Docker image storage effectively requires a combination of understanding, systematic approaches, and automation. Start with safe cleanup methods like removing dangling images, then gradually move to more comprehensive strategies as you become comfortable with the impact. The key is developing a routine that keeps your storage usage reasonable without accidentally removing images you need for current or future projects.
+Managing Docker image storage effectively requires a combination of understanding, systematic approaches, and automation. Start with safe cleanup methods like removing dangling images, then gradually move to broader strategies as you become comfortable with the impact. The key is developing a routine that keeps your storage usage reasonable without accidentally removing images you need for current or future projects.
 
 
 ## Related Resources
 
-- [Delete All Local Docker Images](/posts/delete-all-local-docker-images) — nuclear cleanup option
-- [Remove Old Docker Containers](/posts/remove-old-docker-containers) — container cleanup
-- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup) — reclaim disk space
-- [Docker Image Optimization](/posts/docker-image-optimization-best-practices) — build smaller images
+- [Delete All Local Docker Images](/posts/delete-all-local-docker-images): nuclear cleanup option
+- [Remove Old Docker Containers](/posts/remove-old-docker-containers): container cleanup
+- [Docker No Space Left: How to Clean Up](/posts/docker-no-space-left-cleanup): reclaim disk space
+- [Docker Image Optimization](/posts/docker-image-optimization-best-practices): build smaller images

--- a/content/posts/restart-single-container-docker-compose.md
+++ b/content/posts/restart-single-container-docker-compose.md
@@ -92,7 +92,7 @@ By following these steps, you can efficiently restart individual containers in a
 
 ## Related Resources
 
-- [Docker Compose: Up Only Certain Containers](/posts/docker-compose-up-only-certain-containers) — selective startup
-- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose) — rebuild patterns
-- [Upgrade Docker Container After Image Changed](/posts/upgrade-docker-container-image-changed) — update images
-- [Introduction to Docker: Compose](/guides/introduction-to-docker) — Compose fundamentals
+- [Docker Compose: Up Only Certain Containers](/posts/docker-compose-up-only-certain-containers): selective startup
+- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose): rebuild patterns
+- [Upgrade Docker Container After Image Changed](/posts/upgrade-docker-container-image-changed): update images
+- [Introduction to Docker: Compose](/guides/introduction-to-docker): Compose fundamentals

--- a/content/posts/right-sizing-kubernetes-resources-vpa-karpenter.md
+++ b/content/posts/right-sizing-kubernetes-resources-vpa-karpenter.md
@@ -24,7 +24,7 @@ Setting CPU and memory requests too high in Kubernetes wastes money and reduces 
 
 When you set resource requests too conservatively in Kubernetes, your cluster reserves more capacity than workloads actually need. This leads to underutilized nodes and higher cloud bills. The problem gets worse at scale - imagine 200 pods each requesting 2 CPU cores but only using 200m. That's 400 reserved cores when actual demand is closer to 40 cores.
 
-The solution involves right-sizing both your pods and nodes. You'll use monitoring data to understand actual usage, apply VPA to adjust pod requests automatically, and leverage Karpenter to provision nodes that match your workload requirements.
+The solution involves right-sizing both your pods and nodes. You'll use monitoring data to understand actual usage, apply VPA to adjust pod requests automatically, and use Karpenter to provision nodes that match your workload requirements.
 
 ## Prerequisites
 

--- a/content/posts/secrets-management-guide.md
+++ b/content/posts/secrets-management-guide.md
@@ -36,7 +36,7 @@ Consider these common anti-patterns that show up in almost every organization:
 
 Each one of these creates real risk. The Uber breach in 2016 started with AWS credentials in a GitHub repo and led to 57 million user records exposed. CircleCI's 2023 compromise affected thousands of customers through leaked secrets.
 
-A dedicated secrets manager solves all of these problems with centralized encrypted storage, per-environment credentials, dynamic secrets with short TTLs, comprehensive audit logging, and just-in-time retrieval.
+A dedicated secrets manager solves all of these problems with centralized encrypted storage, per-environment credentials, dynamic secrets with short TTLs, full audit logging, and just-in-time retrieval.
 
 ## Core Principles
 

--- a/content/posts/service-located-in-another-namespace.md
+++ b/content/posts/service-located-in-another-namespace.md
@@ -80,4 +80,4 @@ To enable communication between namespaces, ensure:
 
 ## Conclusion
 
-Accessing Services in another namespace is straightforward with the right commands and configurations. By following these steps, you can ensure seamless communication across namespaces.
+Accessing Services in another namespace is straightforward with the right commands and configurations. By following these steps, you can ensure reliable communication across namespaces.

--- a/content/posts/set-git-editor-commit-messages.md
+++ b/content/posts/set-git-editor-commit-messages.md
@@ -21,7 +21,7 @@ tags:
 
 Git opens a text editor when you run `git commit` without the `-m` flag or when you need to edit messages during rebase or merge. By default, Git uses whatever editor is configured in your shell, which might not be the one you prefer.
 
-**TLDR:** To set your Git editor, use `git config --global core.editor "editor-command"`. For VS Code: `git config --global core.editor "code --wait"`. For Nano: `git config --global core.editor "nano"`. For Vim: `git config --global core.editor "vim"`. The `--wait` flag is crucial for GUI editors to make Git wait for you to close the file.
+**TLDR:** To set your Git editor, use `git config --global core.editor "editor-command"`. For VS Code: `git config --global core.editor "code --wait"`. For Nano: `git config --global core.editor "nano"`. For Vim: `git config --global core.editor "vim"`. The `--wait` flag is required for GUI editors to make Git wait for you to close the file.
 
 In this guide, you'll learn how to configure Git to use any editor for commit messages.
 

--- a/content/posts/set-image-name-dockerfile.md
+++ b/content/posts/set-image-name-dockerfile.md
@@ -93,7 +93,7 @@ By following these steps, you can effectively set and manage image names in Dock
 
 ## Related Resources
 
-- [Docker Rename Image Repository](/posts/docker-rename-image-repository) — rename existing images
-- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo) — push named images
-- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile) — Dockerfile instructions
-- [Introduction to Docker: Building Images](/guides/introduction-to-docker) — Dockerfile guide
+- [Docker Rename Image Repository](/posts/docker-rename-image-repository): rename existing images
+- [Push Docker Image to Private Repo](/posts/push-docker-image-private-repo): push named images
+- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile): Dockerfile instructions
+- [Introduction to Docker: Building Images](/guides/introduction-to-docker): Dockerfile guide

--- a/content/posts/set-variable-command-output-bash.md
+++ b/content/posts/set-variable-command-output-bash.md
@@ -361,4 +361,4 @@ check_connectivity
 7. **Validate command existence** before using external tools
 8. **Use timeouts** for potentially long-running commands
 
-Command substitution is a powerful feature that enables sophisticated data processing in Bash scripts. By following these patterns and best practices, you can create robust scripts that effectively capture and process command output while handling errors gracefully.
+Command substitution is a powerful feature that enables sophisticated data processing in Bash scripts. By following these patterns and best practices, you can create reliable scripts that effectively capture and process command output while handling errors gracefully.

--- a/content/posts/should-terraform-lock-be-in-your-gitignore.md
+++ b/content/posts/should-terraform-lock-be-in-your-gitignore.md
@@ -147,7 +147,7 @@ $ terraform init  # Uses locked versions
 $ terraform apply # Deploys with consistent provider behavior
 ```
 
-This reproducibility is crucial for:
+This reproducibility matters for:
 
 - Disaster recovery scenarios
 - Debugging production issues in development
@@ -290,6 +290,6 @@ A fintech company we worked with learned this lesson the hard way. They initiall
 
 After implementing proper lock file management, they eliminated environment drift and could confidently deploy knowing their infrastructure would behave consistently across all environments.
 
-The `.terraform.lock.hcl` file isn't just another file to manage, it's a crucial component of reproducible infrastructure. By committing it to version control, you ensure that your team can collaborate effectively and your infrastructure behaves predictably across all environments.
+The `.terraform.lock.hcl` file isn't just another file to manage, it's a key component of reproducible infrastructure. By committing it to version control, you ensure that your team can collaborate effectively and your infrastructure behaves predictably across all environments.
 
 Remember: infrastructure as code means your infrastructure should be as predictable and reproducible as your application code. The lock file is essential for achieving this goal.

--- a/content/posts/simulating-slow-internet-connection.md
+++ b/content/posts/simulating-slow-internet-connection.md
@@ -269,7 +269,7 @@ Clumsy is great for testing but can be unstable with some applications.
 
 ### NetLimiter (Paid)
 
-NetLimiter is more robust but costs money:
+NetLimiter is more capable but costs money:
 
 1. Download from [netlimiter.com](https://www.netlimiter.com/)
 2. Install and launch

--- a/content/posts/slos-slis-error-budgets-practical-guide.md
+++ b/content/posts/slos-slis-error-budgets-practical-guide.md
@@ -267,7 +267,7 @@ groups:
           description: "Budget will be exhausted before the window resets if this continues."
 ```
 
-The two-window approach (short and long) prevents alert fatigue. A brief spike triggers the short window but not the long one, so you do not get paged for a 30-second blip. A sustained problem triggers both, which means something is genuinely wrong.
+The two-window approach (short and long) prevents alert fatigue. A brief spike triggers the short window but not the long one, so you do not get paged for a 30-second blip. A sustained problem triggers both, which means something is actually wrong.
 
 ## What to Do When the Budget Runs Out
 

--- a/content/posts/so-reuseaddr-vs-so-reuseport.md
+++ b/content/posts/so-reuseaddr-vs-so-reuseport.md
@@ -25,7 +25,7 @@ You're writing a server application and you keep seeing `SO_REUSEADDR` and `SO_R
 
 `SO_REUSEADDR` allows binding to a port that's in TIME_WAIT state after a previous connection closed, and lets multiple sockets bind to the same port if they're on different IP addresses. `SO_REUSEPORT` allows multiple processes to bind to the exact same IP:port combination, with the kernel load-balancing connections between them. Use `SO_REUSEADDR` for quick server restarts and binding to multiple interfaces. Use `SO_REUSEPORT` for multi-process servers that want to share a port.
 
-These socket options solve different problems in network programming, and understanding them helps you build more robust and efficient servers.
+These socket options solve different problems in network programming, and understanding them helps you build more reliable and efficient servers.
 
 When you bind a socket to a port, the operating system tracks which ports are in use. These socket options modify the rules about port reuse.
 

--- a/content/posts/split-string-delimiter-bash.md
+++ b/content/posts/split-string-delimiter-bash.md
@@ -95,7 +95,7 @@ This method uses:
 
 ## Creating a Reusable Split Function
 
-Here's a robust function that handles various edge cases:
+Here's a reusable function that handles various edge cases:
 
 ```bash
 split_string() {
@@ -355,4 +355,4 @@ process_large_file() {
 5. **Choose the right method** based on your data complexity
 6. **Test with edge cases** like empty fields, special characters, and whitespace
 
-String splitting is essential for data processing in Bash. Whether you're parsing simple comma-separated values or complex structured data, these techniques provide the foundation for robust string manipulation in your scripts. Choose the method that best fits your specific use case and data format.
+String splitting is essential for data processing in Bash. Whether you're parsing simple comma-separated values or complex structured data, these techniques provide the foundation for reliable string manipulation in your scripts. Choose the method that best fits your specific use case and data format.

--- a/content/posts/start-stopped-docker-container-different-command.md
+++ b/content/posts/start-stopped-docker-container-different-command.md
@@ -24,7 +24,7 @@ You can't directly change the command of a stopped Docker container when restart
 
 ## Why Can't You Change the Command with docker start?
 
-When you create a container with `docker run`, the command and entrypoint are set at creation. `docker start` always uses the original command—you can't override it for an existing container.
+When you create a container with `docker run`, the command and entrypoint are set at creation. `docker start` always uses the original command, so you can't override it for an existing container.
 
 ## Option 1: Create a New Container with a Different Command
 
@@ -80,7 +80,7 @@ You can't change the command of a stopped Docker container when restarting it, b
 
 ## Related Resources
 
-- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start) — understand the difference
-- [How to Run a Command on an Existing Container](/posts/how-do-i-run-a-command-on-an-already-existing-docker-container) — exec into containers
-- [Why Docker Container Exits Immediately](/posts/why-docker-container-exits-immediately) — debug exit issues
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start): understand the difference
+- [How to Run a Command on an Existing Container](/posts/how-do-i-run-a-command-on-an-already-existing-docker-container): exec into containers
+- [Why Docker Container Exits Immediately](/posts/why-docker-container-exits-immediately): debug exit issues
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/switch-namespace-in-kubernetes.md
+++ b/content/posts/switch-namespace-in-kubernetes.md
@@ -86,7 +86,7 @@ Now, all `kubectl` commands will use `example-namespace` as the default namespac
 
 ## Example Scenario
 
-Imagine you are managing a Kubernetes cluster with multiple namespaces for different teams. By setting a default namespace, you can streamline your workflow and avoid repetitive commands.
+Imagine you are managing a Kubernetes cluster with multiple namespaces for different teams. By setting a default namespace, you can simplify your workflow and avoid repetitive commands.
 
 ## Conclusion
 

--- a/content/posts/terraform-api-gateway-stage-not-deploying.md
+++ b/content/posts/terraform-api-gateway-stage-not-deploying.md
@@ -156,7 +156,7 @@ However, this doesn't automatically trigger redeployment when you change integra
 
 ## Creating Triggers From Multiple Resources
 
-For complex APIs, create a comprehensive trigger hash:
+For complex APIs, create a trigger hash that covers every resource:
 
 ```hcl
 locals {

--- a/content/posts/terraform-conditionals-if-variable-does-not-exist.md
+++ b/content/posts/terraform-conditionals-if-variable-does-not-exist.md
@@ -74,4 +74,4 @@ In this example, if `var.optional_var` is not defined, the output will use `defa
 - **Validate Inputs**: Use `validation` blocks to enforce constraints on variable values.
 - **Document Variables**: Clearly document which variables are optional and their default values.
 
-By using these techniques, you can handle non-existent variables in Terraform gracefully, making your configurations more robust and flexible.
+By using these techniques, you can handle non-existent variables in Terraform gracefully, making your configurations more resilient and flexible.

--- a/content/posts/terraform-modules-git-branch.md
+++ b/content/posts/terraform-modules-git-branch.md
@@ -77,4 +77,4 @@ Ensure your SSH key is configured for authentication.
 - **Document Module Inputs**: Clearly document the inputs and outputs of your module.
 - **Test Changes**: Validate module changes in a non-production environment before merging them into the main branch.
 
-By using a Git branch as a source for Terraform modules, you can streamline development workflows and manage module versions effectively.
+By using a Git branch as a source for Terraform modules, you can speed up development workflows and manage module versions effectively.

--- a/content/posts/terraform-on-premises-servers.md
+++ b/content/posts/terraform-on-premises-servers.md
@@ -24,7 +24,7 @@ Yes, Terraform can provision on-premises servers by integrating with providers l
 
 ---
 
-Terraform is widely known for managing cloud infrastructure, but it can also be used to provision on-premises servers. By leveraging Terraform providers and integrations, you can manage on-premises resources with the same declarative approach as cloud infrastructure.
+Terraform is widely known for managing cloud infrastructure, but it can also be used to provision on-premises servers. By using Terraform providers and integrations, you can manage on-premises resources with the same declarative approach as cloud infrastructure.
 
 ### Why Use Terraform for On-Premises Servers?
 

--- a/content/posts/terraform-read-environment-variables-from-env-file.md
+++ b/content/posts/terraform-read-environment-variables-from-env-file.md
@@ -137,7 +137,7 @@ chmod +x tf-wrapper.sh
 ./tf-wrapper.sh apply
 ```
 
-For a more robust version that handles comments and validation:
+For a more thorough version that handles comments and validation:
 
 ```bash
 #!/bin/bash
@@ -236,7 +236,7 @@ This approach has limitations:
 - Can't handle multi-line values
 - Doesn't expand variable references
 
-For more robust parsing:
+For more thorough parsing:
 
 ```hcl
 locals {

--- a/content/posts/terraform-refresh-explained.md
+++ b/content/posts/terraform-refresh-explained.md
@@ -128,4 +128,4 @@ terraform plan -refresh-only
 - **Automate State Management**: Integrate state refresh into CI/CD pipelines.
 - **Backup State Files**: Always back up state files before making changes.
 
-By understanding and using the `terraform refresh` command effectively, you can maintain accurate state files and streamline your Terraform workflows.
+By understanding and using the `terraform refresh` command effectively, you can maintain accurate state files and simplify your Terraform workflows.

--- a/content/posts/terraform-variables-not-allowed-error-plan.md
+++ b/content/posts/terraform-variables-not-allowed-error-plan.md
@@ -21,7 +21,7 @@ tags:
 
 When you run `terraform plan`, you might encounter an error saying "Variables not allowed" in certain contexts like backend configuration, provider configuration, or terraform blocks. This happens because Terraform evaluates some parts of your configuration before it processes variables, making them unavailable in these early-evaluation contexts.
 
-Understanding where variables can and cannot be used is crucial for structuring your Terraform configurations correctly.
+Understanding where variables can and cannot be used is important for structuring your Terraform configurations correctly.
 
 **TLDR:** Variables cannot be used in backend configuration blocks, terraform blocks, or provider aliases because these are evaluated before Terraform loads variables. Use hard-coded values, environment variables, `-backend-config` flags, or partial configuration files instead. For dynamic provider configuration, use locals or separate configuration files per environment. The error occurs because Terraform needs to know backend and provider details before it can process variables.
 

--- a/content/posts/upgrade-docker-container-image-changed.md
+++ b/content/posts/upgrade-docker-container-image-changed.md
@@ -21,7 +21,7 @@ tags:
 
 ## TLDR
 
-To upgrade a Docker container after its image has changed, pull the updated image, stop the running container, and recreate it using the new image. Use `docker-compose` or orchestration tools like Kubernetes for seamless upgrades.
+To upgrade a Docker container after its image has changed, pull the updated image, stop the running container, and recreate it using the new image. Use `docker-compose` or orchestration tools like Kubernetes for smooth upgrades.
 
 ---
 
@@ -149,7 +149,7 @@ By following these steps, you can efficiently upgrade Docker containers to use n
 
 ## Related Resources
 
-- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers) — force updates
-- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose) — Compose rebuild
-- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits) — preserve data during upgrades
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Docker Compose: Always Recreate Containers](/posts/docker-compose-always-recreate-containers): force updates
+- [Rebuild Docker Container in Compose](/posts/rebuild-docker-container-compose): Compose rebuild
+- [Docker Data Loss When Container Exits](/posts/docker-data-loss-when-container-exits): preserve data during upgrades
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/use-aws-account-id-variable.md
+++ b/content/posts/use-aws-account-id-variable.md
@@ -20,7 +20,7 @@ tags:
 
 ## TLDR
 
-To use the AWS `account_id` variable in Terraform, leverage the `aws_caller_identity` data source. This allows you to dynamically retrieve the account ID for use in your configurations.
+To use the AWS `account_id` variable in Terraform, use the `aws_caller_identity` data source. This allows you to dynamically retrieve the account ID for use in your configurations.
 
 ---
 

--- a/content/posts/use-local-docker-images-minikube.md
+++ b/content/posts/use-local-docker-images-minikube.md
@@ -112,7 +112,7 @@ The `imagePullPolicy: Never` setting ensures Kubernetes uses the local image and
 
 ## Alternative Pull Policies
 
-Understanding image pull policies is crucial for working with local images:
+Understanding image pull policies is important for working with local images:
 
 ```yaml
 # Never pull, use local image only
@@ -129,7 +129,7 @@ For development with local images, use `Never` or `IfNotPresent` to avoid unnece
 
 ## Automating the Workflow
 
-Create a script to streamline the build and deployment process:
+Create a script to simplify the build and deployment process:
 
 ```bash
 #!/bin/bash
@@ -316,7 +316,7 @@ Now that you can use local Docker images with Minikube, consider learning about:
 
 ## Related Resources
 
-- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences) — choosing orchestration
-- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes) — learn K8s from scratch
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
-- [DevOps Roadmap](/roadmap) — the full DevOps learning path
+- [Docker Compose vs Kubernetes](/posts/docker-compose-vs-kubernetes-differences): choosing orchestration
+- [Introduction to Kubernetes Guide](/guides/introduction-to-kubernetes): learn K8s from scratch
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals
+- [DevOps Roadmap](/roadmap): the full DevOps learning path

--- a/content/posts/using-ssh-keys-in-docker-container.md
+++ b/content/posts/using-ssh-keys-in-docker-container.md
@@ -119,7 +119,7 @@ Using SSH keys in Docker containers is safe and flexible when you mount them at 
 
 ## Related Resources
 
-- [Docker Security Best Practices](/posts/docker-security-best-practices) — keep secrets out of images
-- [Advanced Docker Features](/posts/advanced-docker-features) — BuildKit secrets
-- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables) — pass config securely
-- [Docker Security Checklist](/checklists/docker-security) — verify your setup
+- [Docker Security Best Practices](/posts/docker-security-best-practices): keep secrets out of images
+- [Advanced Docker Features](/posts/advanced-docker-features): BuildKit secrets
+- [Docker Compose Environment Variables](/posts/docker-compose-environment-variables): pass config securely
+- [Docker Security Checklist](/checklists/docker-security): verify your setup

--- a/content/posts/vagrant-vs-docker-for-isolated-environments.md
+++ b/content/posts/vagrant-vs-docker-for-isolated-environments.md
@@ -120,7 +120,7 @@ Pick the tool that matches the problem you're solving, or use both when it makes
 
 ## Related Resources
 
-- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine) — deeper VM comparison
-- [Docker Runtime Performance Cost](/posts/docker-runtime-performance-cost) — performance analysis
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — learn Docker
-- [DevOps Roadmap](/roadmap) — the full learning path
+- [How Docker Differs from a Virtual Machine](/posts/how-docker-differs-from-a-virtual-machine): deeper VM comparison
+- [Docker Runtime Performance Cost](/posts/docker-runtime-performance-cost): performance analysis
+- [Introduction to Docker Guide](/guides/introduction-to-docker): learn Docker
+- [DevOps Roadmap](/roadmap): the full learning path

--- a/content/posts/variables-may-not-be-used-here-terraform-init.md
+++ b/content/posts/variables-may-not-be-used-here-terraform-init.md
@@ -131,4 +131,4 @@ provider "aws" {
 - **Document Workarounds**: Clearly document any workarounds for unsupported contexts.
 - **Test Configurations**: Test your configurations in a staging environment before applying them in production.
 
-By understanding the limitations of variables in Terraform and using the solutions provided, you can resolve the "Variables may not be used here" error and streamline your Terraform workflows.
+By understanding the limitations of variables in Terraform and using the solutions provided, you can resolve the "Variables may not be used here" error and simplify your Terraform workflows.

--- a/content/posts/what-does-2-and-1-mean-linux-bash.md
+++ b/content/posts/what-does-2-and-1-mean-linux-bash.md
@@ -48,7 +48,7 @@ The `2>&1` syntax is a redirection operator that means "redirect file descriptor
 - `>` is the redirection operator
 - `&1` refers to stdout (standard output)
 
-The `&` before the `1` is crucial - it tells the shell that `1` refers to a file descriptor, not a file named "1".
+The `&` before the `1` is important - it tells the shell that `1` refers to a file descriptor, not a file named "1".
 
 ## Basic Examples
 

--- a/content/posts/what-does-set-e-mean-in-bash-script.md
+++ b/content/posts/what-does-set-e-mean-in-bash-script.md
@@ -140,7 +140,7 @@ cat /nonexistent-file | grep "pattern"
 
 ## Combining set -e with set -u and set -o pipefail
 
-Many scripts use a combination of these options for robust error handling:
+Many scripts use a combination of these options for reliable error handling:
 
 ```bash
 #!/bin/bash

--- a/content/posts/what-does-set-e-mean-in-bash.md
+++ b/content/posts/what-does-set-e-mean-in-bash.md
@@ -110,4 +110,4 @@ set -e
 
 ## Conclusion
 
-Using `set -e` in your Bash scripts is a simple way to make them more robust and catch errors early. Just be aware of its limitations and test your scripts to avoid surprises. For even safer scripts, combine it with `set -o pipefail` and handle expected errors explicitly.
+Using `set -e` in your Bash scripts is a simple way to make them more reliable and catch errors early. Just be aware of its limitations and test your scripts to avoid surprises. For even safer scripts, combine it with `set -o pipefail` and handle expected errors explicitly.

--- a/content/posts/what-is-devops.md
+++ b/content/posts/what-is-devops.md
@@ -245,7 +245,7 @@ While "DevOps Engineer" is a real job, DevOps itself is a culture and way of wor
 
 ### "DevOps means no operations team"
 
-Wrong! Operations expertise is still crucial. DevOps just means operations and development work together rather than separately.
+Wrong! Operations expertise still matters. DevOps just means operations and development work together rather than separately.
 
 ### "DevOps is only about tools"
 

--- a/content/posts/why-docker-container-exits-immediately.md
+++ b/content/posts/why-docker-container-exits-immediately.md
@@ -521,8 +521,8 @@ The key to preventing containers from exiting immediately is making sure the mai
 
 ## Related Resources
 
-- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile) — understand CMD behavior
-- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start) — container lifecycle
-- [Start Stopped Container with Different Command](/posts/start-stopped-docker-container-different-command) — override commands
-- [How to Clear Docker Container Logs](/posts/how-to-clear-docker-container-logs-properly) — check logs for clues
-- [Introduction to Docker Guide](/guides/introduction-to-docker) — Docker fundamentals
+- [Difference Between RUN and CMD](/posts/difference-run-cmd-dockerfile): understand CMD behavior
+- [Docker Run vs Docker Start](/posts/docker-run-vs-docker-start): container lifecycle
+- [Start Stopped Container with Different Command](/posts/start-stopped-docker-container-different-command): override commands
+- [How to Clear Docker Container Logs](/posts/how-to-clear-docker-container-logs-properly): check logs for clues
+- [Introduction to Docker Guide](/guides/introduction-to-docker): Docker fundamentals

--- a/content/posts/write-simple-kubernetes-operator.md
+++ b/content/posts/write-simple-kubernetes-operator.md
@@ -1,6 +1,6 @@
 ---
 title: 'Understanding Kubernetes Operators: A Deep Dive with a Practical Example'
-excerpt: 'Learn the concepts behind Kubernetes operators, why they exist, and how the control loop pattern works—then build one yourself to solidify your understanding.'
+excerpt: 'Learn the concepts behind Kubernetes operators, why they exist, and how the control loop pattern works, then build one yourself to solidify your understanding.'
 category:
   name: 'Kubernetes'
   slug: 'kubernetes'
@@ -18,7 +18,7 @@ tags:
   - DevOps
 ---
 
-If you've worked with Kubernetes for any length of time, you've probably heard the term "operator" thrown around. Maybe you've installed one—like the Prometheus Operator or cert-manager—without fully understanding what makes it different from a regular Deployment. This post aims to change that.
+If you've worked with Kubernetes for any length of time, you've probably heard the term "operator" thrown around. Maybe you've installed one (like the Prometheus Operator or cert-manager) without fully understanding what makes it different from a regular Deployment. This post aims to change that.
 
 We'll start by understanding *why* operators exist and the fundamental patterns they implement. Then we'll build one from scratch, explaining each concept as we go. By the end, you'll not only have a working operator but a mental model for how all Kubernetes controllers work under the hood.
 
@@ -28,12 +28,12 @@ Before diving into operators, let's step back and understand how Kubernetes itse
 
 ### The Declarative Model: Kubernetes' Core Philosophy
 
-Kubernetes is built on a **declarative model**. You don't tell Kubernetes "start 3 pods"—you tell it "I want 3 pods running." The difference is subtle but profound:
+Kubernetes is built on a **declarative model**. You don't tell Kubernetes "start 3 pods"; you tell it "I want 3 pods running." The difference is subtle but profound:
 
 - **Imperative**: "Do this action" (create, delete, scale)
 - **Declarative**: "Make it look like this" (desired state)
 
-When you apply a Deployment manifest, you're declaring your desired state. Kubernetes then figures out what actions are needed to make reality match that declaration. If a pod crashes, Kubernetes doesn't need you to tell it to restart—it sees the discrepancy and acts.
+When you apply a Deployment manifest, you're declaring your desired state. Kubernetes then figures out what actions are needed to make reality match that declaration. If a pod crashes, Kubernetes doesn't need you to tell it to restart; it sees the discrepancy and acts.
 
 This is powerful because it makes your infrastructure **self-healing**. You describe what you want, and Kubernetes continuously works to maintain that state.
 
@@ -65,13 +65,13 @@ This "observe and act" behavior is implemented through **control loops** (also c
 
 The Deployment controller, for example, watches Deployment resources. When you create one asking for 3 replicas, it observes there are 0 pods, calculates a diff of -3, and creates 3 ReplicaSets (which in turn create pods).
 
-**Why is this pattern so important?** Because it's **convergent**. No matter how the system gets into a bad state—whether from a crash, network partition, or manual tampering—the controller will keep trying to fix it. This is fundamentally different from scripts that run once and hope nothing changes.
+**Why is this pattern so important?** Because it's **convergent**. No matter how the system gets into a bad state (whether from a crash, network partition, or manual tampering), the controller will keep trying to fix it. This is different from scripts that run once and hope nothing changes.
 
 ### So What Makes an Operator Special?
 
 An **operator** is simply a custom controller that manages **custom resources**. That's it.
 
-The built-in controllers (Deployment, Service, etc.) manage built-in resources. When you need to manage something Kubernetes doesn't understand natively—like a PostgreSQL cluster, a machine learning pipeline, or a complex application—you create:
+The built-in controllers (Deployment, Service, etc.) manage built-in resources. When you need to manage something Kubernetes doesn't understand natively (like a PostgreSQL cluster, a machine learning pipeline, or a complex application), you create:
 
 1. A **Custom Resource Definition (CRD)**: Teaches Kubernetes about your new resource type
 2. A **Controller**: Watches for those resources and takes action
@@ -86,8 +86,8 @@ The key difference is **continuous reconciliation**:
 
 | Approach | When It Runs | What Happens If State Drifts |
 |----------|--------------|------------------------------|
-| Shell script | Once, when you run it | Nothing—drift accumulates |
-| Helm install | Once, at install time | Nothing—you must re-run |
+| Shell script | Once, when you run it | Nothing, drift accumulates |
+| Helm install | Once, at install time | Nothing, you must re-run |
 | Operator | Continuously | Automatically corrects drift |
 
 An operator is always watching and always correcting. If someone manually deletes a resource your application needs, the operator recreates it. If a config drifts, the operator fixes it. This is called **level-triggered** behavior (reacting to state) vs **edge-triggered** (reacting to events).
@@ -98,11 +98,11 @@ An operator is always watching and always correcting. If someone manually delete
 
 To make this concrete, here's what some popular operators do:
 
-- **Prometheus Operator**: You create a `Prometheus` CR specifying retention, replicas, and alerting rules. The operator creates the StatefulSet, ConfigMaps, Services, and wires up service discovery—tasks that would otherwise require deep Prometheus expertise.
+- **Prometheus Operator**: You create a `Prometheus` CR specifying retention, replicas, and alerting rules. The operator creates the StatefulSet, ConfigMaps, Services, and wires up service discovery, tasks that would otherwise require deep Prometheus expertise.
 
-- **cert-manager**: You create a `Certificate` CR specifying the domain. The operator handles ACME challenges, creates secrets with the cert, and renews before expiration—no cron jobs needed.
+- **cert-manager**: You create a `Certificate` CR specifying the domain. The operator handles ACME challenges, creates secrets with the cert, and renews before expiration, with no cron jobs needed.
 
-- **PostgreSQL Operator (Zalando)**: You create a `postgresql` CR. The operator provisions the primary, replicas, handles failover, backups, and connection pooling—encoding years of DBA knowledge.
+- **PostgreSQL Operator (Zalando)**: You create a `postgresql` CR. The operator provisions the primary, replicas, handles failover, backups, and connection pooling, encoding years of DBA knowledge.
 
 In each case, you declare *what* you want, and the operator handles *how* to achieve and maintain it.
 
@@ -142,7 +142,7 @@ kubebuilder version
 
 ## Project Overview: Building a Website Operator
 
-We'll build a "Website" operator—simple enough to understand fully, but complex enough to demonstrate real patterns.
+We'll build a "Website" operator: simple enough to understand fully, but complex enough to demonstrate real patterns.
 
 ### The User Experience We're Creating
 
@@ -200,7 +200,7 @@ website-operator/
 
 ### The Manager: Your Operator's Brain
 
-The `cmd/main.go` file sets up what Kubebuilder calls a "Manager." This is crucial to understand:
+The `cmd/main.go` file sets up what Kubebuilder calls a "Manager." This is important to understand:
 
 ```go
 // Simplified version of what's in cmd/main.go
@@ -219,7 +219,7 @@ The Manager:
 - **Exposes Prometheus metrics** at `/metrics`
 - **Manages graceful shutdown** when receiving SIGTERM
 
-You rarely need to modify this file—Kubebuilder sets it up correctly.
+You rarely need to modify this file; Kubebuilder sets it up correctly.
 
 ## Step 2: Create the API and Controller
 
@@ -236,7 +236,7 @@ Answer `y` to both prompts (create resource and controller).
 Kubernetes API resources follow a strict naming convention:
 
 - **Group**: Like a package name, groups related resources (e.g., `apps`, `networking.k8s.io`). Ours is `webapp`.
-- **Version**: API version (`v1`, `v1beta1`, `v1alpha1`)—allows your API to evolve over time
+- **Version**: API version (`v1`, `v1beta1`, `v1alpha1`), allows your API to evolve over time
 - **Kind**: The resource type name (capitalized, singular)
 
 The full API group becomes `webapp.example.com` (group + domain from init).
@@ -348,7 +348,7 @@ func init() {
 
 ### Understanding the Marker Comments
 
-Those `// +kubebuilder:` comments aren't just documentation—they're **markers** that Kubebuilder's code generator reads:
+Those `// +kubebuilder:` comments aren't just documentation; they're **markers** that Kubebuilder's code generator reads:
 
 | Marker | What It Does |
 |--------|-------------|
@@ -389,7 +389,7 @@ This function gets called whenever:
 - A periodic resync happens (configurable, default 10 hours)
 - You explicitly request a requeue
 
-**Important**: The function receives a `Request` containing just the namespace/name of the resource. You must fetch the actual resource yourself. This is intentional—it prevents stale data issues.
+**Important**: The function receives a `Request` containing just the namespace/name of the resource. You must fetch the actual resource yourself. This is intentional, and it prevents stale data issues.
 
 ### The Reconciliation Pattern
 
@@ -727,7 +727,7 @@ This sets an **OwnerReference** on the child resource pointing to the Website. W
 2. Changes to owned resources trigger reconciliation of the owner
 3. `kubectl get configmap my-site -o yaml` shows the owner
 
-**This is why we don't need cleanup code**—Kubernetes handles it automatically.
+**This is why we don't need cleanup code**: Kubernetes handles it automatically.
 
 ### Setting Up the Controller Watches
 
@@ -949,7 +949,7 @@ make test
 
 Owner references handle Kubernetes resources, but what about external resources (cloud infrastructure, DNS records, external databases)?
 
-Use **finalizers**—they block deletion until you've cleaned up:
+Use **finalizers**: they block deletion until you've cleaned up:
 
 ```go
 import "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"


### PR DESCRIPTION
Removes 484 em dashes and 164 filler words (comprehensive, crucial, robust, leverage, streamline, seamless, etc) across 187 posts.

- Prose only — em dashes inside code blocks are left intact (3 remain, all in code comments)
- Each change is a 1:1 line edit (638 lines, no structural changes)
- Found by grepping all 466 posts, then adjudicating every hit in context so code blocks and legit Kubernetes "orchestration" weren't touched