### PR TITLE
Redesign the interview-questions section

### DIFF
--- a/app/interview-questions/page.tsx
+++ b/app/interview-questions/page.tsx
@@ -1,7 +1,20 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { Briefcase, ChevronRight, Users, TrendingUp, Award, Target, BookOpen, Brain } from 'lucide-react';
-import { interviewQuestions, getAllCategories, getQuestionCountsByTier } from '@/content/interview-questions';
+import {
+  Briefcase,
+  ArrowRight,
+  Users,
+  TrendingUp,
+  Award,
+  Brain,
+  Eye,
+  Target,
+  Layers,
+} from 'lucide-react';
+import {
+  interviewQuestions,
+  getQuestionCountsByTier,
+} from '@/content/interview-questions';
 import { PageHero } from '@/components/page-hero';
 import type { ExperienceTier } from '@/lib/interview-utils';
 
@@ -66,144 +79,185 @@ export const metadata: Metadata = {
 const tierConfig = {
   junior: {
     title: 'Junior',
-    subtitle: '0-2 years',
-    description: 'Linux, Git, Docker basics, CI/CD fundamentals',
+    range: '0-2 years',
+    description: 'Linux, Git, Docker basics, and CI/CD fundamentals.',
     icon: Users,
-    solidBg: 'bg-emerald-500',
-    softBg: 'bg-emerald-50/50 dark:bg-emerald-950/20',
-    borderColor: 'border-emerald-200 dark:border-emerald-800',
-    hoverBorder: 'hover:border-emerald-400 dark:hover:border-emerald-600',
+    dot: 'bg-emerald-500',
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
   },
   mid: {
     title: 'Mid-Level',
-    subtitle: '2-5 years',
-    description: 'Kubernetes, Terraform, monitoring, architecture',
+    range: '2-5 years',
+    description: 'Kubernetes, Terraform, monitoring, and architecture.',
     icon: TrendingUp,
-    solidBg: 'bg-primary',
-    softBg: 'bg-primary/5',
-    borderColor: 'border-primary/30',
-    hoverBorder: 'hover:border-primary/60',
+    dot: 'bg-primary',
+    iconColor: 'text-primary',
   },
   senior: {
     title: 'Senior',
-    subtitle: '5+ years',
-    description: 'System design, incident management, leadership',
+    range: '5+ years',
+    description: 'System design, incident response, and technical leadership.',
     icon: Award,
-    solidBg: 'bg-violet-500',
-    softBg: 'bg-violet-50/50 dark:bg-violet-950/20',
-    borderColor: 'border-violet-200 dark:border-violet-800',
-    hoverBorder: 'hover:border-violet-400 dark:hover:border-violet-600',
+    dot: 'bg-violet-500',
+    iconColor: 'text-violet-600 dark:text-violet-400',
   },
-};
+} as const;
+
+const steps = [
+  {
+    icon: Brain,
+    title: 'Think it through',
+    description: 'Read the prompt and answer out loud, like a real interview.',
+  },
+  {
+    icon: Eye,
+    title: 'Reveal the answer',
+    description: 'Compare against a model answer, code, and common mistakes.',
+  },
+  {
+    icon: Target,
+    title: 'Mark your confidence',
+    description: 'Track what you know and loop back to the weak spots.',
+  },
+];
+
+// Topics covered, derived from the question set so the list stays in sync with
+// content. Sorted by how many questions touch each topic.
+function getTopicCounts(): Array<{ name: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const q of interviewQuestions) {
+    counts.set(q.category, (counts.get(q.category) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
 
 export default function InterviewQuestionsPage() {
-  const categories = getAllCategories();
   const questionsByTier = getQuestionCountsByTier();
+  const topics = getTopicCounts();
+  const tiers = ['junior', 'mid', 'senior'] as ExperienceTier[];
 
   return (
     <div className="min-h-screen">
       <PageHero
         icon={Briefcase}
         title="DevOps Interview Questions"
-        description={`Practice ${interviewQuestions.length} real interview questions with hidden answers. Think through each question, then reveal the sample answer to compare.`}
+        accentWord="Interview"
+        description={`Practice ${interviewQuestions.length} real interview questions with hidden answers. Think through each one, then reveal the model answer to compare.`}
         breadcrumbs={[{ label: 'Interview Questions' }]}
         badge="Mock Interview Practice"
+        stats={[
+          { label: 'questions', value: interviewQuestions.length },
+          { label: 'topics', value: topics.length },
+          { label: 'levels', value: 3 },
+        ]}
       />
 
       <div className="container mx-auto px-4 max-w-4xl py-10">
         {/* How it works */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10">
-          <div className="flex items-start gap-3 p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <div className="p-2 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
-              <Brain className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm">1. Think First</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Read the question and formulate your answer</p>
-            </div>
-          </div>
-          <div className="flex items-start gap-3 p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <div className="p-2 bg-green-100 dark:bg-green-900/50 rounded-lg">
-              <BookOpen className="w-5 h-5 text-green-600 dark:text-green-400" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm">2. Compare</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Reveal the sample answer and key points</p>
-            </div>
-          </div>
-          <div className="flex items-start gap-3 p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-            <div className="p-2 bg-purple-100 dark:bg-purple-900/50 rounded-lg">
-              <Target className="w-5 h-5 text-purple-600 dark:text-purple-400" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm">3. Track Progress</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Mark your confidence level and review weak areas</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Tier List */}
-        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">
-          Choose Your Level
-        </h2>
-        <div className="flex flex-col gap-3">
-          {(['junior', 'mid', 'senior'] as ExperienceTier[]).map((tier) => {
-            const config = tierConfig[tier];
-            const Icon = config.icon;
-            const questionCount = questionsByTier[tier] || 0;
-
-            return (
-              <Link
-                key={tier}
-                href={`/interview-questions/${tier}`}
-                className={`group relative overflow-hidden rounded-xl border-2 ${config.borderColor} ${config.hoverBorder} ${config.softBg} p-4 transition-all duration-300 hover:shadow-lg`}
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className={`flex-shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-lg ${config.solidBg}`}
-                  >
-                    <Icon className="w-5 h-5 text-white" />
+        <section className="mb-12">
+          <p className="text-xs font-mono text-muted-foreground mb-3">// how it works</p>
+          <div className="rounded-md border bg-card divide-y md:divide-y-0 md:divide-x divide-border grid grid-cols-1 md:grid-cols-3">
+            {steps.map((step, i) => {
+              const Icon = step.icon;
+              return (
+                <div key={step.title} className="flex items-start gap-3 p-5">
+                  <div className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-md bg-primary/10 text-primary text-sm font-mono font-semibold">
+                    {i + 1}
                   </div>
-
-                  <div className="flex-grow min-w-0">
-                    <div className="flex items-center gap-2">
-                      <h3 className="text-base font-bold text-gray-900 dark:text-gray-100">
-                        {config.title}
-                      </h3>
-                      <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {config.subtitle}
-                      </span>
-                    </div>
-                    <p className="text-sm text-gray-600 dark:text-gray-300">
-                      {config.description}
+                  <div>
+                    <h3 className="font-semibold text-sm mb-1 flex items-center gap-1.5">
+                      <Icon className="w-4 h-4 text-muted-foreground" strokeWidth={1.5} />
+                      {step.title}
+                    </h3>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      {step.description}
                     </p>
                   </div>
-
-                  <div className="flex-shrink-0 flex items-center gap-3">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                      {questionCount} questions
-                    </span>
-                    <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-primary group-hover:translate-x-1 transition-all" />
-                  </div>
                 </div>
+              );
+            })}
+          </div>
+        </section>
 
-                <div
-                  className={`absolute -right-8 -top-8 w-20 h-20 rounded-full ${config.solidBg} opacity-10 group-hover:opacity-20 transition-opacity`}
-                />
-              </Link>
-            );
-          })}
-        </div>
+        {/* Choose your level */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-mono text-muted-foreground">// choose your level</p>
+          </div>
+          <div className="grid gap-px grid-cols-1 sm:grid-cols-3 bg-border border rounded-md overflow-hidden">
+            {tiers.map((tier) => {
+              const config = tierConfig[tier];
+              const Icon = config.icon;
+              const count = questionsByTier[tier] || 0;
+              return (
+                <Link
+                  key={tier}
+                  href={`/interview-questions/${tier}`}
+                  className="group bg-card p-5 flex flex-col transition-colors hover:bg-muted/40"
+                >
+                  <div className="flex items-center justify-between mb-4">
+                    <Icon
+                      className={`w-5 h-5 ${config.iconColor}`}
+                      strokeWidth={1.5}
+                    />
+                    <span className="flex items-center gap-1.5 text-[10px] font-mono text-muted-foreground/80 uppercase tracking-wider">
+                      <span className={`w-1.5 h-1.5 rounded-full ${config.dot}`} />
+                      {config.range}
+                    </span>
+                  </div>
+                  <h3 className="font-semibold text-base mb-1 group-hover:text-primary transition-colors">
+                    {config.title}
+                  </h3>
+                  <p className="text-muted-foreground text-sm leading-relaxed flex-1">
+                    {config.description}
+                  </p>
+                  <div className="flex items-center justify-between mt-4 pt-3 border-t border-border/60">
+                    <span className="text-xs font-mono text-muted-foreground">
+                      {count} questions
+                    </span>
+                    <ArrowRight className="w-4 h-4 text-muted-foreground transition-all group-hover:text-primary group-hover:translate-x-1" />
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
 
-        {/* Note about quizzes */}
-        <div className="mt-8 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-          <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
-            Want to test your knowledge with scored assessments?{' '}
-            <Link href="/quizzes" className="text-primary hover:underline font-medium">
-              Take our DevOps Quizzes
-            </Link>
+        {/* Topics covered */}
+        <section className="mb-12">
+          <p className="text-xs font-mono text-muted-foreground mb-3 flex items-center gap-1.5">
+            <Layers className="w-3.5 h-3.5" strokeWidth={1.5} />
+            <span>// topics covered</span>
           </p>
-        </div>
+          <div className="flex flex-wrap gap-2">
+            {topics.map((topic) => (
+              <span
+                key={topic.name}
+                className="inline-flex items-center gap-1.5 rounded-md border bg-card px-2.5 py-1 text-xs"
+              >
+                <span className="text-foreground">{topic.name}</span>
+                <span className="font-mono text-muted-foreground/70">{topic.count}</span>
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* Cross-links */}
+        <section className="rounded-md border bg-muted/20 p-5 text-center">
+          <p className="text-sm text-muted-foreground">
+            Prefer scored assessments? Try the{' '}
+            <Link href="/quizzes" className="text-primary hover:underline font-medium">
+              DevOps quizzes
+            </Link>{' '}
+            or drill concepts with{' '}
+            <Link href="/flashcards" className="text-primary hover:underline font-medium">
+              flashcards
+            </Link>
+            .
+          </p>
+        </section>
       </div>
     </div>
   );

--- a/components/interview-questions/interview-question-page.tsx
+++ b/components/interview-questions/interview-question-page.tsx
@@ -1,179 +1,168 @@
 'use client';
 
 import { InterviewQuestion, ExperienceTier } from '@/lib/interview-utils';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { getDifficultyColor } from '@/lib/interview-utils';
 import { Button } from '@/components/ui/button';
 import { CodeBlock } from '@/components/code-block-wrapper';
 import Link from 'next/link';
-import { ArrowLeft, BookOpen, Lightbulb, AlertTriangle, Tag } from 'lucide-react';
+import { ArrowLeft, BookOpen, Lightbulb, AlertTriangle, Code, ArrowRight } from 'lucide-react';
 
 interface InterviewQuestionPageProps {
   question: InterviewQuestion;
   tier: ExperienceTier;
 }
 
-const tierColors = {
-  junior: 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400',
-  mid: 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400',
-  senior: 'bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400',
-};
-
-const difficultyColors = {
-  beginner: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400',
-  intermediate: 'bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400',
-  advanced: 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400',
+const tierLabels: Record<ExperienceTier, string> = {
+  junior: 'Junior',
+  mid: 'Mid-Level',
+  senior: 'Senior',
 };
 
 export function InterviewQuestionPage({ question, tier }: InterviewQuestionPageProps) {
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
-      {/* Back button */}
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
+      {/* Back */}
       <div className="mb-6">
-        <Button variant="ghost" asChild className="-ml-4">
+        <Button variant="ghost" asChild className="-ml-3 text-muted-foreground">
           <Link href={`/interview-questions/${tier}`}>
             <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to {tier} questions
+            Back to {tierLabels[tier]} questions
           </Link>
         </Button>
       </div>
 
-      {/* Title lives in <PageHero>; we keep only the badge row here so the
-          title does not render twice (Bing's SEO scanner counted the
-          large-text duplicate as a second H1). */}
-      <div className="mb-8 flex flex-wrap gap-2">
-        <Badge className={tierColors[tier]}>{tier}</Badge>
-        <Badge className={difficultyColors[question.difficulty as keyof typeof difficultyColors]}>
+      {/* Meta row. Title itself lives in <PageHero> to avoid a duplicate H1. */}
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        <span className="px-2.5 py-0.5 text-xs font-mono rounded-md border bg-muted/50 text-muted-foreground">
+          {tierLabels[tier]}
+        </span>
+        <span
+          className={`px-2.5 py-0.5 text-xs font-medium rounded-md ${getDifficultyColor(question.difficulty)}`}
+        >
           {question.difficulty}
-        </Badge>
-        <Badge variant="outline">{question.category}</Badge>
+        </span>
+        <span className="px-2.5 py-0.5 text-xs font-mono rounded-md border bg-muted/50 text-muted-foreground">
+          {question.category}
+        </span>
       </div>
 
       {/* Question */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="text-xl">Question</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-lg leading-relaxed">{question.question}</p>
-        </CardContent>
-      </Card>
+      <div className="rounded-md border bg-muted/30 p-5 sm:p-6 mb-8">
+        <p className="text-xs font-mono text-primary mb-2 flex items-center gap-1.5">
+          <Lightbulb className="w-3.5 h-3.5" strokeWidth={1.5} />
+          // question
+        </p>
+        <p className="text-lg leading-relaxed text-foreground">{question.question}</p>
+      </div>
 
       {/* Answer */}
-      <Card className="mb-6">
-        <CardHeader>
-          <CardTitle className="text-xl">Answer</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="leading-relaxed whitespace-pre-line">{question.answer}</p>
-        </CardContent>
-      </Card>
+      <section className="mb-8">
+        <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-3">
+          Answer
+        </h2>
+        <div className="prose prose-neutral dark:prose-invert max-w-none prose-p:leading-relaxed">
+          {question.answer.split('\n\n').map((para, i) => (
+            <p key={i} className="whitespace-pre-line">
+              {para}
+            </p>
+          ))}
+        </div>
+      </section>
 
-      {/* Explanation */}
+      {/* Why this matters */}
       {question.explanation && (
-        <Card className="mb-6 border-blue-200 dark:border-blue-900">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <Lightbulb className="w-5 h-5 text-blue-500" />
-              Why This Matters
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="leading-relaxed">{question.explanation}</p>
-          </CardContent>
-        </Card>
+        <section className="mb-8">
+          <div className="rounded-md border border-primary/30 bg-primary/[0.06] p-5">
+            <h2 className="text-sm font-semibold mb-2 flex items-center gap-2 text-primary">
+              <Lightbulb className="w-4 h-4" strokeWidth={1.5} />
+              Why this matters
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line">
+              {question.explanation}
+            </p>
+          </div>
+        </section>
       )}
 
-      {/* Code Examples */}
+      {/* Code examples */}
       {question.codeExamples && question.codeExamples.length > 0 && (
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="text-xl">Code Examples</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+        <section className="mb-8">
+          <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
+            <Code className="w-3.5 h-3.5" strokeWidth={1.5} />
+            Code examples
+          </h2>
+          <div className="space-y-4">
             {question.codeExamples.map((example, index) => (
               <div key={index}>
                 {example.label && (
-                  <p className="text-sm font-medium mb-2 text-muted-foreground">{example.label}</p>
+                  <p className="text-sm text-muted-foreground mb-2">{example.label}</p>
                 )}
-                <CodeBlock code={example.code} language={example.language} />
+                <CodeBlock language={example.language}>{example.code}</CodeBlock>
               </div>
             ))}
-          </CardContent>
-        </Card>
+          </div>
+        </section>
       )}
 
-      {/* Common Mistakes */}
+      {/* Common mistakes */}
       {question.commonMistakes && question.commonMistakes.length > 0 && (
-        <Card className="mb-6 border-orange-200 dark:border-orange-900">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <AlertTriangle className="w-5 h-5 text-orange-500" />
-              Common Mistakes
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="list-disc list-inside space-y-2">
+        <section className="mb-8">
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/[0.06] p-5">
+            <h2 className="text-sm font-semibold mb-2 flex items-center gap-2 text-amber-700 dark:text-amber-400">
+              <AlertTriangle className="w-4 h-4" strokeWidth={1.5} />
+              Common mistakes
+            </h2>
+            <ul className="space-y-1.5">
               {question.commonMistakes.map((mistake, index) => (
-                <li key={index} className="leading-relaxed">
+                <li key={index} className="text-sm text-muted-foreground leading-relaxed">
                   {mistake}
                 </li>
               ))}
             </ul>
-          </CardContent>
-        </Card>
+          </div>
+        </section>
       )}
 
-      {/* Follow-up Questions */}
+      {/* Follow-up questions */}
       {question.followUpQuestions && question.followUpQuestions.length > 0 && (
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <BookOpen className="w-5 h-5" />
-              Follow-up Questions
-            </CardTitle>
-            <CardDescription>
-              Interviewers often ask these as follow-up questions
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ul className="list-disc list-inside space-y-2">
-              {question.followUpQuestions.map((followUp, index) => (
-                <li key={index} className="leading-relaxed">
-                  {followUp}
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
+        <section className="mb-8">
+          <h2 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
+            <BookOpen className="w-3.5 h-3.5" strokeWidth={1.5} />
+            Likely follow-ups
+          </h2>
+          <ul className="space-y-2">
+            {question.followUpQuestions.map((followUp, index) => (
+              <li key={index} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <ArrowRight className="w-3.5 h-3.5 text-primary flex-shrink-0 mt-1" strokeWidth={1.5} />
+                {followUp}
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       {/* Tags */}
       {question.tags && question.tags.length > 0 && (
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-xl">
-              <Tag className="w-5 h-5" />
-              Tags
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {question.tags.map((tag) => (
-                <Badge key={tag} variant="secondary">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <section className="mb-8 pt-6 border-t">
+          <div className="flex flex-wrap gap-2">
+            {question.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-md border bg-card px-2.5 py-1 text-xs font-mono text-muted-foreground"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        </section>
       )}
 
-      {/* Navigation */}
-      <div className="mt-8 flex justify-center">
-        <Button asChild>
+      {/* Footer nav */}
+      <div className="flex justify-center pt-2">
+        <Button asChild variant="outline">
           <Link href={`/interview-questions/${tier}`}>
-            View all {tier} questions
+            View all {tierLabels[tier]} questions
+            <ArrowRight className="w-4 h-4 ml-2" />
           </Link>
         </Button>
       </div>

--- a/components/interview-questions/interview-tier-page.tsx
+++ b/components/interview-questions/interview-tier-page.tsx
@@ -1,29 +1,24 @@
 'use client';
 
 import { useState, useMemo, useEffect } from 'react';
-import Link from 'next/link';
 import {
-  ArrowLeft,
   ChevronLeft,
   ChevronRight,
   Code,
   AlertTriangle,
   CheckCircle,
   XCircle,
-  Users,
-  TrendingUp,
-  Award,
   Shuffle,
   Eye,
   EyeOff,
   Lightbulb,
-  BookOpen,
   RotateCcw,
   Square,
   CheckSquare,
+  ArrowRight,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { CodeBlockWrapper } from '@/components/code-block-wrapper';
+import { CodeBlock } from '@/components/code-block-wrapper';
 import type { InterviewQuestion, ExperienceTier } from '@/lib/interview-utils';
 import {
   getDifficultyColor,
@@ -32,58 +27,35 @@ import {
   resetInterviewProgress,
 } from '@/lib/interview-utils';
 
-const tierConfig = {
-  junior: {
-    title: 'Junior',
-    subtitle: '0-2 years experience',
-    icon: Users,
-    gradient: 'bg-emerald-500',
-    accentColor: 'text-emerald-600 dark:text-emerald-400',
-    bgColor: 'bg-emerald-50 dark:bg-emerald-950/30',
-  },
-  mid: {
-    title: 'Mid-Level',
-    subtitle: '2-5 years experience',
-    icon: TrendingUp,
-    gradient: 'bg-primary',
-    accentColor: 'text-primary',
-    bgColor: 'bg-primary/10',
-  },
-  senior: {
-    title: 'Senior',
-    subtitle: '5+ years experience',
-    icon: Award,
-    gradient: 'bg-violet-500',
-    accentColor: 'text-violet-600 dark:text-violet-400',
-    bgColor: 'bg-violet-50 dark:bg-violet-950/30',
-  },
-};
-
 interface InterviewTierPageProps {
   tier: ExperienceTier;
   questions: InterviewQuestion[];
   categories: string[];
 }
 
-function PracticeCard({ question, onComplete }: { question: InterviewQuestion; onComplete: (confident: boolean) => void }) {
+function PracticeCard({
+  question,
+  onComplete,
+}: {
+  question: InterviewQuestion;
+  onComplete: (confident: boolean) => void;
+}) {
   const [showAnswer, setShowAnswer] = useState(false);
   const [checkedPoints, setCheckedPoints] = useState<Set<number>>(new Set());
-  
-  // Key points extracted from the answer for self-evaluation
+
+  // Key points extracted from the answer for self-evaluation.
   const keyPoints = useMemo(() => {
-    // Split answer into sentences and take first few as key points
-    const sentences = question.answer.split(/[.!]/).filter(s => s.trim().length > 10);
-    return sentences.slice(0, 4).map(s => s.trim());
+    const sentences = question.answer.split(/[.!]/).filter((s) => s.trim().length > 10);
+    return sentences.slice(0, 4).map((s) => s.trim());
   }, [question.answer]);
 
   const togglePoint = (index: number) => {
-    const newChecked = new Set(checkedPoints);
-    if (newChecked.has(index)) {
-      newChecked.delete(index);
-    } else {
-      newChecked.add(index);
-    }
-    setCheckedPoints(newChecked);
+    setCheckedPoints((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
   };
 
   const handleComplete = (confident: boolean) => {
@@ -93,151 +65,154 @@ function PracticeCard({ question, onComplete }: { question: InterviewQuestion; o
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden shadow-lg">
+    <div className="rounded-md border bg-card overflow-hidden">
       {/* Header */}
-      <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex flex-wrap items-center gap-2 mb-4">
-          <span className="px-3 py-1 text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">
+      <div className="p-5 sm:p-6 border-b">
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <span className="px-2.5 py-0.5 text-xs font-mono rounded-md border bg-muted/50 text-muted-foreground">
             {question.category}
           </span>
-          <span className={`px-3 py-1 text-sm font-medium rounded-full ${getDifficultyColor(question.difficulty)}`}>
+          <span
+            className={`px-2.5 py-0.5 text-xs font-medium rounded-md ${getDifficultyColor(question.difficulty)}`}
+          >
             {question.difficulty}
           </span>
         </div>
-        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
-          {question.title}
-        </h2>
+        <h2 className="text-lg sm:text-xl font-bold">{question.title}</h2>
       </div>
 
-      {/* Question */}
-      <div className="p-6 bg-primary/5">
-        <div className="flex items-start gap-3">
-          <div className="p-2 bg-primary/10 rounded-lg">
-            <Lightbulb className="w-5 h-5 text-primary" />
-          </div>
-          <div>
-            <p className="text-sm font-medium text-primary mb-2">Interview Question</p>
-            <p className="text-lg text-gray-800 dark:text-gray-200 leading-relaxed">
-              {question.question}
-            </p>
-          </div>
-        </div>
+      {/* Question prompt */}
+      <div className="p-5 sm:p-6 bg-muted/30 border-b">
+        <p className="text-xs font-mono text-primary mb-2 flex items-center gap-1.5">
+          <Lightbulb className="w-3.5 h-3.5" strokeWidth={1.5} />
+          // interview question
+        </p>
+        <p className="text-base sm:text-lg leading-relaxed text-foreground">
+          {question.question}
+        </p>
       </div>
 
-      {/* Practice Area */}
+      {/* Practice area */}
       {!showAnswer ? (
-        <div className="p-6">
-          <div className="text-center py-8">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full mb-4">
-              <EyeOff className="w-8 h-8 text-gray-400" />
-            </div>
-            <p className="text-gray-600 dark:text-gray-400 mb-2">
-              Take a moment to formulate your answer
-            </p>
-            <p className="text-sm text-gray-500 dark:text-gray-500 mb-6">
-              Think about the key points you would mention in an interview
-            </p>
-            <Button
-              onClick={() => setShowAnswer(true)}
-            >
-              <Eye className="w-4 h-4 mr-2" />
-              Reveal Sample Answer
-            </Button>
+        <div className="px-6 py-10 text-center">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-muted mb-4">
+            <EyeOff className="w-6 h-6 text-muted-foreground" strokeWidth={1.5} />
           </div>
+          <p className="text-sm text-foreground mb-1">Take a moment to answer out loud.</p>
+          <p className="text-sm text-muted-foreground mb-6">
+            Think through the key points you would mention, then reveal the model answer.
+          </p>
+          <Button onClick={() => setShowAnswer(true)}>
+            <Eye className="w-4 h-4 mr-2" />
+            Reveal sample answer
+          </Button>
         </div>
       ) : (
-        <div className="p-6 space-y-6">
-          {/* Sample Answer */}
+        <div className="p-5 sm:p-6 space-y-6">
+          {/* Sample answer */}
           <div>
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3 flex items-center gap-2">
-              <BookOpen className="w-4 h-4" />
-              Sample Answer
+            <h3 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-2">
+              Sample answer
             </h3>
-            <div className="p-4 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded-lg">
-              <p className="text-gray-800 dark:text-gray-200 leading-relaxed">
+            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/[0.06] p-4">
+              <p className="leading-relaxed whitespace-pre-line text-foreground/90">
                 {question.answer}
               </p>
             </div>
           </div>
 
-          {/* Explanation */}
+          {/* Why this matters */}
           {question.explanation && (
-            <div>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3">
-                Why This Matters
+            <div className="rounded-md border border-primary/30 bg-primary/[0.06] p-4">
+              <h3 className="text-sm font-semibold mb-1.5 flex items-center gap-2 text-primary">
+                <Lightbulb className="w-4 h-4" strokeWidth={1.5} />
+                Why this matters
               </h3>
-              <p className="text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-muted-foreground leading-relaxed">
                 {question.explanation}
               </p>
             </div>
           )}
 
-          {/* Self-Evaluation Checklist */}
-          <div>
-            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3">
-              Self-Evaluation: Did you mention these points?
-            </h3>
-            <div className="space-y-2">
-              {keyPoints.map((point, index) => (
-                <button
-                  key={index}
-                  onClick={() => togglePoint(index)}
-                  className={`w-full text-left p-3 rounded-lg border transition-all flex items-start gap-3 ${
-                    checkedPoints.has(index)
-                      ? 'bg-green-50 dark:bg-green-950/30 border-green-300 dark:border-green-700'
-                      : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
-                  }`}
-                >
-                  {checkedPoints.has(index) ? (
-                    <CheckSquare className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
-                  ) : (
-                    <Square className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" />
-                  )}
-                  <span className={`text-sm ${
-                    checkedPoints.has(index)
-                      ? 'text-green-800 dark:text-green-300'
-                      : 'text-gray-700 dark:text-gray-300'
-                  }`}>
-                    {point}
-                  </span>
-                </button>
-              ))}
+          {/* Self-evaluation checklist */}
+          {keyPoints.length > 0 && (
+            <div>
+              <h3 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-2">
+                Self-check: did you mention these?
+              </h3>
+              <div className="space-y-2">
+                {keyPoints.map((point, index) => {
+                  const checked = checkedPoints.has(index);
+                  return (
+                    <button
+                      key={index}
+                      onClick={() => togglePoint(index)}
+                      className={`w-full text-left p-3 rounded-md border transition-colors flex items-start gap-3 ${
+                        checked
+                          ? 'bg-emerald-500/[0.08] border-emerald-500/40'
+                          : 'bg-card border-border hover:border-primary/30'
+                      }`}
+                    >
+                      {checked ? (
+                        <CheckSquare
+                          className="w-4 h-4 text-emerald-600 dark:text-emerald-400 flex-shrink-0 mt-0.5"
+                          strokeWidth={1.5}
+                        />
+                      ) : (
+                        <Square
+                          className="w-4 h-4 text-muted-foreground flex-shrink-0 mt-0.5"
+                          strokeWidth={1.5}
+                        />
+                      )}
+                      <span
+                        className={`text-sm ${checked ? 'text-foreground' : 'text-muted-foreground'}`}
+                      >
+                        {point}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
+          )}
 
-          {/* Code Examples */}
+          {/* Code examples */}
           {question.codeExamples && question.codeExamples.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3 flex items-center gap-2">
-                <Code className="w-4 h-4" />
-                Code Examples
+              <h3 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-2 flex items-center gap-2">
+                <Code className="w-3.5 h-3.5" strokeWidth={1.5} />
+                Code examples
               </h3>
               <div className="space-y-4">
                 {question.codeExamples.map((example, index) => (
                   <div key={index}>
                     {example.label && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{example.label}</p>
+                      <p className="text-sm text-muted-foreground mb-2">{example.label}</p>
                     )}
-                    <CodeBlockWrapper language={example.language}>
-                      {example.code}
-                    </CodeBlockWrapper>
+                    <CodeBlock language={example.language}>{example.code}</CodeBlock>
                   </div>
                 ))}
               </div>
             </div>
           )}
 
-          {/* Common Mistakes */}
+          {/* Common mistakes */}
           {question.commonMistakes && question.commonMistakes.length > 0 && (
-            <div>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3 flex items-center gap-2">
-                <AlertTriangle className="w-4 h-4 text-amber-500" />
-                Common Mistakes to Avoid
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/[0.06] p-4">
+              <h3 className="text-sm font-semibold mb-2 flex items-center gap-2 text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="w-4 h-4" strokeWidth={1.5} />
+                Common mistakes to avoid
               </h3>
-              <ul className="space-y-2">
+              <ul className="space-y-1.5">
                 {question.commonMistakes.map((mistake, index) => (
-                  <li key={index} className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400">
-                    <XCircle className="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" />
+                  <li
+                    key={index}
+                    className="flex items-start gap-2 text-sm text-muted-foreground"
+                  >
+                    <XCircle
+                      className="w-4 h-4 text-amber-600/70 dark:text-amber-400/70 flex-shrink-0 mt-0.5"
+                      strokeWidth={1.5}
+                    />
                     {mistake}
                   </li>
                 ))}
@@ -245,16 +220,22 @@ function PracticeCard({ question, onComplete }: { question: InterviewQuestion; o
             </div>
           )}
 
-          {/* Follow-up Questions */}
+          {/* Follow-up questions */}
           {question.followUpQuestions && question.followUpQuestions.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3">
-                Possible Follow-up Questions
+              <h3 className="text-xs font-mono text-muted-foreground uppercase tracking-wide mb-2">
+                Likely follow-ups
               </h3>
-              <ul className="space-y-2">
+              <ul className="space-y-1.5">
                 {question.followUpQuestions.map((fq, index) => (
-                  <li key={index} className="flex items-start gap-2 text-sm text-gray-600 dark:text-gray-400">
-                    <span className="text-primary">→</span>
+                  <li
+                    key={index}
+                    className="flex items-start gap-2 text-sm text-muted-foreground"
+                  >
+                    <ArrowRight
+                      className="w-3.5 h-3.5 text-primary flex-shrink-0 mt-1"
+                      strokeWidth={1.5}
+                    />
                     {fq}
                   </li>
                 ))}
@@ -262,27 +243,27 @@ function PracticeCard({ question, onComplete }: { question: InterviewQuestion; o
             </div>
           )}
 
-          {/* Self-Assessment */}
-          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 text-center">
-              How confident do you feel about this question?
+          {/* Self-assessment */}
+          <div className="pt-4 border-t">
+            <p className="text-sm text-muted-foreground mb-3 text-center">
+              How confident do you feel about this one?
             </p>
             <div className="flex gap-3 justify-center">
               <Button
                 onClick={() => handleComplete(true)}
                 variant="outline"
-                className="flex-1 max-w-[200px] border-green-300 dark:border-green-700 text-green-700 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-950/30"
+                className="flex-1 max-w-[200px] border-emerald-500/40 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-500/10"
               >
                 <CheckCircle className="w-4 h-4 mr-2" />
-                Got It
+                Got it
               </Button>
               <Button
                 onClick={() => handleComplete(false)}
                 variant="outline"
-                className="flex-1 max-w-[200px] border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-950/30"
+                className="flex-1 max-w-[200px] border-amber-500/40 text-amber-700 dark:text-amber-400 hover:bg-amber-500/10"
               >
                 <RotateCcw className="w-4 h-4 mr-2" />
-                Need Review
+                Need review
               </Button>
             </div>
           </div>
@@ -293,46 +274,38 @@ function PracticeCard({ question, onComplete }: { question: InterviewQuestion; o
 }
 
 export function InterviewTierPage({ tier, questions, categories }: InterviewTierPageProps) {
-  const config = tierConfig[tier];
-  const Icon = config.icon;
-  
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [displayQuestions, setDisplayQuestions] = useState<InterviewQuestion[]>([]);
-  const [progress, setProgress] = useState<Record<string, { reviewed: boolean; confident: boolean }>>({});
+  const [progress, setProgress] = useState<
+    Record<string, { reviewed: boolean; confident: boolean }>
+  >({});
 
-  // Load progress on mount
   useEffect(() => {
     setProgress(getInterviewProgress());
   }, []);
 
-  // Filter questions by category
   const filteredQuestions = useMemo(() => {
-    return questions.filter((q) => {
-      return !selectedCategory || q.category === selectedCategory;
-    });
+    return questions.filter((q) => !selectedCategory || q.category === selectedCategory);
   }, [questions, selectedCategory]);
 
-  // Initialize display questions when filtered questions change
   useEffect(() => {
     setDisplayQuestions(filteredQuestions);
     setCurrentIndex(0);
   }, [filteredQuestions]);
 
   const currentQuestion = displayQuestions[currentIndex];
-  
-  const completedCount = Object.values(progress).filter(p => p.reviewed).length;
-  const confidentCount = Object.values(progress).filter(p => p.confident).length;
+
+  const completedCount = Object.values(progress).filter((p) => p.reviewed).length;
+  const confidentCount = Object.values(progress).filter((p) => p.confident).length;
+  const pct = questions.length ? Math.round((completedCount / questions.length) * 100) : 0;
 
   const handleQuestionComplete = (confident: boolean) => {
-    if (currentQuestion) {
-      markQuestionReviewed(currentQuestion.id, confident);
-      setProgress(getInterviewProgress());
-      
-      // Auto-advance to next question
-      if (currentIndex < displayQuestions.length - 1) {
-        setCurrentIndex(currentIndex + 1);
-      }
+    if (!currentQuestion) return;
+    markQuestionReviewed(currentQuestion.id, confident);
+    setProgress(getInterviewProgress());
+    if (currentIndex < displayQuestions.length - 1) {
+      setCurrentIndex(currentIndex + 1);
     }
   };
 
@@ -352,81 +325,80 @@ export function InterviewTierPage({ tier, questions, categories }: InterviewTier
   return (
     <div className="min-h-screen">
       <div className="container mx-auto px-4 max-w-4xl py-8">
-        {/* Progress Bar */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 mb-6 border border-gray-200 dark:border-gray-700">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Progress: {completedCount} of {questions.length} practiced
+        {/* Progress */}
+        <div className="rounded-md border bg-card p-4 mb-5">
+          <div className="flex items-center justify-between mb-2 text-sm">
+            <span className="font-medium">
+              {completedCount} of {questions.length} practiced
             </span>
-            <span className="text-sm text-green-600 dark:text-green-400">
-              {confidentCount} confident
+            <span className="font-mono text-xs text-muted-foreground">
+              {confidentCount} confident &middot; {pct}%
             </span>
           </div>
-          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-            <div 
-              className="h-full bg-gradient-to-r from-green-500 to-emerald-500 transition-all duration-300"
-              style={{ width: `${(completedCount / questions.length) * 100}%` }}
+          <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+            <div
+              className="h-full bg-primary transition-all duration-300"
+              style={{ width: `${pct}%` }}
             />
           </div>
         </div>
 
         {/* Controls */}
-       <div className="flex flex-wrap gap-4 mb-6">
-          {/* Category filter */}
+        <div className="flex flex-wrap items-center gap-2 mb-5">
           <select
             value={selectedCategory || ''}
             onChange={(e) => {
               setSelectedCategory(e.target.value || null);
               setCurrentIndex(0);
             }}
-            className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            className="px-3 py-2 bg-background border border-input rounded-md text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+            aria-label="Filter by category"
           >
-            <option value="">All Categories</option>
+            <option value="">All categories</option>
             {categories.map((cat) => (
-              <option key={cat} value={cat}>{cat}</option>
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
             ))}
           </select>
-
-          {/* Shuffle button */}
-          <Button
-            onClick={handleShuffle}
-            variant="outline"
-          >
+          <Button onClick={handleShuffle} variant="outline" size="sm">
             <Shuffle className="w-4 h-4 mr-2" />
             Shuffle
           </Button>
-
-          {/* Reset button */}
-          <Button onClick={handleReset} variant="outline">
+          <Button onClick={handleReset} variant="outline" size="sm">
             <RotateCcw className="w-4 h-4 mr-2" />
             Reset
           </Button>
         </div>
 
-        {/* Question Navigation */}
-        <div className="flex items-center justify-between mb-6">
+        {/* Question navigation */}
+        <div className="flex items-center justify-between mb-5">
           <Button
-           onClick={() => setCurrentIndex(Math.max(0, currentIndex - 1))}
-           disabled={currentIndex === 0}
-           variant="outline"
-         >
-            <ChevronLeft className="w-4 h-4 mr-2" />
-           Previous
-        </Button>
-        <span className="text-sm text-gray-600 dark:text-gray-400">
-           Question {currentIndex + 1} of {displayQuestions.length}
-        </span>
-        <Button
-           onClick={() => setCurrentIndex(Math.min(displayQuestions.length - 1, currentIndex + 1))}
-           disabled={currentIndex === displayQuestions.length - 1}
-           variant="outline"
-         >
-           Next
-            <ChevronRight className="w-4 h-4 ml-2" />
-         </Button>
+            onClick={() => setCurrentIndex(Math.max(0, currentIndex - 1))}
+            disabled={currentIndex === 0}
+            variant="outline"
+            size="sm"
+          >
+            <ChevronLeft className="w-4 h-4 mr-1" />
+            Previous
+          </Button>
+          <span className="text-sm font-mono text-muted-foreground">
+            {displayQuestions.length ? currentIndex + 1 : 0} / {displayQuestions.length}
+          </span>
+          <Button
+            onClick={() =>
+              setCurrentIndex(Math.min(displayQuestions.length - 1, currentIndex + 1))
+            }
+            disabled={currentIndex >= displayQuestions.length - 1}
+            variant="outline"
+            size="sm"
+          >
+            Next
+            <ChevronRight className="w-4 h-4 ml-1" />
+          </Button>
         </div>
 
-        {/* Current Question Card */}
+        {/* Current question */}
         {currentQuestion ? (
           <PracticeCard
             key={currentQuestion.id}
@@ -434,49 +406,48 @@ export function InterviewTierPage({ tier, questions, categories }: InterviewTier
             onComplete={handleQuestionComplete}
           />
         ) : (
-          <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
-            <p className="text-gray-500 dark:text-gray-400">No questions match your filters.</p>
+          <div className="text-center py-12 rounded-md border bg-card">
+            <p className="text-sm text-muted-foreground">No questions match your filter.</p>
           </div>
         )}
 
-        {/* Question List (Quick Jump) */}
-        <div className="mt-8">
-          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">
-            All Questions
-          </h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {displayQuestions.map((q, index) => {
-              const isCompleted = progress[q.id]?.reviewed;
-              const isConfident = progress[q.id]?.confident;
-              const isCurrent = index === currentIndex;
-              
-              return (
-                <button
-                  key={q.id}
-                  onClick={() => setCurrentIndex(index)}
-                  className={`text-left p-3 rounded-lg border transition-all flex items-center gap-3 ${
-                    isCurrent
-                      ? 'bg-primary/10 border-primary/30'
-                      : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
-                  }`}
-                >
-                  <span className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium ${
-                    isConfident
-                      ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-400'
-                      : isCompleted
-                        ? 'bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-400'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
-                  }`}>
-                    {isConfident ? '✓' : isCompleted ? '?' : index + 1}
-                  </span>
-                  <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                    {q.title}
-                  </span>
-                </button>
-              );
-            })}
+        {/* Quick jump */}
+        {displayQuestions.length > 0 && (
+          <div className="mt-8">
+            <p className="text-xs font-mono text-muted-foreground mb-3">// jump to a question</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {displayQuestions.map((q, index) => {
+                const isCompleted = progress[q.id]?.reviewed;
+                const isConfident = progress[q.id]?.confident;
+                const isCurrent = index === currentIndex;
+                return (
+                  <button
+                    key={q.id}
+                    onClick={() => setCurrentIndex(index)}
+                    className={`text-left p-3 rounded-md border transition-colors flex items-center gap-3 ${
+                      isCurrent
+                        ? 'bg-primary/10 border-primary/40'
+                        : 'bg-card border-border hover:border-primary/30'
+                    }`}
+                  >
+                    <span
+                      className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-mono font-medium ${
+                        isConfident
+                          ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                          : isCompleted
+                            ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+                            : 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {isConfident ? '✓' : isCompleted ? '?' : index + 1}
+                    </span>
+                    <span className="text-sm text-foreground truncate">{q.title}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Reworks all three interview-questions views to use the site's design tokens instead of hardcoded gray/blue/green/purple, so the section matches the rest of the site in both light and dark mode.

- **Index**: tighter how-it-works strip, a seamless tier-card grid, a new topics-covered overview derived from the question set, and hero stats.
- **Tier practice**: token-based progress bar and controls, a cleaner reveal flow, and callout-style blocks for the model answer, why-it-matters, and common mistakes.
- **Question detail**: question/answer/callout hierarchy that mirrors the practice card; code blocks now use the labelled CodeBlock (fixes a latent prop bug where the language label was dropped).