### PR TITLE
feat: roadmap UX refresh

### DIFF
--- a/app/roadmap/layout.tsx
+++ b/app/roadmap/layout.tsx
@@ -59,6 +59,38 @@ export const metadata: Metadata = {
   ],
 };
 
+const stagesJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'DevOps Learning Roadmap',
+  description:
+    'Staged learning path for DevOps engineers, from fundamentals to advanced platform skills.',
+  itemListElement: [
+    'Fundamentals',
+    'Infrastructure as Code',
+    'Containerization & Orchestration',
+    'CI/CD Pipelines',
+    'Cloud Platforms',
+    'Monitoring & Observability',
+    'Security & Compliance',
+    'Database Management',
+    'Continuous Learning',
+  ].map((name, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name,
+    url: 'https://devops-daily.com/roadmap',
+  })),
+};
+
 export default function RoadmapLayout({ children }: { children: React.ReactNode }) {
-  return children;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(stagesJsonLd) }}
+      />
+      {children}
+    </>
+  );
 }

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -598,7 +598,7 @@ export default function RoadmapPage() {
               </div>
 
               {roadmapStages.map((stage, index) => (
-                <div key={stage.id} id={`stage-${stage.id}`} className="relative mb-24 scroll-mt-28">
+                <div key={stage.id} id={`stage-${stage.id}`} className="relative mb-16 scroll-mt-28">
                   {/* Timeline Icon */}
                   <div className="absolute z-10 transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-8">
                     <div

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Separator } from '@/components/ui/separator';
 import { ReportIssue } from '@/components/report-issue';
 import { RoadmapHero } from '@/components/roadmap-hero';
+import { RoadmapStageNav } from '@/components/roadmap-stage-nav';
 import { Github } from '@/components/icons/social-icons';
 import {
   Dialog,
@@ -43,7 +44,7 @@ import {
   ShieldCheck,
 } from 'lucide-react';
 import Link from 'next/link';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { cn } from '@/lib/utils';
 
 import {
@@ -530,11 +531,6 @@ export default function RoadmapPage() {
   const [selectedSkill, setSelectedSkill] = useState<RoadmapSkill | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // Set document title for client component
-  useEffect(() => {
-    document.title = 'DevOps Roadmap | DevOps Daily';
-  }, []);
-
   const learningStages = roadmapStages.filter((stage) => stage.id !== 'lifetime');
   const totalTime = learningStages.reduce((acc, stage) => {
     const weeks = parseInt(stage.timeEstimate.split('-')[1] || stage.timeEstimate);
@@ -555,6 +551,10 @@ export default function RoadmapPage() {
     <div className="min-h-screen bg-linear-to-b from-background via-background to-muted/20">
       {/* Enhanced Hero Section with Animations */}
       <RoadmapHero />
+
+      <RoadmapStageNav
+        stages={roadmapStages.map((s) => ({ id: s.id, title: s.title, icon: s.icon }))}
+      />
 
       {/* Roadmap Timeline */}
       <section id="roadmap" className="py-20">
@@ -594,18 +594,18 @@ export default function RoadmapPage() {
             <div className="relative hidden lg:block">
               <div className="absolute w-2 h-full transform -translate-x-1/2 left-1/2">
                 <div className="w-full h-full rounded-full bg-primary opacity-20" />
-                <div className="absolute inset-0 w-1 mx-auto rounded-full bg-primary animate-pulse" />
+                <div className="absolute inset-0 w-1 mx-auto rounded-full bg-primary/60" />
               </div>
 
               {roadmapStages.map((stage, index) => (
-                <div key={stage.id} className="relative mb-24">
+                <div key={stage.id} id={`stage-${stage.id}`} className="relative mb-24 scroll-mt-28">
                   {/* Timeline Icon */}
                   <div className="absolute z-10 transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-8">
                     <div
                       className={cn(
-                        'w-12 h-12 rounded-full border-4 border-background flex items-center justify-center transition-all duration-300 hover:scale-125',
+                        'w-12 h-12 rounded-full border-4 border-background flex items-center justify-center transition-transform duration-300 hover:scale-105',
                         stage.id === 'lifetime'
-                          ? 'bg-linear-to-r from-yellow-500 via-pink-500 to-purple-500 animate-pulse'
+                          ? 'bg-linear-to-r from-amber-500 to-primary'
                           : 'bg-primary shadow-lg shadow-primary/25'
                       )}
                     >
@@ -658,7 +658,7 @@ export default function RoadmapPage() {
                             className={cn(
                               'flex items-center gap-1 transition-all duration-300 px-3 py-1 w-fit',
                               stage.id === 'lifetime' &&
-                                'bg-linear-to-r from-yellow-500 via-pink-500 to-purple-500 text-white border-none'
+                                'bg-amber-500/15 border-amber-500/40 text-amber-600 dark:text-amber-400'
                             )}
                           >
                             {stage.id === 'lifetime' ? (
@@ -819,7 +819,7 @@ export default function RoadmapPage() {
                     className={cn(
                       'group hover:border-primary/40 hover:bg-muted/30 transition-colors border',
                       stage.id === 'lifetime' &&
-                        'border-gradient-to-r from-yellow-500 via-pink-500 to-purple-500'
+                        'border-amber-500/40'
                     )}
                   >
                     <div
@@ -1024,7 +1024,7 @@ export default function RoadmapPage() {
           <div>
             <Card className="border-0 shadow-2xl bg-primary/10 backdrop-blur-sm">
               <CardContent className="p-12 text-center">
-                <Sparkles className="w-12 h-12 mx-auto mb-6 text-yellow-500 animate-pulse" />
+                <Sparkles className="w-12 h-12 mx-auto mb-6 text-amber-500" />
 
                 <h2 className="mb-6 text-3xl font-bold text-primary md:text-4xl">
                   Ready to Begin Your DevOps Journey?

--- a/components/roadmap-hero.tsx
+++ b/components/roadmap-hero.tsx
@@ -155,7 +155,7 @@ export function RoadmapHero() {
               variant="secondary"
               className="px-4 py-2 text-sm font-medium bg-primary/10 border-primary/20 text-primary"
             >
-              <Sparkles className="inline-block w-4 h-4 mr-2 text-yellow-500 animate-pulse" />
+              <Sparkles className="inline-block w-4 h-4 mr-2 text-amber-500" />
               Your Complete DevOps Learning Path
             </Badge>
           </motion.div>

--- a/components/roadmap-hero.tsx
+++ b/components/roadmap-hero.tsx
@@ -40,18 +40,6 @@ export function RoadmapHero() {
     },
   };
 
-  const pulseVariants = {
-   animate: {
-     scale: [1, 1.05, 1],
-     opacity: [0.5, 0.8, 0.5],
-     transition: {
-       duration: 2,
-       repeat: Infinity,
-       ease: easeInOut,
-     },
-   },
- };
-
   const orbVariants = {
     animate: (custom: number) => ({
       x: [0, custom * 30, 0],
@@ -220,38 +208,8 @@ export function RoadmapHero() {
             className="flex justify-center mb-8"
          >
            <div className="relative">
-             {/* Multiple pulse rings */}
-             <motion.div
-               animate={{
-                 scale: [1, 1.5, 2],
-                 opacity: [0.5, 0.2, 0],
-               }}
-               transition={{
-                 duration: 2,
-                 repeat: Infinity,
-                 ease: 'easeOut',
-               }}
-               className="absolute inset-0 bg-primary/40 rounded-full"
-             />
-             <motion.div
-               animate={{
-                 scale: [1, 1.5, 2],
-                 opacity: [0.5, 0.2, 0],
-               }}
-               transition={{
-                 duration: 2,
-                 repeat: Infinity,
-                 ease: 'easeOut',
-                 delay: 0.5,
-               }}
-               className="absolute inset-0 bg-primary/30 rounded-full"
-             />
-             {/* Pulse background effect */}
-             <motion.div
-               variants={pulseVariants}
-               animate="animate"
-               className="absolute inset-0 bg-primary/40 rounded-full blur-xl"
-             />
+             {/* Soft static glow */}
+             <div className="absolute inset-0 bg-primary/25 rounded-full blur-xl" />
              <motion.div
                animate={{
                  rotate: [0, 5, -5, 0],

--- a/components/roadmap-stage-nav.tsx
+++ b/components/roadmap-stage-nav.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { Map, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { LucideIcon } from 'lucide-react';
 
@@ -11,17 +12,19 @@ interface StageNavItem {
 }
 
 /**
- * Sticky stage navigator for the roadmap: a vertical rail on large screens,
- * a horizontal scroller pinned under the header on smaller ones. Highlights
- * the stage currently in view and scrolls smoothly on click.
+ * Sticky stage navigator for the roadmap. On large screens it is a slim
+ * icon rail (labels slide out on hover so content is never covered) with a
+ * hide toggle and a floating reopen button. On smaller screens it is a
+ * horizontal scroller pinned under the header, in normal flow so it never
+ * overlaps content. Highlights the stage in view; click scrolls.
  */
 export function RoadmapStageNav({ stages }: { stages: StageNavItem[] }) {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        // Pick the visible stage closest to the top of the viewport
         const visible = entries
           .filter((e) => e.isIntersecting)
           .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
@@ -42,48 +45,66 @@ export function RoadmapStageNav({ stages }: { stages: StageNavItem[] }) {
 
   return (
     <>
-      {/* Vertical rail, large screens */}
-      <nav
-        aria-label="Roadmap stages"
-        className="hidden xl:flex fixed right-6 top-1/2 -translate-y-1/2 z-30 flex-col gap-1"
-      >
-        {stages.map((stage) => {
-          const active = activeId === stage.id;
-          return (
-            <button
-              key={stage.id}
-              onClick={() => scrollTo(stage.id)}
-              aria-label={`Jump to ${stage.title}`}
-              aria-current={active ? 'true' : undefined}
-              className={cn(
-                'group flex items-center gap-2 rounded-full py-1.5 pl-1.5 pr-3 text-left transition-colors',
-                active ? 'bg-primary/10' : 'hover:bg-muted/60'
-              )}
-            >
-              <span
-                className={cn(
-                  'flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-colors',
-                  active
-                    ? 'border-primary/50 bg-primary text-primary-foreground'
-                    : 'border-border bg-background text-muted-foreground group-hover:text-foreground'
-                )}
+      {/* Slim icon rail, large screens */}
+      {!hidden && (
+        <nav
+          aria-label="Roadmap stages"
+          className="hidden xl:flex fixed right-4 top-1/2 -translate-y-1/2 z-30 flex-col items-end gap-1"
+        >
+          <button
+            onClick={() => setHidden(true)}
+            aria-label="Hide stage navigation"
+            className="mb-1 flex h-6 w-6 items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground transition-colors hover:text-foreground hover:bg-muted"
+          >
+            <X className="h-3 w-3" />
+          </button>
+          {stages.map((stage) => {
+            const active = activeId === stage.id;
+            return (
+              <button
+                key={stage.id}
+                onClick={() => scrollTo(stage.id)}
+                aria-label={`Jump to ${stage.title}`}
+                aria-current={active ? 'true' : undefined}
+                className="group flex items-center justify-end gap-0"
               >
-                <stage.icon className="h-3.5 w-3.5" />
-              </span>
-              <span
-                className={cn(
-                  'max-w-[9rem] truncate text-xs font-medium transition-colors',
-                  active ? 'text-foreground' : 'text-muted-foreground group-hover:text-foreground'
-                )}
-              >
-                {stage.title}
-              </span>
-            </button>
-          );
-        })}
-      </nav>
+                <span
+                  className={cn(
+                    'pointer-events-none max-w-0 overflow-hidden whitespace-nowrap rounded-l-full border border-r-0 text-xs font-medium opacity-0 transition-all duration-200',
+                    'group-hover:max-w-[11rem] group-hover:px-3 group-hover:py-1.5 group-hover:opacity-100',
+                    'border-border/60 bg-background/95 text-foreground shadow-sm'
+                  )}
+                >
+                  {stage.title}
+                </span>
+                <span
+                  className={cn(
+                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border shadow-sm transition-colors',
+                    active
+                      ? 'border-primary/50 bg-primary text-primary-foreground'
+                      : 'border-border/60 bg-background/90 text-muted-foreground group-hover:text-foreground group-hover:bg-muted'
+                  )}
+                >
+                  <stage.icon className="h-3.5 w-3.5" />
+                </span>
+              </button>
+            );
+          })}
+        </nav>
+      )}
 
-      {/* Horizontal scroller, small and medium screens */}
+      {/* Floating reopen button when hidden */}
+      {hidden && (
+        <button
+          onClick={() => setHidden(false)}
+          aria-label="Show stage navigation"
+          className="hidden xl:flex fixed right-4 bottom-6 z-30 h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-background/95 text-muted-foreground shadow-md transition-colors hover:text-foreground hover:bg-muted"
+        >
+          <Map className="h-4 w-4" />
+        </button>
+      )}
+
+      {/* Horizontal scroller, small and medium screens (in flow, never overlaps) */}
       <nav
         aria-label="Roadmap stages"
         className="xl:hidden sticky top-14 z-30 -mx-4 border-y border-border/50 bg-background/90 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/70"

--- a/components/roadmap-stage-nav.tsx
+++ b/components/roadmap-stage-nav.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { LucideIcon } from 'lucide-react';
+
+interface StageNavItem {
+  id: string;
+  title: string;
+  icon: LucideIcon;
+}
+
+/**
+ * Sticky stage navigator for the roadmap: a vertical rail on large screens,
+ * a horizontal scroller pinned under the header on smaller ones. Highlights
+ * the stage currently in view and scrolls smoothly on click.
+ */
+export function RoadmapStageNav({ stages }: { stages: StageNavItem[] }) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Pick the visible stage closest to the top of the viewport
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActiveId(visible[0].target.id.replace('stage-', ''));
+      },
+      { rootMargin: '-15% 0px -65% 0px' }
+    );
+    for (const stage of stages) {
+      const el = document.getElementById(`stage-${stage.id}`);
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [stages]);
+
+  const scrollTo = (id: string) => {
+    document.getElementById(`stage-${id}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <>
+      {/* Vertical rail, large screens */}
+      <nav
+        aria-label="Roadmap stages"
+        className="hidden xl:flex fixed right-6 top-1/2 -translate-y-1/2 z-30 flex-col gap-1"
+      >
+        {stages.map((stage) => {
+          const active = activeId === stage.id;
+          return (
+            <button
+              key={stage.id}
+              onClick={() => scrollTo(stage.id)}
+              aria-label={`Jump to ${stage.title}`}
+              aria-current={active ? 'true' : undefined}
+              className={cn(
+                'group flex items-center gap-2 rounded-full py-1.5 pl-1.5 pr-3 text-left transition-colors',
+                active ? 'bg-primary/10' : 'hover:bg-muted/60'
+              )}
+            >
+              <span
+                className={cn(
+                  'flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-colors',
+                  active
+                    ? 'border-primary/50 bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-muted-foreground group-hover:text-foreground'
+                )}
+              >
+                <stage.icon className="h-3.5 w-3.5" />
+              </span>
+              <span
+                className={cn(
+                  'max-w-[9rem] truncate text-xs font-medium transition-colors',
+                  active ? 'text-foreground' : 'text-muted-foreground group-hover:text-foreground'
+                )}
+              >
+                {stage.title}
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* Horizontal scroller, small and medium screens */}
+      <nav
+        aria-label="Roadmap stages"
+        className="xl:hidden sticky top-14 z-30 -mx-4 border-y border-border/50 bg-background/90 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/70"
+      >
+        <div className="flex gap-2 overflow-x-auto scrollbar-none">
+          {stages.map((stage) => {
+            const active = activeId === stage.id;
+            return (
+              <button
+                key={stage.id}
+                onClick={() => scrollTo(stage.id)}
+                aria-current={active ? 'true' : undefined}
+                className={cn(
+                  'flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                  active
+                    ? 'border-primary/40 bg-primary/10 text-foreground'
+                    : 'border-border/60 text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                )}
+              >
+                <stage.icon className="h-3 w-3" />
+                {stage.title}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    </>
+  );
+}


### PR DESCRIPTION
Adds a sticky stage navigator (vertical rail on xl, horizontal pinned scroller below; IntersectionObserver highlights the stage in view, click scrolls). Calms the dated effects: pulsing timeline line, hover scale-125 icons, rainbow gradients and pulsing sparkles become the site's amber/primary accents. Removes the client-side document.title override (layout metadata already owns it). Progress tracking intentionally skipped per discussion. Best reviewed on the Cloudflare preview.