### PR TITLE
fix: resolve Docker pnpm corepack signature verification issue for M1/Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for optimized development and production images
 
 ARG NODE_VERSION=22.13.1
-ARG PNPM_VERSION=10.28.1
+ARG PNPM_VERSION=9.12.3
 
 # ===========================================================================
 # Stage 1: Base image with common dependencies
@@ -17,8 +17,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN corepack enable && \
-    corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN npm install -g pnpm@${PNPM_VERSION}
 
 WORKDIR /app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       target: development
       args:
         NODE_VERSION: 22.13.1
-        PNPM_VERSION: 10.28.1
+        PNPM_VERSION: 9.12.3
     container_name: devops-daily-dev
     image: devops-daily:dev
     ports:
@@ -72,7 +72,7 @@ services:
       target: production
       args:
         NODE_VERSION: 22.13.1
-        PNPM_VERSION: 10.28.1
+        PNPM_VERSION: 9.12.3
     container_name: devops-daily-prod
     image: devops-daily:prod
     ports:


### PR DESCRIPTION
## Problem
Docker build fails on M1/Linux with pnpm 10.28.1 corepack signature error:
`Internal Error: Cannot find matching keyid`

## Root Cause
pnpm@10.28.1 has signature verification issues with corepack

## Solution
- Downgrade pnpm from 10.28.1 to 9.12.3 (stable version)
- Replace corepack prepare with npm install -g
- Updated both Dockerfile and docker-compose.yaml

## Files Changed
- Dockerfile
- docker-compose.yaml

## Testing
- Docker build successful on M1 Mac ✅
- Development server running correctly ✅
- Hot-reload working ✅