### PR TITLE
Link interactive simulators from the guides

### DIFF
--- a/content/guides/cryptography-essentials/index.md
+++ b/content/guides/cryptography-essentials/index.md
@@ -64,3 +64,7 @@ This guide is designed for:
 - Anyone preparing for security-focused interviews
 
 Let's build your cryptographic foundation!
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [SSL/TLS Handshake simulator](/games/ssl-tls-handshake), right in your browser with no setup required.

--- a/content/guides/introduction-to-aws/index.md
+++ b/content/guides/introduction-to-aws/index.md
@@ -92,3 +92,7 @@ Cloud computing might seem complex, but remember that every expert started exact
 Don't worry about understanding everything immediately. Focus on the big picture first, then dive deeper into the areas that interest you most.
 
 Ready to start your cloud journey? Let's begin with setting up your AWS account and getting familiar with the basics.
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [AWS VPC simulator](/games/aws-vpc-simulator), right in your browser with no setup required.

--- a/content/guides/introduction-to-bash/index.md
+++ b/content/guides/introduction-to-bash/index.md
@@ -45,3 +45,7 @@ By the end of this guide, you'll be comfortable working within a Bash environmen
 ## Free eBook
 
 For a more in-depth exploration of Bash, download the free eBook ["Introduction to Bash"](https://github.com/bobbyiliev/introduction-to-bash-scripting). This eBook covers everything from the basics to advanced scripting techniques, complete with examples and exercises to reinforce your learning.
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Linux Terminal simulator](/games/linux-terminal), right in your browser with no setup required.

--- a/content/guides/introduction-to-cicd/index.md
+++ b/content/guides/introduction-to-cicd/index.md
@@ -75,3 +75,7 @@ Modern software development relies on automation to maintain quality while movin
 We'll start with simple workflows and add complexity gradually. Each section builds on previous concepts, so you develop deep understanding rather than just copying configurations. The automation you build will be production-ready and designed to scale with your projects and teams.
 
 The skills you learn here apply beyond GitHub Actions. The principles of pipeline design, testing strategies, and deployment patterns work across all CI/CD platforms. You're learning to think systematically about software delivery, not just memorizing syntax.
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [CI/CD Stack Generator](/games/cicd-stack-generator), right in your browser with no setup required.

--- a/content/guides/introduction-to-docker/index.md
+++ b/content/guides/introduction-to-docker/index.md
@@ -37,3 +37,7 @@ This guide walks you through Docker from the ground up. We'll start with fundame
 Whether you're a developer looking to standardize your development environment, a DevOps engineer implementing containerization strategies, or just curious about container technology, this guide will provide you with the knowledge and practical skills to use Docker effectively.
 
 Each section includes hands-on examples and real-world scenarios to help you apply what you learn immediately. Let's start your Docker journey!
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Docker Terminal simulator](/games/docker-terminal-simulator), right in your browser with no setup required.

--- a/content/guides/introduction-to-git/index.md
+++ b/content/guides/introduction-to-git/index.md
@@ -59,3 +59,7 @@ This guide is organized into logical, step-by-step sections that build upon each
 Each section includes practical examples that you can follow along with on your own machine. By the end of this guide, you'll have both the knowledge and confidence to use Git effectively in your daily development work.
 
 Let's get started with the fundamentals of Git!
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Git Concepts simulator](/games/git-concepts-simulator), right in your browser with no setup required.

--- a/content/guides/introduction-to-kubernetes/index.md
+++ b/content/guides/introduction-to-kubernetes/index.md
@@ -37,3 +37,7 @@ This guide will walk you through Kubernetes from the ground up. We'll start with
 Kubernetes can seem complex at first, but it's designed around a set of consistent principles that become clearer as you work with it. This guide aims to demystify these concepts through practical examples and clear explanations.
 
 Each section builds on the previous one, providing a structured learning path that will take you from Kubernetes beginner to confident practitioner. Let's begin your Kubernetes journey!
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Kubernetes Terminal simulator](/games/kubernetes-terminal-simulator), right in your browser with no setup required.

--- a/content/guides/introduction-to-linux/index.md
+++ b/content/guides/introduction-to-linux/index.md
@@ -49,3 +49,7 @@ This guide is designed for:
 Whether you're completely new to Linux or have some experience but want to fill in gaps in your knowledge, you'll find value in this guide.
 
 Let's get started with our Linux journey!
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Linux Terminal simulator](/games/linux-terminal), right in your browser with no setup required.

--- a/content/guides/introduction-to-postgres/index.md
+++ b/content/guides/introduction-to-postgres/index.md
@@ -90,3 +90,7 @@ Each section builds on previous ones with hands-on examples. We use realistic sc
 By the end of this guide, you'll understand how PostgreSQL works, when to use it, and how to avoid common pitfalls. You'll be ready to use PostgreSQL for real projects and have the foundation to dive deeper into advanced topics.
 
 Let's start by understanding what databases actually do and why relational databases like PostgreSQL solve problems that simpler storage options can't handle.
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [Database Indexing simulator](/games/db-indexing-simulator), right in your browser with no setup required.

--- a/content/guides/networking-fundamentals/index.md
+++ b/content/guides/networking-fundamentals/index.md
@@ -64,3 +64,7 @@ Each section builds on previous concepts while remaining practical and actionabl
 You can work through the guide sequentially or jump to specific sections based on your immediate needs. Each section includes practical examples and real-world scenarios.
 
 By the end of this guide, you'll have the networking knowledge to debug connectivity issues, design secure network architectures, and implement reliable communication patterns in your applications.
+
+## Practice hands-on
+
+Reinforce what you learn here with the interactive [DNS Resolution simulator](/games/dns-simulator), right in your browser with no setup required.


### PR DESCRIPTION
Adds a short "Practice hands-on" callout to 10 guide landing pages, linking the matching in-browser simulator so readers can practice as they learn.

- Introduction to Linux → Linux Terminal
- Introduction to Bash → Linux Terminal
- Introduction to Git → Git Concepts
- Introduction to Docker → Docker Terminal
- Introduction to Kubernetes → Kubernetes Terminal
- Networking Fundamentals → DNS Resolution
- Introduction to AWS → AWS VPC
- Introduction to Postgres → Database Indexing
- Introduction to CI/CD → CI/CD Stack Generator
- Cryptography Essentials → SSL/TLS Handshake

All linked /games routes verified to exist. Companion to the roadmap simulator links (#1344).