### PR TITLE
Clarify HEAD in the git simulator's diff --staged step

### DIFF
--- a/components/games/git-concepts-simulator.tsx
+++ b/components/games/git-concepts-simulator.tsx
@@ -144,7 +144,7 @@ const LESSONS: Lesson[] = [
         hint: 'Use "git diff --staged".',
         expectedCommand: ['git diff --staged', 'git diff --cached'],
         explanation:
-          'git diff shows unstaged changes by default. --staged compares the index to HEAD.',
+          'git diff shows unstaged changes by default (working tree vs index). --staged (or --cached) compares the index to your last commit, known as HEAD.',
       },
       {
         instruction: 'Commit the staged snapshot into the local repository.',


### PR DESCRIPTION
User feedback on the Git concepts simulator: the `git diff --staged` step said "--staged compares the index to HEAD", but HEAD hasn't really been explained by that point, so it read as obscure.

Reworded to lead with the plain idea and define the term inline: "git diff shows unstaged changes by default (working tree vs index). --staged (or --cached) compares the index to your last commit, known as HEAD."