### PR TITLE
Only generate tag pages for tags used by 2+ items

### DIFF
--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema, TechArticleSchema } from '@/components/schema-markup';
 import { tagToSlug } from '@/lib/tag-utils';
+import { getLinkableTagSlugs } from '@/lib/tags';
 import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { GuidePartNavigation } from '@/components/guide-part-navigation';
 import { ReportIssue } from '@/components/report-issue';
@@ -133,6 +134,8 @@ export default async function GuidePartPage({
     },
   ];
 
+  const linkableTags = await getLinkableTagSlugs();
+
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
@@ -219,14 +222,20 @@ export default async function GuidePartPage({
                         <div className="flex flex-wrap gap-2">
                           {guide.tags.map((tag) => {
                             const tagSlug = tagToSlug(tag);
-                            return (
+                            const base =
+                              'px-3 py-1 text-sm rounded-full bg-secondary text-secondary-foreground';
+                            return linkableTags.has(tagSlug) ? (
                               <a
                                 key={tag}
                                 href={`/tags/${tagSlug}`}
-                                className="px-3 py-1 text-sm transition-colors rounded-full bg-secondary text-secondary-foreground hover:bg-primary/40 hover:text-primary-foreground"
+                                className={`${base} transition-colors hover:bg-primary/40 hover:text-primary-foreground`}
                               >
                                 {tag}
                               </a>
+                            ) : (
+                              <span key={tag} className={base}>
+                                {tag}
+                              </span>
                             );
                           })}
                         </div>

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema, TechArticleSchema } from '@/components/schema-markup';
 import { tagToSlug } from '@/lib/tag-utils';
+import { getLinkableTagSlugs } from '@/lib/tags';
 import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { GuidePartNavigation } from '@/components/guide-part-navigation';
 import { ReportIssue } from '@/components/report-issue';
@@ -83,6 +84,8 @@ export default async function GuidePage({ params }: { params: Promise<{ slug: st
     { name: guide.title, url: `/guides/${guide.slug}` },
   ];
 
+  const linkableTags = await getLinkableTagSlugs();
+
   return (
     <>
       <BreadcrumbSchema items={schemaItems} />
@@ -142,14 +145,20 @@ export default async function GuidePage({ params }: { params: Promise<{ slug: st
                     <div className="flex flex-wrap gap-2">
                       {guide.tags.map((tag) => {
                         const tagSlug = tagToSlug(tag);
-                        return (
+                        const base =
+                          'px-3 py-1 text-sm rounded-full bg-secondary text-secondary-foreground';
+                        return linkableTags.has(tagSlug) ? (
                           <a
                             key={tag}
                             href={`/tags/${tagSlug}`}
-                            className="px-3 py-1 text-sm transition-colors rounded-full bg-secondary text-secondary-foreground hover:bg-primary/40 hover:text-primary-foreground"
+                            className={`${base} transition-colors hover:bg-primary/40 hover:text-primary-foreground`}
                           >
                             {tag}
                           </a>
+                        ) : (
+                          <span key={tag} className={base}>
+                            {tag}
+                          </span>
                         );
                       })}
                     </div>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { SponsorSidebar } from '@/components/sponsor-sidebar';
 import { InlineSponsors } from '@/components/inline-sponsors';
 import { OptimizedImage } from '@/components/optimized-image';
 import { getPostBySlug, getAllPosts, getRelatedPosts } from '@/lib/posts';
+import { getLinkableTagSlugs } from '@/lib/tags';
+import { tagToSlug } from '@/lib/tag-utils';
 import { notFound, redirect } from 'next/navigation';
 import { ArticleSchema, BreadcrumbSchema } from '@/components/schema-markup';
 import { RelatedPosts } from '@/components/related-posts';
@@ -108,6 +110,8 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     { name: post.title, url: `/posts/${post.slug}` },
   ];
 
+  const linkableTags = await getLinkableTagSlugs();
+
   return (
     <>
       <ArticleSchema post={post} />
@@ -161,15 +165,21 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                     <h3 className="mb-2 text-lg font-semibold">Tags</h3>
                     <div className="flex flex-wrap gap-2">
                       {post.tags.map((tag) => {
-                        const tagSlug = tag.toLowerCase().replace(/\s+/g, '-');
-                        return (
+                        const tagSlug = tagToSlug(tag);
+                        const base =
+                          'px-3 py-1 text-sm rounded-full bg-secondary text-secondary-foreground';
+                        return linkableTags.has(tagSlug) ? (
                           <a
                             key={tag}
                             href={`/tags/${tagSlug}`}
-                            className="px-3 py-1 text-sm transition-colors rounded-full bg-secondary text-secondary-foreground hover:bg-primary/40 hover:text-white"
+                            className={`${base} transition-colors hover:bg-primary/40 hover:text-white`}
                           >
                             {tag}
                           </a>
+                        ) : (
+                          <span key={tag} className={base}>
+                            {tag}
+                          </span>
                         );
                       })}
                     </div>

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,7 +1,7 @@
 import { PageHero } from '@/components/page-hero';
 import { PostsList } from '@/components/posts-list';
 import { SponsorSidebar } from '@/components/sponsor-sidebar';
-import { getPostsByTagSlug, getGuidesByTagSlug, getAllTags, getTagBySlug } from '@/lib/tags';
+import { getPostsByTagSlug, getGuidesByTagSlug, getPagedTags, getTagBySlug } from '@/lib/tags';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import { Tags } from 'lucide-react';
 import type { Metadata } from 'next';
@@ -55,7 +55,7 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
-  const tags = await getAllTags();
+  const tags = await getPagedTags();
   return tags.map((tag) => ({
     tag: tag.slug,
   }));

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,5 +1,5 @@
 import { PageHero } from '@/components/page-hero';
-import { getAllTags } from '@/lib/tags';
+import { getPagedTags } from '@/lib/tags';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 };
 
 export default async function TagsPage() {
-  const tags = await getAllTags();
+  const tags = await getPagedTags();
 
   const schemaItems = [
     { name: 'Home', url: '/' },

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -61,6 +61,24 @@ export async function getAllTags(): Promise<Tag[]> {
   return tags.sort((a, b) => b.count - a.count);
 }
 
+// A tag used by fewer than this many items doesn't get its own page: a single-post
+// tag is a thin near-duplicate of that post and mostly inflates the static-file
+// count. This is a reversible knob — once the site renders on demand (no CF Pages
+// file cap) it can drop back to 1 to restore every tag page at zero file cost.
+export const MIN_TAG_PAGE_COUNT = 2;
+
+// Tags that get their own page (count >= threshold). Used for route generation,
+// the tags index, and to decide which tag chips link out.
+export async function getPagedTags(): Promise<Tag[]> {
+  const tags = await getAllTags();
+  return tags.filter((t) => t.count >= MIN_TAG_PAGE_COUNT);
+}
+
+export async function getLinkableTagSlugs(): Promise<Set<string>> {
+  const tags = await getPagedTags();
+  return new Set(tags.map((t) => t.slug));
+}
+
 export async function getTagBySlug(slug: string): Promise<string | null> {
   const tags = await getAllTags();
   const tag = tags.find((t) => t.slug === slug);


### PR DESCRIPTION
Single-post tags are thin near-duplicates of the post they belong to, and each one is another file in the static export as we approach Cloudflare Pages' 20k-file cap. This generates tag pages (and lists/links tags) only when a tag is used by 2 or more items, which drops roughly 340 pages. Below-threshold tags still show on posts, just as plain text instead of dead links.

Also fixes the posts page slugifying tags inline (which broke on tags like CI/CD); it now uses `tagToSlug` like the rest of the site.

The threshold is a single constant (`MIN_TAG_PAGE_COUNT`), so once the site renders on demand we can drop it back to 1 and every tag page returns at zero file cost.