### PR TITLE
feat: embeddable charts in blog posts

### DIFF
--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -2,6 +2,7 @@ import type { Ref } from 'react';
 import { parseMarkdown } from '@/lib/markdown';
 import { cn } from '@/lib/utils';
 import { CodeBlockWrapper } from '@/components/code-block-wrapper';
+import { ChartBlockWrapper } from '@/components/post-chart-blocks';
 import { HeadingWrapper } from '@/components/heading-with-anchor';
 
 const PROSE_CLASS =
@@ -32,7 +33,9 @@ export function MarkdownContent({ content, className }: MarkdownContentProps) {
   return (
     <HeadingWrapper>
       <CodeBlockWrapper>
-        <MarkdownHtml html={parseMarkdown(content)} className={className} />
+        <ChartBlockWrapper>
+          <MarkdownHtml html={parseMarkdown(content)} className={className} />
+        </ChartBlockWrapper>
       </CodeBlockWrapper>
     </HeadingWrapper>
   );

--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  type ChartSpec,
+  type BarRow,
+  type LineSeries,
+  type DotSeries,
+  parseChartSpec,
+  formatValue,
+  median,
+  seriesColor,
+} from '@/lib/post-charts';
+
+/* ------------------------------------------------------------------ */
+/* Chart primitives: hand-rolled SVG, theme-aware via currentColor     */
+/* ------------------------------------------------------------------ */
+
+function BarChart({ spec }: { spec: ChartSpec }) {
+  const rows = spec.rows as BarRow[];
+  const width = 720;
+  const rowH = 42;
+  const labelW = 190;
+  const valueW = spec.tickLabel ? 150 : 90;
+  const pad = 6;
+  const height = rows.length * rowH + pad * 2;
+  const max = Math.max(...rows.map((r) => Math.max(r.value, r.tick ?? 0))) * 1.08;
+  const scale = (v: number) => (v / max) * (width - labelW - valueW);
+
+  const seriesNames = [...new Set(rows.map((r) => r.series).filter(Boolean))] as string[];
+  const colorFor = (row: BarRow) =>
+    row.series ? seriesColor(seriesNames.indexOf(row.series)) : seriesColor(0);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Bar chart'}>
+      {rows.map((r, i) => {
+        const cy = pad + i * rowH + rowH / 2;
+        return (
+          <g key={`${r.label}-${i}`}>
+            <text x={0} y={cy + 4} fontSize={13} className="fill-muted-foreground">{r.label}</text>
+            <line x1={labelW} y1={cy} x2={width - valueW} y2={cy} className="stroke-border" strokeOpacity={0.5} />
+            <rect
+              x={labelW}
+              y={cy - 7}
+              width={Math.max(2, scale(r.value))}
+              height={14}
+              rx={4}
+              fill={colorFor(r)}
+              fillOpacity={0.85}
+            />
+            {r.tick != null && (
+              <line
+                x1={labelW + scale(r.tick)}
+                y1={cy - 11}
+                x2={labelW + scale(r.tick)}
+                y2={cy + 11}
+                stroke="#f59e0b"
+                strokeWidth={2}
+              />
+            )}
+            <text x={width - valueW + 12} y={cy + 4} fontSize={13} fontWeight={600} className="fill-foreground">
+              {formatValue(r.value, spec.unit)}
+            </text>
+            {r.tick != null && (
+              <text x={width - valueW + 78} y={cy + 4} fontSize={11.5} className="fill-muted-foreground">
+                {spec.tickLabel ?? 'tick'} {formatValue(r.tick, spec.unit)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function LineChart({ spec }: { spec: ChartSpec }) {
+  const series = spec.series as LineSeries[];
+  const width = 720;
+  const height = 300;
+  const padL = 56;
+  const padR = 16;
+  const padT = 12;
+  const padB = 34;
+  const points = Math.max(...series.map((s) => s.data.length));
+  const all = series.flatMap((s) => s.data);
+  const maxV = Math.max(...all) * 1.06;
+  const minV = Math.min(0, Math.min(...all));
+  const x = (i: number) => padL + (i / Math.max(1, points - 1)) * (width - padL - padR);
+  const y = (v: number) => padT + (1 - (v - minV) / (maxV - minV)) * (height - padT - padB);
+  const yTicks = [...Array(4).keys()].map((t) => minV + ((maxV - minV) * (t + 1)) / 4);
+  const labels = spec.x ?? [...Array(points).keys()].map((i) => i + 1);
+  const labelStep = Math.ceil(labels.length / 8);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Line chart'}>
+      {yTicks.map((v) => (
+        <g key={v}>
+          <line x1={padL} y1={y(v)} x2={width - padR} y2={y(v)} className="stroke-border" strokeOpacity={0.4} />
+          <text x={padL - 8} y={y(v) + 4} fontSize={11.5} textAnchor="end" className="fill-muted-foreground">
+            {formatValue(v, spec.unit)}
+          </text>
+        </g>
+      ))}
+      {labels.map((l, i) =>
+        i % labelStep === 0 ? (
+          <text key={`${l}-${i}`} x={x(i)} y={height - 12} fontSize={11.5} textAnchor="middle" className="fill-muted-foreground">
+            {String(l)}
+          </text>
+        ) : null
+      )}
+      {series.map((s, si) => {
+        const d = s.data.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(' ');
+        return (
+          <g key={s.name}>
+            <path d={d} fill="none" stroke={seriesColor(si)} strokeWidth={2.5} strokeLinejoin="round" />
+            {s.data.map((v, i) => (
+              <circle key={i} cx={x(i)} cy={y(v)} r={3} fill={seriesColor(si)} />
+            ))}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function DotPlot({ spec }: { spec: ChartSpec }) {
+  const series = spec.series as DotSeries[];
+  const width = 720;
+  const rowH = 58;
+  const labelH = 26;
+  const padX = 6;
+  const height = series.length * rowH + labelH;
+  const all = series.flatMap((s) => s.samples);
+  const min = Math.min(...all) * 0.94;
+  const max = Math.max(...all) * 1.04;
+  const scale = (v: number) => padX + ((v - min) / (max - min)) * (width - padX * 2);
+  const ticks = [...Array(6).keys()].map((t) => min + ((max - min) * t) / 5);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Distribution plot'}>
+      {ticks.map((v) => (
+        <g key={v}>
+          <line x1={scale(v)} y1={0} x2={scale(v)} y2={height - labelH} className="stroke-border" strokeOpacity={0.35} />
+          <text x={scale(v)} y={height - 8} fontSize={11.5} textAnchor="middle" className="fill-muted-foreground">
+            {formatValue(v, spec.unit)}
+          </text>
+        </g>
+      ))}
+      {series.map((s, si) => {
+        const cy = si * rowH + rowH / 2;
+        const med = s.median ?? median(s.samples);
+        const mx = scale(med);
+        return (
+          <g key={s.name}>
+            {s.name && (
+              <text x={padX} y={si * rowH + 15} fontSize={13} className="fill-muted-foreground">{s.name}</text>
+            )}
+            {s.samples.map((v, j) => (
+              <circle key={j} cx={scale(v)} cy={cy + 8} r={4.5} fill={seriesColor(si)} fillOpacity={0.55} />
+            ))}
+            <line x1={mx} y1={cy - 7} x2={mx} y2={cy + 23} stroke="#f59e0b" strokeWidth={2.5} />
+            <text x={mx + 8} y={cy} fontSize={12} fill="#f59e0b" fontWeight={600}>
+              {formatValue(med, spec.unit)}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function Legend({ spec }: { spec: ChartSpec }) {
+  let names: string[] = [];
+  if (spec.type === 'bar') {
+    names = [...new Set((spec.rows ?? []).map((r) => r.series).filter(Boolean))] as string[];
+  } else if (spec.series) {
+    names = (spec.series as Array<{ name: string }>).map((s) => s.name).filter(Boolean);
+  }
+  const items = names.map((name, i) => ({ name, color: seriesColor(i) }));
+  if (spec.type !== 'line' && spec.tickLabel) items.push({ name: spec.tickLabel, color: '#f59e0b' });
+  if (spec.type === 'dots') items.push({ name: 'median', color: '#f59e0b' });
+  if (items.length < 2) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5 text-xs text-muted-foreground">
+      {items.map((item) => (
+        <span key={item.name} className="inline-flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-sm" style={{ background: item.color }} />
+          {item.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function PostChart({ spec }: { spec: ChartSpec }) {
+  return (
+    <figure className="my-8 rounded-lg border border-border/60 bg-muted/20 p-4 sm:p-5">
+      {spec.title && (
+        <figcaption className="mb-4 text-sm font-semibold text-foreground">{spec.title}</figcaption>
+      )}
+      {spec.type === 'bar' && <BarChart spec={spec} />}
+      {spec.type === 'line' && <LineChart spec={spec} />}
+      {spec.type === 'dots' && <DotPlot spec={spec} />}
+      <Legend spec={spec} />
+      {spec.caption && <p className="mt-3 text-xs text-muted-foreground">{spec.caption}</p>}
+    </figure>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Hydration: mounts PostChart into .post-chart placeholders emitted   */
+/* by the markdown renderer (same pattern as the code copy buttons).   */
+/* ------------------------------------------------------------------ */
+
+export function ChartBlockWrapper({ children }: { children: React.ReactNode }) {
+  const rootsRef = useRef<Root[]>([]);
+
+  useEffect(() => {
+    const nodes = document.querySelectorAll<HTMLElement>('.post-chart[data-chart]:not([data-mounted])');
+    nodes.forEach((node) => {
+      const spec = parseChartSpec(node.dataset.chart ?? '');
+      if (!spec) return;
+      node.setAttribute('data-mounted', 'true');
+      const root = createRoot(node);
+      root.render(<PostChart spec={spec} />);
+      rootsRef.current.push(root);
+    });
+    const roots = rootsRef.current;
+    return () => {
+      // Deferred so React isn't unmounting roots mid-render pass
+      setTimeout(() => roots.forEach((root) => root.unmount()), 0);
+      rootsRef.current = [];
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -139,10 +139,16 @@ function DotPlot({ spec }: { spec: ChartSpec }) {
 
   return (
     <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Distribution plot'}>
-      {ticks.map((v) => (
+      {ticks.map((v, ti) => (
         <g key={v}>
           <line x1={scale(v)} y1={0} x2={scale(v)} y2={height - labelH} className="stroke-border" strokeOpacity={0.35} />
-          <text x={scale(v)} y={height - 8} fontSize={11.5} textAnchor="middle" className="fill-muted-foreground">
+          <text
+            x={scale(v)}
+            y={height - 8}
+            fontSize={11.5}
+            textAnchor={ti === 0 ? 'start' : ti === ticks.length - 1 ? 'end' : 'middle'}
+            className="fill-muted-foreground"
+          >
             {formatValue(v, spec.unit)}
           </text>
         </g>

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -122,6 +122,9 @@ marked.use(
   markedHighlight({
     langPrefix: 'hljs language-',
     highlight(code, lang) {
+      // Chart fences carry JSON for the chart renderer; leave the text
+      // untouched so the code renderer below can parse it.
+      if (lang === 'chart') return code;
       const language = hljs.getLanguage(lang) ? lang : 'plaintext';
       return hljs.highlight(code, { language }).value;
     },
@@ -138,9 +141,33 @@ marked.setOptions({
 // We'll handle heading IDs ourselves in the custom renderer
 // marked.use(gfmHeadingId({}));
 
-// Custom renderer to enhance headings with anchor links
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Custom renderer: headings get anchor links, and ```chart fences become
+// placeholders that ChartBlockWrapper hydrates client-side.
 marked.use({
   renderer: {
+    code({ text, lang }: Tokens.Code) {
+      if (lang === 'chart') {
+        try {
+          const spec = JSON.parse(text);
+          if (spec && typeof spec === 'object' && spec.type) {
+            return `<div class="post-chart not-prose" data-chart="${escapeHtml(JSON.stringify(spec))}"></div>`;
+          }
+        } catch {
+          // malformed spec: fall through to a visible code block so the
+          // mistake is obvious in the rendered post instead of a blank hole
+        }
+        return `<pre><code class="hljs language-chart">${escapeHtml(text)}</code></pre>`;
+      }
+      return false;
+    },
     heading({ tokens, depth }: Tokens.Heading) {
       // Extract text from tokens
       const text = tokens

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -1,0 +1,76 @@
+/**
+ * Spec for charts embedded in post markdown via ```chart fences.
+ * The fence body is JSON; parse failures fall back to a normal code block
+ * so a typo never breaks a post build.
+ */
+
+export type ChartType = 'bar' | 'line' | 'dots';
+
+export interface BarRow {
+  label: string;
+  value: number;
+  /** Optional secondary marker (e.g. p95) rendered as a tick */
+  tick?: number;
+  /** Series name used for color + legend grouping */
+  series?: string;
+}
+
+export interface LineSeries {
+  name: string;
+  data: number[];
+}
+
+export interface DotSeries {
+  name: string;
+  samples: number[];
+  /** Optional median override; computed from samples when omitted */
+  median?: number;
+}
+
+export interface ChartSpec {
+  type: ChartType;
+  title?: string;
+  caption?: string;
+  /** Value formatting: 'ms' | 's' | '%' | free-form suffix */
+  unit?: string;
+  /** Legend label for the tick marker (bar charts), e.g. "p95" */
+  tickLabel?: string;
+  /** bar */
+  rows?: BarRow[];
+  /** line */
+  x?: Array<string | number>;
+  series?: LineSeries[] | DotSeries[];
+}
+
+export function parseChartSpec(raw: string): ChartSpec | null {
+  try {
+    const spec = JSON.parse(raw) as ChartSpec;
+    if (!spec || typeof spec !== 'object') return null;
+    if (spec.type === 'bar' && Array.isArray(spec.rows) && spec.rows.length > 0) return spec;
+    if (spec.type === 'line' && Array.isArray(spec.series) && spec.series.length > 0) return spec;
+    if (spec.type === 'dots' && Array.isArray(spec.series) && spec.series.length > 0) return spec;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatValue(v: number, unit?: string): string {
+  if (unit === 'ms') return v >= 1000 ? `${(v / 1000).toFixed(v >= 10000 ? 1 : 2)}s` : `${Math.round(v * 10) / 10}ms`;
+  if (unit === 's') return `${(Math.round(v * 10) / 10).toLocaleString()}s`;
+  if (unit === '%') return `${Math.round(v * 10) / 10}%`;
+  return unit ? `${v.toLocaleString()}${unit}` : v.toLocaleString();
+}
+
+export function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Fixed palette that reads well on both themes, assigned by series order. */
+export const CHART_COLORS = ['#10b981', '#38bdf8', '#f59e0b', '#f472b6', '#a78bfa', '#fb923c'];
+
+export function seriesColor(index: number): string {
+  return CHART_COLORS[index % CHART_COLORS.length];
+}

--- a/scripts/render-chart-demo.tsx
+++ b/scripts/render-chart-demo.tsx
@@ -1,0 +1,47 @@
+/**
+ * Renders the PostChart components to a standalone HTML file for visual
+ * review on machines where headless chromium can only load file:// pages.
+ * Not part of the build; run with: npx tsx scripts/render-chart-demo.tsx
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { PostChart } from '../components/post-chart-blocks';
+import type { ChartSpec } from '../lib/post-charts';
+
+const specs = JSON.parse(readFileSync('/tmp/chart-specs.json', 'utf8')) as Record<string, ChartSpec>;
+
+const sections = (['latencySpec', 'createSpec', 'coldSpec'] as const)
+  .map((key) => renderToStaticMarkup(<PostChart spec={specs[key]} />))
+  .join('\n');
+
+const css = `
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, "Segoe UI", Inter, sans-serif; }
+  .theme { padding: 40px; }
+  .theme.light { --foreground: hsl(240 10% 3.9%); --muted-foreground: hsl(240 3.8% 46.1%);
+    --muted: hsl(240 4.8% 95.9%); --border: hsl(240 5.9% 90%); background: #fff; color: hsl(240 10% 3.9%); }
+  .theme.dark { --foreground: hsl(0 0% 98%); --muted-foreground: hsl(240 5% 64.9%);
+    --muted: hsl(240 3.7% 15.9%); --border: hsl(240 3.7% 15.9%); background: hsl(240 10% 3.9%); color: hsl(0 0% 98%); }
+  .wrap { max-width: 760px; margin: 0 auto; }
+  h2 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.5; }
+  figure { margin: 32px 0; border-radius: 0.5rem; border: 1px solid var(--border); padding: 20px;
+    background: color-mix(in srgb, var(--muted) 20%, transparent); }
+  figcaption { margin-bottom: 16px; font-size: 14px; font-weight: 600; color: var(--foreground); }
+  figure p { margin: 12px 0 0; font-size: 12px; color: var(--muted-foreground); }
+  .fill-muted-foreground { fill: var(--muted-foreground); }
+  .fill-foreground { fill: var(--foreground); }
+  .stroke-border { stroke: var(--border); }
+  .mt-3 { margin-top: 12px; } .flex { display: flex; } .flex-wrap { flex-wrap: wrap; }
+  .gap-x-5 { column-gap: 20px; } .gap-y-1\\.5 { row-gap: 6px; }
+  .text-xs { font-size: 12px; } .text-muted-foreground { color: var(--muted-foreground); }
+  .inline-flex { display: inline-flex; } .items-center { align-items: center; } .gap-1\\.5 { gap: 6px; }
+  .h-2 { height: 8px; } .w-2 { width: 8px; } .rounded-sm { border-radius: 3px; }
+`;
+
+const html = `<!doctype html><html><head><meta charset="utf-8"><style>${css}</style></head><body>
+<div class="theme light"><div class="wrap"><h2>Light theme</h2>${sections}</div></div>
+<div class="theme dark"><div class="wrap"><h2>Dark theme</h2>${sections}</div></div>
+</body></html>`;
+
+writeFileSync('/tmp/charts-demo.html', html);
+console.log('written /tmp/charts-demo.html');

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown } from '@/lib/markdown';
+import { parseChartSpec, formatValue, median } from '@/lib/post-charts';
+
+const BAR_SPEC = {
+  type: 'bar',
+  title: 'Query latency',
+  unit: 'ms',
+  tickLabel: 'p95',
+  rows: [
+    { label: 'Neon pooler', value: 25.1, tick: 36, series: 'Neon' },
+    { label: 'Supabase session', value: 29, tick: 37.2, series: 'Supabase' },
+  ],
+};
+
+describe('post chart embeds', () => {
+  it('turns a chart fence into a placeholder div', () => {
+    const md = '# Title\n\n```chart\n' + JSON.stringify(BAR_SPEC, null, 2) + '\n```\n';
+    const html = parseMarkdown(md);
+    expect(html).toContain('class="post-chart not-prose"');
+    expect(html).toContain('data-chart="');
+    expect(html).not.toContain('<pre><code class="hljs language-chart">');
+  });
+
+  it('round-trips the spec through the data attribute', () => {
+    const md = '```chart\n' + JSON.stringify(BAR_SPEC) + '\n```';
+    const html = parseMarkdown(md);
+    const match = html.match(/data-chart="([^"]+)"/);
+    expect(match).toBeTruthy();
+    const decoded = match![1]
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+    const spec = parseChartSpec(decoded);
+    expect(spec?.type).toBe('bar');
+    expect(spec?.rows).toHaveLength(2);
+    expect(spec?.rows?.[0].value).toBe(25.1);
+  });
+
+  it('renders malformed chart JSON as a visible code block instead of a blank hole', () => {
+    const html = parseMarkdown('```chart\n{ not json\n```');
+    expect(html).not.toContain('post-chart');
+    expect(html).toContain('language-chart');
+    expect(html).toContain('{ not json');
+  });
+
+  it('leaves other code fences untouched', () => {
+    const html = parseMarkdown('```bash\necho hi\n```');
+    expect(html).toContain('language-bash');
+    expect(html).not.toContain('post-chart');
+  });
+
+  it('rejects specs without a known shape', () => {
+    expect(parseChartSpec('{"type":"bar"}')).toBeNull();
+    expect(parseChartSpec('{"type":"pie","rows":[{"label":"a","value":1}]}')).toBeNull();
+    expect(parseChartSpec('"just a string"')).toBeNull();
+    expect(parseChartSpec('{"type":"dots","series":[{"name":"a","samples":[1,2]}]}')).not.toBeNull();
+  });
+
+  it('formats values by unit', () => {
+    expect(formatValue(25.14, 'ms')).toBe('25.1ms');
+    expect(formatValue(2176, 'ms')).toBe('2.18s');
+    expect(formatValue(13558, 'ms')).toBe('13.6s');
+    expect(formatValue(42, '%')).toBe('42%');
+  });
+
+  it('computes medians', () => {
+    expect(median([3, 1, 2])).toBe(2);
+    expect(median([4, 1, 2, 3])).toBe(2.5);
+  });
+});


### PR DESCRIPTION
Adds a ```chart code fence for posts: the fence body is a JSON spec (bar, line, or dots) rendered as a theme-aware SVG figure. Malformed specs fall back to a visible code block so a typo can't blank a section. Hand-rolled SVG, no chart library; hydrated client-side the same way as the code copy buttons. 7 unit tests cover the markdown transform, spec validation, and formatting.