### PR TITLE
fix: SEO improvements from site scan

### DIFF
--- a/app/advent-of-devops/page.tsx
+++ b/app/advent-of-devops/page.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Advent of DevOps 2026 - 25 Day Challenge | DevOps Daily',
+  title: 'Advent of DevOps 2026 - 25 Day Challenge',
   description:
     'Join the Advent of DevOps 2026 challenge! 25 days of hands-on DevOps tasks covering Docker, Kubernetes, CI/CD, security, monitoring, and more. Level up your DevOps skills this December.',
   alternates: {

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -32,7 +32,7 @@ import {
 } from 'lucide-react';
 
 export const metadata: Metadata = {
-  title: 'DevOps Books | DevOps Daily',
+  title: 'DevOps Books',
   description:
     'Curated collection of the best DevOps, SRE, and Cloud Engineering books. From beginner guides to advanced practices.',
   alternates: {

--- a/app/hacktoberfest/page.tsx
+++ b/app/hacktoberfest/page.tsx
@@ -26,7 +26,7 @@ import { SectionSeparator } from '@/components/section-separator';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Hacktoberfest 2026 - 7-Day DevOps Contribution Challenge | DevOps Daily',
+  title: 'Hacktoberfest 2026 - 7-Day DevOps Contribution Challenge',
   description:
     'Join the DevOps Daily Hacktoberfest 2026 challenge! 7 days of beginner-friendly open source contributions. Add your profile, fix bugs, contribute quizzes, flashcards, and more. No coding required.',
   alternates: {

--- a/app/interview-questions/[tier]/[slug]/page.tsx
+++ b/app/interview-questions/[tier]/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { Briefcase } from 'lucide-react';
 import { interviewQuestions, getQuestionBySlug } from '@/content/interview-questions';
 import { InterviewQuestionPage } from '@/components/interview-questions/interview-question-page';
+import { BreadcrumbSchema, QAPageSchema } from '@/components/schema-markup';
 import { PageHero } from '@/components/page-hero';
 import { getSocialImagePath } from '@/lib/image-utils';
 import { truncateMetaDescription } from '@/lib/meta-description';
@@ -118,6 +119,19 @@ export default async function QuestionPage({ params }: PageProps) {
 
   return (
     <>
+      <QAPageSchema
+        question={question.question}
+        answer={question.answer}
+        url={`/interview-questions/${tier}/${slug}`}
+      />
+      <BreadcrumbSchema
+        items={[
+          { name: 'Home', url: '/' },
+          { name: 'Interview Questions', url: '/interview-questions' },
+          { name: capitalizedTier, url: `/interview-questions/${tier}` },
+          { name: question.title, url: `/interview-questions/${tier}/${slug}` },
+        ]}
+      />
       <PageHero
         title={question.title}
         description={question.question}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -133,8 +133,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           title="DevOps Daily RSS Feed"
           href="/feed.xml"
         />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <OrganizationSchema />
         <WebsiteSchema />
       </head>

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -6,7 +6,7 @@ import { PageHero } from '@/components/page-hero';
 import { NewsletterForm } from '@/components/footer/newsletter-form';
 
 export const metadata: Metadata = {
-  title: 'Newsletter Archive | DevOps Daily',
+  title: 'Newsletter Archive',
   description:
     'Browse past issues of the DevOps Daily newsletter. Weekly roundups of new content, tools, and learning resources for DevOps engineers.',
   alternates: { canonical: '/newsletters' },

--- a/app/newsletters/welcome/page.tsx
+++ b/app/newsletters/welcome/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react';
 import { WelcomeContent } from './_components/welcome-content';
 
 export const metadata: Metadata = {
-  title: "You're subscribed | DevOps Daily Newsletter",
+  title: "You're subscribed",
   description:
     "Welcome to the DevOps Daily newsletter. Here's what to expect, what every Monday issue looks like, and where to start while you wait for your first one.",
   alternates: { canonical: '/newsletters/welcome' },

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,104 +1,13 @@
-'use client';
+import type { Metadata } from 'next';
+import { NotFoundClient } from '@/components/not-found-client';
 
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
+// The 404 UI needs window.location, so it lives in a client component; this
+// server wrapper exists to give the page its own title instead of the
+// layout's homepage default.
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+};
 
 export default function NotFound() {
-  const [path, setPath] = useState('/');
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setPath(window.location.pathname || '/');
-    }
-  }, []);
-
-  const isMdRequest = path.endsWith('.md');
-  const strippedPath = isMdRequest ? path.replace(/\.md$/, '') : path;
-
-  return (
-    <main className="min-h-[70vh] flex items-center justify-center px-4">
-      <div className="w-full max-w-2xl">
-        <div className="rounded-md border bg-card overflow-hidden font-mono text-sm">
-          <div className="flex items-center gap-2 px-4 py-2.5 bg-muted/60 border-b">
-            <div className="flex gap-1.5">
-              <div className="w-3 h-3 rounded-full bg-red-400/70" />
-              <div className="w-3 h-3 rounded-full bg-yellow-400/70" />
-              <div className="w-3 h-3 rounded-full bg-green-400/70" />
-            </div>
-            <span className="text-xs text-muted-foreground ml-2">devops-daily - 404</span>
-          </div>
-          <div className="p-6 space-y-3">
-            <div>
-              <span className="text-green-500">$</span>{' '}
-              <span className="text-muted-foreground">cd {path}</span>
-            </div>
-            <p className="pl-4 text-red-400">
-              bash: cd: {path}: No such file or directory
-            </p>
-            {isMdRequest && (
-              <>
-                <div>
-                  <span className="text-green-500">$</span>{' '}
-                  <span className="text-muted-foreground">
-                    # try the HTML version
-                  </span>
-                </div>
-                <p className="pl-4 text-primary">
-                  <Link href={strippedPath} className="hover:underline">
-                    {strippedPath}
-                  </Link>
-                </p>
-              </>
-            )}
-            <div>
-              <span className="text-green-500">$</span>{' '}
-              <span className="text-muted-foreground"># available paths</span>
-            </div>
-            <ul className="pl-4 space-y-0.5 text-foreground">
-              <li>
-                <Link href="/" className="text-primary hover:underline">
-                  /
-                </Link>{' '}
-                <span className="text-muted-foreground"># home</span>
-              </li>
-              <li>
-                <Link href="/games" className="text-primary hover:underline">
-                  /games
-                </Link>{' '}
-                <span className="text-muted-foreground"># interactive simulators</span>
-              </li>
-              <li>
-                <Link href="/posts" className="text-primary hover:underline">
-                  /posts
-                </Link>{' '}
-                <span className="text-muted-foreground"># latest articles</span>
-              </li>
-              <li>
-                <Link href="/guides" className="text-primary hover:underline">
-                  /guides
-                </Link>{' '}
-                <span className="text-muted-foreground"># step-by-step tutorials</span>
-              </li>
-              <li>
-                <Link href="/exercises" className="text-primary hover:underline">
-                  /exercises
-                </Link>{' '}
-                <span className="text-muted-foreground"># hands-on labs</span>
-              </li>
-            </ul>
-            <div className="text-xs text-muted-foreground/60 pt-1">
-              <span className="text-green-500/70">$</span>{' '}
-              <span className="inline-block w-[0.6em] h-[1em] align-middle bg-foreground/60 animate-cursor-blink" />
-            </div>
-          </div>
-        </div>
-
-        <p className="mt-6 text-center text-sm text-muted-foreground">
-          <Link href="/" className="font-mono hover:text-primary transition-colors">
-            <span className="text-green-500/80">$</span> cd ~
-          </Link>
-        </p>
-      </div>
-    </main>
-  );
+  return <NotFoundClient />;
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react';
 import { SearchPageClient } from '@/components/search-page-client';
 
 export const metadata: Metadata = {
-  title: 'Search | DevOps Daily',
+  title: 'Search',
   description: 'Search across DevOps Daily posts, guides, quizzes, games, flashcards, comparisons, and tools to find content on Docker, Kubernetes, AWS, CI/CD, and more.',
   alternates: {
     canonical: '/search',

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -19,7 +19,7 @@ import { BreadcrumbSchema } from '@/components/schema-markup';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Sponsorship - Reach 25,000+ DevOps Engineers | DevOps Daily',
+  title: 'Sponsorship - Reach 25,000+ DevOps Engineers',
   description:
     'Partner with DevOps Daily to reach 25,000+ monthly readers, 5,000+ newsletter subscribers, and a highly engaged audience of DevOps engineers, SREs, and technical decision-makers.',
   alternates: {

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -6,7 +6,7 @@ import { BreadcrumbSchema } from '@/components/schema-markup';
 import { ToolsIndexList } from '@/components/tools/tools-index-list';
 
 export const metadata: Metadata = {
-  title: 'DevOps Tools and Calculators | DevOps Daily',
+  title: 'DevOps Tools and Calculators',
   description:
     'Free DevOps utilities that run entirely in your browser: CIDR calculator, JWT decoder, base64 and URL encoder, UUID generator, cron expression parser, and more. No sign-up, no server.',
   alternates: { canonical: '/tools' },

--- a/components/not-found-client.tsx
+++ b/components/not-found-client.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+export function NotFoundClient() {
+  const [path, setPath] = useState('/');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setPath(window.location.pathname || '/');
+    }
+  }, []);
+
+  const isMdRequest = path.endsWith('.md');
+  const strippedPath = isMdRequest ? path.replace(/\.md$/, '') : path;
+
+  return (
+    <main className="min-h-[70vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-2xl">
+        <div className="rounded-md border bg-card overflow-hidden font-mono text-sm">
+          <div className="flex items-center gap-2 px-4 py-2.5 bg-muted/60 border-b">
+            <div className="flex gap-1.5">
+              <div className="w-3 h-3 rounded-full bg-red-400/70" />
+              <div className="w-3 h-3 rounded-full bg-yellow-400/70" />
+              <div className="w-3 h-3 rounded-full bg-green-400/70" />
+            </div>
+            <span className="text-xs text-muted-foreground ml-2">devops-daily - 404</span>
+          </div>
+          <div className="p-6 space-y-3">
+            <div>
+              <span className="text-green-500">$</span>{' '}
+              <span className="text-muted-foreground">cd {path}</span>
+            </div>
+            <p className="pl-4 text-red-400">
+              bash: cd: {path}: No such file or directory
+            </p>
+            {isMdRequest && (
+              <>
+                <div>
+                  <span className="text-green-500">$</span>{' '}
+                  <span className="text-muted-foreground">
+                    # try the HTML version
+                  </span>
+                </div>
+                <p className="pl-4 text-primary">
+                  <Link href={strippedPath} className="hover:underline">
+                    {strippedPath}
+                  </Link>
+                </p>
+              </>
+            )}
+            <div>
+              <span className="text-green-500">$</span>{' '}
+              <span className="text-muted-foreground"># available paths</span>
+            </div>
+            <ul className="pl-4 space-y-0.5 text-foreground">
+              <li>
+                <Link href="/" className="text-primary hover:underline">
+                  /
+                </Link>{' '}
+                <span className="text-muted-foreground"># home</span>
+              </li>
+              <li>
+                <Link href="/games" className="text-primary hover:underline">
+                  /games
+                </Link>{' '}
+                <span className="text-muted-foreground"># interactive simulators</span>
+              </li>
+              <li>
+                <Link href="/posts" className="text-primary hover:underline">
+                  /posts
+                </Link>{' '}
+                <span className="text-muted-foreground"># latest articles</span>
+              </li>
+              <li>
+                <Link href="/guides" className="text-primary hover:underline">
+                  /guides
+                </Link>{' '}
+                <span className="text-muted-foreground"># step-by-step tutorials</span>
+              </li>
+              <li>
+                <Link href="/exercises" className="text-primary hover:underline">
+                  /exercises
+                </Link>{' '}
+                <span className="text-muted-foreground"># hands-on labs</span>
+              </li>
+            </ul>
+            <div className="text-xs text-muted-foreground/60 pt-1">
+              <span className="text-green-500/70">$</span>{' '}
+              <span className="inline-block w-[0.6em] h-[1em] align-middle bg-foreground/60 animate-cursor-blink" />
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          <Link href="/" className="font-mono hover:text-primary transition-colors">
+            <span className="text-green-500/80">$</span> cd ~
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/components/schema-markup.tsx
+++ b/components/schema-markup.tsx
@@ -137,10 +137,12 @@ export function ArticleSchema({
     image: articleImage,
     datePublished: articlePublished,
     dateModified: articleModified,
-    author: {
-      '@type': 'Person',
-      name: articleAuthor,
-    },
+    // Team-authored content credits the Organization entity (referencing the
+    // full node already on every page); only named individuals are a Person.
+    author:
+      articleAuthor === 'DevOps Daily Team'
+        ? { '@id': ORGANIZATION_ID }
+        : { '@type': 'Person', name: articleAuthor },
     publisher: {
       '@id': ORGANIZATION_ID,
     },
@@ -192,19 +194,26 @@ export function TechArticleSchema({
       : `${SITE_URL}${imageUrl}`
     : `${SITE_URL}/og-image.png`;
 
+  const articleAuthor = authorName || 'DevOps Daily Team';
+
   const schema: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SITE_URL}${url}`,
+    },
     headline: title,
     description,
     url: `${SITE_URL}${url}`,
     image: articleImage,
     datePublished: publishedDate,
     dateModified: modifiedDate,
-    author: {
-      '@type': 'Person',
-      name: authorName || 'DevOps Daily Team',
-    },
+    // Same Organization-vs-Person split as ArticleSchema above.
+    author:
+      articleAuthor === 'DevOps Daily Team'
+        ? { '@id': ORGANIZATION_ID }
+        : { '@type': 'Person', name: articleAuthor },
     publisher: {
       '@id': ORGANIZATION_ID,
     },

--- a/components/schema-markup.tsx
+++ b/components/schema-markup.tsx
@@ -367,6 +367,44 @@ export function FAQSchema({ questions }: { questions: { question: string; answer
   );
 }
 
+/**
+ * Single question-and-answer page (interview questions). QAPage fits a page
+ * whose main entity is one question with an accepted answer; FAQPage above is
+ * for pages listing several Q&As.
+ */
+export function QAPageSchema({
+  question,
+  answer,
+  url,
+}: {
+  question: string;
+  answer: string;
+  url: string;
+}) {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'QAPage',
+    mainEntity: {
+      '@type': 'Question',
+      name: question,
+      text: question,
+      answerCount: 1,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: answer,
+        url: `${SITE_URL}${url}`,
+      },
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
 export function BreadcrumbSchema({ items }: { items: { name: string; url: string }[] }) {
   const itemListElement = items.map((item, index) => ({
     '@type': 'ListItem',

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,7 @@
 /*
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; connect-src 'self' https:; frame-src https://giscus.app
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https: data:; connect-src 'self' https:; frame-src https://giscus.app; frame-ancestors 'self'
 
 /sw.js
   Service-Worker-Allowed: /


### PR DESCRIPTION
SEO fixes from the site scan, one commit per area:

- Remove doubled "| DevOps Daily" brand suffix from 8 page titles (layout template already appends it); live /tools rendered "... | DevOps Daily | DevOps Daily"
- Add QAPage + BreadcrumbList JSON-LD to the 96 interview-question pages (they had no rich-result schema at all)
- Credit team-authored posts/guides to the Organization entity instead of a Person named "DevOps Daily Team"; add mainEntityOfPage to guides' TechArticle
- Give the 404 page its own title (was the homepage title); drop Google Fonts preconnects left over from before fonts were self-hosted
- Add frame-ancestors 'self' to the global CSP for clickjacking protection; /games/*/embed override still allows external embedding

All 5,174 tests pass; touched files type-check clean.