### PR TITLE
Link interactive simulators from the roadmaps

### DIFF
--- a/app/roadmap/devsecops/page.tsx
+++ b/app/roadmap/devsecops/page.tsx
@@ -53,6 +53,7 @@ interface DevSecOpsSkill {
   name: string;
   description: string;
   link?: string;
+  simulators?: { name: string; link: string }[];
   external?: boolean;
   icon: LucideIcon;
   priority: 'essential' | 'important' | 'nice-to-have';
@@ -117,6 +118,7 @@ const milestones: DevSecOpsMilestone[] = [
         name: 'Linux Security Basics',
         description: 'File permissions, user management, SSH hardening, and firewall basics',
         link: '/checklists/ssh-hardening',
+        simulators: [{ name: 'Linux Terminal', link: '/games/linux-terminal' }],
         icon: Terminal,
         priority: 'essential',
         estimatedHours: 20,
@@ -312,6 +314,10 @@ const milestones: DevSecOpsMilestone[] = [
         name: 'Kubernetes Security',
         description: 'RBAC, Network Policies, Pod Security Standards, and admission controllers',
         link: '/checklists/kubernetes-security',
+        simulators: [
+          { name: 'Kubernetes Terminal', link: '/games/kubernetes-terminal-simulator' },
+          { name: 'K8s Network Policies', link: '/games/kubernetes-networking-cni-simulator' },
+        ],
         icon: Server,
         priority: 'essential',
         estimatedHours: 30,
@@ -326,6 +332,7 @@ const milestones: DevSecOpsMilestone[] = [
       {
         name: 'Service Mesh Security',
         description: 'mTLS, authorization policies, and traffic encryption with Istio or Linkerd',
+        simulators: [{ name: 'Service Mesh', link: '/games/service-mesh-simulator' }],
         icon: Network,
         priority: 'nice-to-have',
         estimatedHours: 20,
@@ -362,6 +369,7 @@ const milestones: DevSecOpsMilestone[] = [
         name: 'IAM Best Practices',
         description: 'Least privilege, role-based access, and identity federation',
         link: '/checklists/aws-security',
+        simulators: [{ name: 'OAuth / OIDC Flow', link: '/games/oauth-oidc-flow-simulator' }],
         icon: Fingerprint,
         priority: 'essential',
         estimatedHours: 25,
@@ -390,6 +398,10 @@ const milestones: DevSecOpsMilestone[] = [
       {
         name: 'Network Security',
         description: 'VPCs, security groups, WAF, and DDoS protection',
+        simulators: [
+          { name: 'DDoS Defense', link: '/games/ddos-simulator' },
+          { name: 'Rate Limiting', link: '/games/rate-limit-simulator' },
+        ],
         icon: Globe,
         priority: 'important',
         estimatedHours: 20,
@@ -774,6 +786,17 @@ export default function DevSecOpsRoadmapPage() {
                                         )}
                                       </Link>
                                     )}
+                                    {skill.simulators?.map((sim) => (
+                                      <Link
+                                        key={sim.link}
+                                        href={sim.link}
+                                        className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2 ml-3"
+                                        onClick={(e) => e.stopPropagation()}
+                                      >
+                                        <Terminal className="h-3 w-3" />
+                                        Try: {sim.name}
+                                      </Link>
+                                    ))}
                                   </div>
                                 </div>
                               </div>

--- a/app/roadmap/junior/page.tsx
+++ b/app/roadmap/junior/page.tsx
@@ -41,6 +41,7 @@ interface JuniorSkill {
   name: string;
   description: string;
   link?: string;
+  simulators?: { name: string; link: string }[];
   external?: boolean;
   icon: LucideIcon;
   priority: 'essential' | 'important' | 'nice-to-have';
@@ -81,6 +82,7 @@ const milestones: JuniorMilestone[] = [
         name: 'Linux Basics',
         description: 'Learn essential Linux commands, file system navigation, and permissions',
         link: '/guides/introduction-to-linux',
+        simulators: [{ name: 'Linux Terminal', link: '/games/linux-terminal' }],
         icon: Terminal,
         priority: 'essential',
         estimatedHours: 20,
@@ -97,6 +99,7 @@ const milestones: JuniorMilestone[] = [
         name: 'Git Basics',
         description: 'Learn version control fundamentals - commit, push, pull, and branches',
         link: '/guides/introduction-to-git',
+        simulators: [{ name: 'Git Concepts', link: '/games/git-concepts-simulator' }],
         icon: GitBranch,
         priority: 'essential',
         estimatedHours: 10,
@@ -105,6 +108,7 @@ const milestones: JuniorMilestone[] = [
         name: 'Networking Fundamentals',
         description: 'Understand IP addresses, DNS, HTTP, and basic networking concepts',
         link: '/guides/networking-fundamentals',
+        simulators: [{ name: 'DNS Resolution', link: '/games/dns-simulator' }],
         icon: Globe,
         priority: 'important',
         estimatedHours: 12,
@@ -191,6 +195,7 @@ const milestones: JuniorMilestone[] = [
         name: 'Docker Fundamentals',
         description: 'Build, run, and manage containers with Docker',
         link: '/guides/introduction-to-docker',
+        simulators: [{ name: 'Docker Terminal', link: '/games/docker-terminal-simulator' }],
         icon: Container,
         priority: 'essential',
         estimatedHours: 20,
@@ -301,6 +306,7 @@ const milestones: JuniorMilestone[] = [
         name: 'AWS/Azure/GCP Core Services',
         description: 'Learn compute, storage, and networking basics on your chosen platform',
         link: '/guides/aws-for-beginners',
+        simulators: [{ name: 'AWS VPC', link: '/games/aws-vpc-simulator' }],
         icon: Server,
         priority: 'essential',
         estimatedHours: 25,
@@ -626,6 +632,17 @@ export default function JuniorDevOpsRoadmap() {
                                       {skill.external && <ExternalLink className="w-3 h-3" />}
                                     </Link>
                                   )}
+                                  {skill.simulators?.map((sim) => (
+                                    <Link
+                                      key={sim.link}
+                                      href={sim.link}
+                                      className="inline-flex items-center gap-1 mt-2 ml-3 text-xs text-primary hover:underline"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <Terminal className="w-3 h-3" />
+                                      Try: {sim.name}
+                                    </Link>
+                                  ))}
                                 </div>
                               </div>
                             </div>

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -172,6 +172,12 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
       type: 'practice',
       description: 'Test your Git knowledge with interactive scenarios',
     },
+    {
+      title: 'Git Concepts Simulator',
+      url: '/games/git-concepts-simulator',
+      type: 'practice',
+      description: 'Visualize commits, branches, and merges in an interactive simulator',
+    },
   ],
   'Docker Fundamentals': [
     {
@@ -207,6 +213,12 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
       external: true,
       description: 'Free Docker playground',
     },
+    {
+      title: 'Docker Terminal Simulator',
+      url: '/games/docker-terminal-simulator',
+      type: 'practice',
+      description: 'Practice Docker commands in a simulated terminal',
+    },
   ],
   'Kubernetes Basics': [
     {
@@ -228,6 +240,12 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
       type: 'practice',
       external: true,
       description: 'Free Kubernetes cluster for learning',
+    },
+    {
+      title: 'Kubernetes Terminal Simulator',
+      url: '/games/kubernetes-terminal-simulator',
+      type: 'practice',
+      description: 'Practice kubectl commands in a simulated cluster',
     },
   ],
   Terraform: [
@@ -307,6 +325,12 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
       external: true,
       description: 'Practice with AWS free tier',
     },
+    {
+      title: 'AWS VPC Simulator',
+      url: '/games/aws-vpc-simulator',
+      type: 'practice',
+      description: 'Build and explore a VPC network layout interactively',
+    },
   ],
   'Prometheus & Grafana': [
     {
@@ -322,6 +346,28 @@ const skillResourcesDatabase: Record<string, SkillResource[]> = {
       type: 'documentation',
       external: true,
       description: 'Grafana visualization platform docs',
+    },
+  ],
+  'Networking Fundamentals': [
+    {
+      title: 'DNS Resolution Simulator',
+      url: '/games/dns-simulator',
+      type: 'practice',
+      description: 'Walk through how a DNS query resolves, step by step',
+    },
+  ],
+  'Container Networking': [
+    {
+      title: 'Kubernetes Network Policies Simulator',
+      url: '/games/kubernetes-networking-cni-simulator',
+      type: 'practice',
+      description: 'See how CNI network policies allow and block pod traffic',
+    },
+    {
+      title: 'Load Balancer Simulator',
+      url: '/games/load-balancer-simulator',
+      type: 'practice',
+      description: 'Explore load balancing algorithms and traffic distribution',
     },
   ],
 };


### PR DESCRIPTION
Surfaces the interactive simulators from all three roadmaps so learners can jump from a topic straight into a hands-on sim.

**Junior + DevSecOps roadmaps** (`app/roadmap/{junior,devsecops}`): added an optional `simulators` list per skill, rendered as a "Try: <simulator>" link next to "Start learning".
- Junior: Linux Basics → Linux Terminal · Git Basics → Git Concepts · Networking → DNS · Docker → Docker Terminal · AWS → AWS VPC
- DevSecOps: Linux Security → Linux Terminal · Kubernetes Security → Kubernetes Terminal + K8s Network Policies · Service Mesh Security → Service Mesh · IAM → OAuth/OIDC · Network Security → DDoS + Rate Limiting

**Standalone /roadmap** (SEO page, `app/roadmap/page.tsx`): added simulator entries (type `practice`) to the `skillResourcesDatabase`.
- Git Version Control → Git Concepts · Docker Fundamentals → Docker Terminal · Kubernetes Basics → Kubernetes Terminal · AWS Fundamentals → AWS VPC · Networking Fundamentals → DNS · Container Networking → K8s Network Policies + Load Balancer (Linux already linked the terminal sim)

All linked `/games/*` routes verified to exist. Roadmap files type-check clean.