### PR TITLE
fix(guide): broken README block in Docker best-practices guide

### DIFF
--- a/content/guides/introduction-to-docker/09-docker-best-practices.md
+++ b/content/guides/introduction-to-docker/09-docker-best-practices.md
@@ -449,19 +449,17 @@ Create a comprehensive README with build and run instructions:
 ## Build
 
     docker build -t myapp .
-```
 
 ## Run
 
-```bash
-docker run -d -p 8000:8000 -e DB_HOST=localhost myapp
-```
+    docker run -d -p 8000:8000 -e DB_HOST=localhost myapp
 
 ## Environment Variables
 
 - `DB_HOST`: Database hostname (required)
 - `PORT`: Application port (default: 8000)
 - `LOG_LEVEL`: Logging level (default: info)
+```
 
 ### Document Image Versions
 


### PR DESCRIPTION
Fixes #1394.

In the "Documentation Best Practices" section of the Docker best-practices guide, the sample README opened a ```markdown fence but closed it right after the "## Build" heading. As a result the "## Run" and "## Environment Variables" parts rendered as real page sections (and the docker run command sat in its own separate bash fence), instead of being one README example, exactly what the issue reported.

Fix: make the whole README sample a single ```markdown block, with the build and run commands as indented code (a nested triple-backtick fence can't live inside a markdown fence without re-breaking it). The section now renders as one cohesive README example. Content-only, data-integrity tests green.
