### PR TITLE
Add interactive diagram fence for posts

### DIFF
--- a/.claude/commands/write-post.md
+++ b/.claude/commands/write-post.md
@@ -191,6 +191,46 @@ https://github.com/The-DevOps-Daily/devops-daily
 
 The body can be a full `https://github.com/owner/repo` URL or just `owner/repo`. Data is fetched at view time (the site is statically exported), cached per session, and degrades to a simple link card if the GitHub API is unreachable or rate-limited. Use it once where the repo matters rather than after every mention.
 
+**Diagram** — ` ```diagram ` renders a clean, theme-aware, lightly animated diagram from JSON: step flows, loops, branches, infrastructure groups, and small node/edge graphs. Connectors flow, nodes lift on hover, and flow/graph diagrams get a Trace button; all of it respects `prefers-reduced-motion` and falls back to a code block on a bad spec. Use it for architecture, request paths, and process loops instead of an ASCII diagram or a screenshot.
+
+Pick a `type`:
+
+- **`flow`** — a row of steps with flowing arrows. `nodes: [{ label, sub?, icon?, tone? }]`. Trace button on by default.
+- **`loop`** — a flow with a labelled loop-back arc and an optional `goal` bar. Adds `goal?`, `loopTop?`, `loopBack?`. Nodes usually use a `variant` fill (`soft` / `solid` / `accent`) instead of an icon.
+- **`branch`** — a flow that splits into outcomes. Adds `branch: [{ label, variant }]` (use `good` / `bad` variants).
+- **`infra`** — host/cluster diagrams. `groups: [{ label, sub?, icon?, tone?, nodes?: [...], groups?: [...] }]` (groups nest), plus an optional top `flow: [...]` request path.
+- **`graph`** — a non-linear DAG. `columns: [[{ id, label, sub?, icon?, tone? }]]` and `edges: [[fromId, toId]]`; edges are drawn between columns, hover a node to isolate its path, Trace fires request packets.
+
+Nodes take an `icon` (a name from the built-in set or any emoji) and a `tone` (`slate` / `blue` / `green` / `violet` / `red` / `amber` / `accent`). Built-in icons: `globe`, `box`, `database`, `queue`, `cpu`, `server`, `net`, `branch`, `gear`, `check`, `rocket`, `activity`, `pod`, `k8s`, `cloud`, `shield`, `lock`.
+
+Example, a Docker-on-a-Pi infra diagram:
+
+```diagram
+{
+  "type": "infra",
+  "flow": [
+    { "label": "Internet", "icon": "globe", "tone": "slate" },
+    { "label": "nginx :443", "icon": "globe", "tone": "green" },
+    { "label": "app :3000", "icon": "box", "tone": "blue" }
+  ],
+  "groups": [
+    {
+      "label": "Raspberry Pi 5",
+      "sub": "Docker Compose",
+      "icon": "cpu",
+      "tone": "red",
+      "nodes": [
+        { "label": "nginx", "sub": "reverse proxy", "icon": "globe", "tone": "green" },
+        { "label": "app", "sub": "Node.js", "icon": "box", "tone": "blue" },
+        { "label": "Postgres", "sub": "pgdata", "icon": "database", "tone": "violet" }
+      ]
+    }
+  ]
+}
+```
+
+Keep diagrams to a handful of nodes so they stay readable, and validate the JSON before finishing (a quick `node -e` JSON.parse over each ` ```diagram ` block). For a sprawling topology that needs auto-routing, a plain image is still the better choice.
+
 ## OG Image
 
 After creating the post, remind the user to generate the OG image:

--- a/.claude/commands/write-post.md
+++ b/.claude/commands/write-post.md
@@ -201,7 +201,7 @@ Pick a `type`:
 - **`infra`** — host/cluster diagrams. `groups: [{ label, sub?, icon?, tone?, nodes?: [...], groups?: [...] }]` (groups nest), plus an optional top `flow: [...]` request path.
 - **`graph`** — a non-linear DAG. `columns: [[{ id, label, sub?, icon?, tone? }]]` and `edges: [[fromId, toId]]` (or `[fromId, toId, "label"]` to put a port or verb on the edge); edges are drawn between columns, hover a node to isolate its path, Trace fires request packets.
 
-Nodes take an `icon` (a name from the built-in set or any emoji) and a `tone` (`slate` / `blue` / `green` / `violet` / `red` / `amber` / `accent`). Built-in icons: `globe`, `box`, `database`, `queue`, `cpu`, `server`, `net`, `branch`, `gear`, `check`, `rocket`, `activity`, `pod`, `k8s`, `cloud`, `shield`, `lock`.
+Nodes take an `icon` (a name from the built-in set or any emoji) and a `tone` (`slate` / `blue` / `green` / `violet` / `red` / `amber` / `accent`). Built-in icons: `globe`, `box`, `database`, `queue`, `cpu`, `server`, `net`, `branch`, `gear`, `check`, `rocket`, `activity`, `pod`, `k8s`, `cloud`, `shield`, `lock`. A node can also carry a `status` (`ok` / `warn` / `down`, drawn as a small coloured dot, handy for incident diagrams) and, in a `graph`, a `detail` string that is revealed in a strip below the diagram when you hover or tap the node.
 
 Example, a Docker-on-a-Pi infra diagram:
 

--- a/.claude/commands/write-post.md
+++ b/.claude/commands/write-post.md
@@ -199,7 +199,7 @@ Pick a `type`:
 - **`loop`** — a flow with a labelled loop-back arc and an optional `goal` bar. Adds `goal?`, `loopTop?`, `loopBack?`. Nodes usually use a `variant` fill (`soft` / `solid` / `accent`) instead of an icon.
 - **`branch`** — a flow that splits into outcomes. Adds `branch: [{ label, variant }]` (use `good` / `bad` variants).
 - **`infra`** — host/cluster diagrams. `groups: [{ label, sub?, icon?, tone?, nodes?: [...], groups?: [...] }]` (groups nest), plus an optional top `flow: [...]` request path.
-- **`graph`** — a non-linear DAG. `columns: [[{ id, label, sub?, icon?, tone? }]]` and `edges: [[fromId, toId]]`; edges are drawn between columns, hover a node to isolate its path, Trace fires request packets.
+- **`graph`** — a non-linear DAG. `columns: [[{ id, label, sub?, icon?, tone? }]]` and `edges: [[fromId, toId]]` (or `[fromId, toId, "label"]` to put a port or verb on the edge); edges are drawn between columns, hover a node to isolate its path, Trace fires request packets.
 
 Nodes take an `icon` (a name from the built-in set or any emoji) and a `tone` (`slate` / `blue` / `green` / `violet` / `red` / `amber` / `accent`). Built-in icons: `globe`, `box`, `database`, `queue`, `cpu`, `server`, `net`, `branch`, `gear`, `check`, `rocket`, `activity`, `pod`, `k8s`, `cloud`, `shield`, `lock`.
 

--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { CodeBlockWrapper } from '@/components/code-block-wrapper';
 import { ChartBlockWrapper } from '@/components/post-chart-blocks';
 import { TerminalBlockWrapper, TabsBlockWrapper } from '@/components/post-interactive-blocks';
+import { DiagramBlockWrapper } from '@/components/post-diagram-blocks';
 import { GithubEmbedWrapper } from '@/components/post-github-embed';
 import { HeadingWrapper } from '@/components/heading-with-anchor';
 
@@ -38,9 +39,11 @@ export function MarkdownContent({ content, className }: MarkdownContentProps) {
         <ChartBlockWrapper>
           <TerminalBlockWrapper>
             <TabsBlockWrapper>
-              <GithubEmbedWrapper>
-                <MarkdownHtml html={parseMarkdown(content)} className={className} />
-              </GithubEmbedWrapper>
+              <DiagramBlockWrapper>
+                <GithubEmbedWrapper>
+                  <MarkdownHtml html={parseMarkdown(content)} className={className} />
+                </GithubEmbedWrapper>
+              </DiagramBlockWrapper>
             </TabsBlockWrapper>
           </TerminalBlockWrapper>
         </ChartBlockWrapper>

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -224,6 +224,9 @@ interface EdgePath {
   d: string;
   from: string;
   to: string;
+  label?: string;
+  mx: number;
+  my: number;
 }
 
 function GraphDiagram({ spec }: { spec: DiagramSpec }) {
@@ -258,6 +261,9 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
         id: 'e' + i,
         from: e[0],
         to: e[1],
+        label: e[2],
+        mx: (x1 + x2) / 2,
+        my: (y1 + y2) / 2,
         d: `M${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`,
       });
     });
@@ -345,6 +351,11 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
                     flowRefs.current[p.id] = el;
                   }}
                 />
+                {p.label && (
+                  <text className={'pd-edge-label' + (hot ? ' hot' : '')} x={p.mx} y={p.my}>
+                    {p.label}
+                  </text>
+                )}
               </g>
             );
           })}
@@ -515,6 +526,9 @@ const STYLES = `
 .pdiag .pd-edge-flow{ fill:none; stroke:color-mix(in srgb,var(--pd-accent) 55%,var(--pd-line2)); stroke-width:2; stroke-dasharray:3 11; opacity:.8; }
 @media (prefers-reduced-motion:no-preference){ .pdiag .pd-edge-flow{ animation:pd-dash 1.1s linear infinite; } }
 .pdiag .pd-edge.hot,.pdiag .pd-edge-flow.hot{ stroke:var(--pd-accent); opacity:1; }
+.pdiag .pd-edge-label{ font-family:var(--pd-mono); font-size:11px; fill:var(--pd-muted); text-anchor:middle; dominant-baseline:middle; paint-order:stroke; stroke:var(--pd-bg); stroke-width:5px; stroke-linejoin:round; }
+.pdiag .pd-edge-label.hot{ fill:var(--pd-accent); }
+.pdiag .pd-graph.pd-dim .pd-edge-label:not(.hot){ opacity:.1; }
 .pdiag .pd-graph.pd-dim .pd-node.pd-faded{ opacity:.34; }
 .pdiag .pd-graph.pd-dim .pd-edge:not(.hot),.pdiag .pd-graph.pd-dim .pd-edge-flow:not(.hot){ opacity:.1; }
 .pdiag .pd-node.pd-hot{ border-color:var(--pd-accent); box-shadow:0 0 0 2px rgba(224,121,43,.16); }

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -1,0 +1,520 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  parseDiagramSpec,
+  type DiagramSpec,
+  type DiagramNode,
+  type DiagramGroup,
+} from '@/lib/post-diagram';
+
+/* ------------------------------------------------------------------ */
+/* Icons: a small inline SVG set, or any emoji passed through as text. */
+/* ------------------------------------------------------------------ */
+
+const ICONS: Record<string, string> = {
+  globe: '<circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3.2 3 14.8 0 18M12 3c-3 3.2-3 14.8 0 18"/>',
+  box: '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z"/><path d="M4 7.5 12 12l8-4.5M12 12v9"/>',
+  database: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+  queue: '<rect x="3" y="6" width="5" height="12" rx="1"/><rect x="9.5" y="6" width="5" height="12" rx="1"/><rect x="16" y="6" width="5" height="12" rx="1"/>',
+  cpu: '<rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>',
+  server: '<rect x="3" y="4" width="18" height="7" rx="2"/><rect x="3" y="13" width="18" height="7" rx="2"/><path d="M7 7.5h.01M7 16.5h.01"/>',
+  net: '<circle cx="12" cy="5" r="2.2"/><circle cx="5" cy="19" r="2.2"/><circle cx="19" cy="19" r="2.2"/><path d="M12 7.2v3.8M12 11l-6.4 6M12 11l6.4 6"/>',
+  branch: '<circle cx="6" cy="6" r="2.4"/><circle cx="6" cy="18" r="2.4"/><circle cx="18" cy="8" r="2.4"/><path d="M6 8.4v7.2M6 15c0-4.5 12-1.5 12-6.6"/>',
+  gear: '<circle cx="12" cy="12" r="3.2"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.2 5.2l2.1 2.1M16.7 16.7l2.1 2.1M18.8 5.2l-2.1 2.1M7.3 16.7l-2.1 2.1"/>',
+  check: '<circle cx="12" cy="12" r="9"/><path d="M8 12l2.8 2.8L16 9"/>',
+  rocket: '<path d="M12 3c3 2.2 4.8 6 4.8 10L14 16h-4l-2.8-3c0-4 1.8-7.8 4.8-10z"/><circle cx="12" cy="10" r="1.6"/><path d="M9.2 16.5 7 20.5M14.8 16.5 17 20.5"/>',
+  activity: '<path d="M3 12h4l3-8 4 16 3-8h4"/>',
+  pod: '<path d="M12 3l7 4v10l-7 4-7-4V7z"/>',
+  k8s: '<path d="M12 2l8.5 4v8L12 22 3.5 14V6z"/><circle cx="12" cy="12" r="3"/><path d="M12 2v6.5M20.5 6 14.6 10M20.5 14l-6-2M12 22v-6.5M3.5 14l6-2M3.5 6l6 4"/>',
+  cloud: '<path d="M6.5 18a4.5 4.5 0 0 1-.5-9 6 6 0 0 1 11.6 1.5A3.75 3.75 0 0 1 17 18z"/>',
+  shield: '<path d="M12 3l7 3v6c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6z"/><path d="M9 12l2 2 4-4"/>',
+  lock: '<rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/>',
+};
+
+function PdIcon({ name, tone }: { name?: string; tone?: string }) {
+  if (!name) return null;
+  const cls = 'pd-ic' + (tone ? ' t-' + tone : '');
+  if (ICONS[name]) {
+    // Safe: the injected markup is a trusted, hardcoded constant (ICONS[name]).
+    // `name` is only used as a lookup key; unknown values fall through to the
+    // React-escaped text branch below, so author input never reaches innerHTML.
+    return (
+      <span
+        className={cls}
+        dangerouslySetInnerHTML={{
+          __html: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">${ICONS[name]}</svg>`,
+        }}
+      />
+    );
+  }
+  return <span className={cls}>{name}</span>;
+}
+
+function NodeCard({ node }: { node: DiagramNode }) {
+  if (node.variant) {
+    return (
+      <div className={'pd-node pd-fill v-' + node.variant}>
+        <div className="pd-lab">{node.label}</div>
+        {node.sub && <div className="pd-sub is-italic">{node.sub}</div>}
+      </div>
+    );
+  }
+  return (
+    <div className="pd-node">
+      <PdIcon name={node.icon} tone={node.tone} />
+      <div>
+        <div className="pd-lab">{node.label}</div>
+        {node.sub && <div className="pd-sub">{node.sub}</div>}
+      </div>
+    </div>
+  );
+}
+
+function Conn() {
+  return (
+    <svg className="pd-conn" viewBox="0 0 58 24" height="24" preserveAspectRatio="none" aria-hidden="true">
+      <line className="base" x1="3" y1="12" x2="47" y2="12" />
+      <line className="flow" x1="3" y1="12" x2="47" y2="12" />
+      <path className="head" d="M45 8l6 4-6 4" />
+    </svg>
+  );
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* flow / loop / branch                                                */
+/* ------------------------------------------------------------------ */
+
+function RowDiagram({ spec }: { spec: DiagramSpec }) {
+  const nodes = spec.nodes ?? [];
+  const rowRef = useRef<HTMLDivElement>(null);
+  const nodeEls = useRef<HTMLElement[]>([]);
+  const [showTrace] = useState(spec.type === 'flow' && spec.trace !== false && nodes.length > 1);
+
+  useEffect(() => {
+    const els = Array.from(rowRef.current?.querySelectorAll<HTMLElement>('.pd-node') ?? []);
+    nodeEls.current = els;
+    els.forEach((e, i) => setTimeout(() => e.classList.add('pd-in'), 80 * i + 60));
+  }, []);
+
+  const trace = () => {
+    if (prefersReducedMotion()) return;
+    const els = nodeEls.current;
+    els.forEach((e) => e.classList.remove('pd-pulse'));
+    els.forEach((e, i) =>
+      setTimeout(() => {
+        els.forEach((x) => x.classList.remove('pd-pulse'));
+        e.classList.add('pd-pulse');
+        if (i === els.length - 1) setTimeout(() => e.classList.remove('pd-pulse'), 620);
+      }, 500 * i)
+    );
+  };
+
+  return (
+    <div className="pdiag">
+      {spec.title && <div className="pd-title">{spec.title}</div>}
+      {showTrace && (
+        <div className="pd-toolbar">
+          <button type="button" className="pd-btn" onClick={trace}>
+            &#9654; Trace flow
+          </button>
+        </div>
+      )}
+      {spec.goal && <div className="pd-goal">{spec.goal}</div>}
+      {spec.loopTop && <div className="pd-toplabel">{spec.loopTop}</div>}
+      <div className="pd-row" ref={rowRef}>
+        {nodes.map((n, i) => (
+          <React.Fragment key={i}>
+            <NodeCard node={n} />
+            {i < nodes.length - 1 && <Conn />}
+          </React.Fragment>
+        ))}
+      </div>
+      {spec.type === 'loop' && (
+        <div className="pd-loopback">
+          <svg viewBox="0 0 1000 62" preserveAspectRatio="none" aria-hidden="true">
+            <path className="track" d="M 960 8 C 960 56, 700 60, 500 60 C 300 60, 40 56, 40 12" />
+            <path className="track" d="M 40 12 l -7 10 M 40 12 l 9 6" />
+          </svg>
+          {spec.loopBack && <span className="pd-lb-label">{spec.loopBack}</span>}
+        </div>
+      )}
+      {spec.type === 'branch' && spec.branch && spec.branch.length > 0 && (
+        <div className="pd-branch">
+          {spec.branch.map((n, i) => (
+            <div className="pd-leg" key={i}>
+              <span className="pd-down">&darr;</span>
+              <NodeCard node={n} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* infra                                                               */
+/* ------------------------------------------------------------------ */
+
+function GroupBox({ group }: { group: DiagramGroup }) {
+  return (
+    <div className="pd-group">
+      <div className="pd-ghead">
+        <PdIcon name={group.icon} tone={group.tone} />
+        <div>
+          <div className="pd-gtitle">{group.label}</div>
+          {group.sub && <div className="pd-gsub">{group.sub}</div>}
+        </div>
+      </div>
+      {group.groups && group.groups.length > 0 ? (
+        <div className="pd-nested">
+          {group.groups.map((g, i) => (
+            <GroupBox group={g} key={i} />
+          ))}
+        </div>
+      ) : (
+        <div className="pd-gbody">
+          {(group.nodes ?? []).map((n, i) => (
+            <NodeCard node={n} key={i} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfraDiagram({ spec }: { spec: DiagramSpec }) {
+  return (
+    <div className="pdiag">
+      {spec.title && <div className="pd-title">{spec.title}</div>}
+      {spec.flow && spec.flow.length > 0 && (
+        <div className="pd-row">
+          {spec.flow.map((n, i) => (
+            <React.Fragment key={i}>
+              <NodeCard node={n} />
+              {i < spec.flow!.length - 1 && <Conn />}
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+      {(spec.groups ?? []).map((g, i) => (
+        <GroupBox group={g} key={i} />
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* graph: columns of nodes with drawn, measured SVG edges              */
+/* ------------------------------------------------------------------ */
+
+interface EdgePath {
+  id: string;
+  d: string;
+  from: string;
+  to: string;
+}
+
+function GraphDiagram({ spec }: { spec: DiagramSpec }) {
+  const columns = spec.columns ?? [];
+  const edges = spec.edges ?? [];
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const nodeRefs = useRef<Record<string, HTMLElement | null>>({});
+  const flowRefs = useRef<Record<string, SVGPathElement | null>>({});
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [paths, setPaths] = useState<EdgePath[]>([]);
+  const [hovered, setHovered] = useState<string | null>(null);
+  const layer: Record<string, number> = {};
+  columns.forEach((col, ci) => col.forEach((n) => n.id && (layer[n.id] = ci)));
+
+  const draw = () => {
+    const wrap = wrapRef.current;
+    if (!wrap) return;
+    const gr = wrap.getBoundingClientRect();
+    const next: EdgePath[] = [];
+    edges.forEach((e, i) => {
+      const a = nodeRefs.current[e[0]];
+      const b = nodeRefs.current[e[1]];
+      if (!a || !b) return;
+      const ar = a.getBoundingClientRect();
+      const br = b.getBoundingClientRect();
+      const x1 = ar.right - gr.left;
+      const y1 = ar.top + ar.height / 2 - gr.top;
+      const x2 = br.left - gr.left;
+      const y2 = br.top + br.height / 2 - gr.top;
+      const dx = Math.max(28, (x2 - x1) * 0.5);
+      next.push({
+        id: 'e' + i,
+        from: e[0],
+        to: e[1],
+        d: `M${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`,
+      });
+    });
+    setPaths(next);
+  };
+
+  useEffect(() => {
+    draw();
+    const ro =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => draw())
+        : null;
+    if (ro && wrapRef.current) ro.observe(wrapRef.current);
+    window.addEventListener('resize', draw);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', draw);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const connected = (id: string) => {
+    const set = new Set<string>([id]);
+    edges.forEach((e) => {
+      if (e[0] === id) set.add(e[1]);
+      if (e[1] === id) set.add(e[0]);
+    });
+    return set;
+  };
+  const hi = hovered ? connected(hovered) : null;
+
+  const firePacket = (pathEl: SVGPathElement, delay: number) => {
+    setTimeout(() => {
+      const svg = svgRef.current;
+      if (!svg) return;
+      const len = pathEl.getTotalLength();
+      const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      dot.setAttribute('r', '4.5');
+      dot.setAttribute('class', 'pd-pkt');
+      svg.appendChild(dot);
+      let start: number | null = null;
+      const dur = 620;
+      const step = (ts: number) => {
+        if (start === null) start = ts;
+        const t = Math.min(1, (ts - start) / dur);
+        const p = pathEl.getPointAtLength(t * len);
+        dot.setAttribute('cx', String(p.x));
+        dot.setAttribute('cy', String(p.y));
+        if (t < 1) requestAnimationFrame(step);
+        else if (dot.parentNode) svg.removeChild(dot);
+      };
+      requestAnimationFrame(step);
+    }, delay);
+  };
+
+  const trace = () => {
+    if (prefersReducedMotion()) return;
+    paths.forEach((p) => {
+      const el = flowRefs.current[p.id];
+      if (el) firePacket(el, (layer[p.from] ?? 0) * 520);
+    });
+  };
+
+  return (
+    <div className="pdiag">
+      <div className="pd-toolbar">
+        {spec.title && <span className="pd-title pd-title-inline">{spec.title}</span>}
+        {spec.trace !== false && edges.length > 0 && (
+          <button type="button" className="pd-btn" onClick={trace}>
+            &#9654; Trace requests
+          </button>
+        )}
+      </div>
+      <div className={'pd-graph' + (hovered ? ' pd-dim' : '')} ref={wrapRef}>
+        <svg className="pd-edges" ref={svgRef} aria-hidden="true">
+          {paths.map((p) => {
+            const hot = hi && (hi.has(p.from) && hi.has(p.to) && (p.from === hovered || p.to === hovered));
+            return (
+              <g key={p.id}>
+                <path className={'pd-edge' + (hot ? ' hot' : '')} d={p.d} />
+                <path
+                  className={'pd-edge-flow' + (hot ? ' hot' : '')}
+                  d={p.d}
+                  ref={(el) => {
+                    flowRefs.current[p.id] = el;
+                  }}
+                />
+              </g>
+            );
+          })}
+        </svg>
+        {columns.map((col, ci) => (
+          <div className="pd-col" key={ci}>
+            {col.map((n, ni) => {
+              const id = n.id ?? `c${ci}n${ni}`;
+              const dim = hi && !hi.has(id);
+              return (
+                <div
+                  key={id}
+                  className={'pd-node pd-in' + (dim ? ' pd-faded' : '') + (id === hovered ? ' pd-hot' : '')}
+                  ref={(el) => {
+                    nodeRefs.current[id] = el;
+                  }}
+                  onMouseEnter={() => setHovered(id)}
+                  onMouseLeave={() => setHovered(null)}
+                >
+                  <PdIcon name={n.icon} tone={n.tone} />
+                  <div>
+                    <div className="pd-lab">{n.label}</div>
+                    {n.sub && <div className="pd-sub">{n.sub}</div>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* dispatch + styles + hydration                                       */
+/* ------------------------------------------------------------------ */
+
+function DiagramBlock({ spec }: { spec: DiagramSpec }) {
+  useEffect(() => ensureStyles(), []);
+  let inner: React.ReactElement;
+  if (spec.type === 'graph') inner = <GraphDiagram spec={spec} />;
+  else if (spec.type === 'infra') inner = <InfraDiagram spec={spec} />;
+  else inner = <RowDiagram spec={spec} />;
+  return <div className="not-prose pd-card">{inner}</div>;
+}
+
+let stylesInjected = false;
+function ensureStyles() {
+  if (stylesInjected || typeof document === 'undefined') return;
+  stylesInjected = true;
+  const el = document.createElement('style');
+  el.id = 'pd-styles';
+  el.textContent = STYLES;
+  document.head.appendChild(el);
+}
+
+function useHydrate(
+  selector: string,
+  dataKey: string,
+  render: (raw: string) => React.ReactElement | null
+) {
+  const rootsRef = useRef<Root[]>([]);
+  useEffect(() => {
+    const nodes = document.querySelectorAll<HTMLElement>(selector);
+    nodes.forEach((node) => {
+      const element = render(node.dataset[dataKey] ?? '');
+      if (!element) return;
+      node.setAttribute('data-mounted', 'true');
+      const root = createRoot(node);
+      root.render(element);
+      rootsRef.current.push(root);
+    });
+    const roots = rootsRef.current;
+    return () => {
+      setTimeout(() => roots.forEach((root) => root.unmount()), 0);
+      rootsRef.current = [];
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export function DiagramBlockWrapper({ children }: { children: React.ReactNode }) {
+  useHydrate('.post-diagram[data-diagram]:not([data-mounted])', 'diagram', (raw) => {
+    const spec = parseDiagramSpec(raw);
+    return spec ? <DiagramBlock spec={spec} /> : null;
+  });
+  return <>{children}</>;
+}
+
+const STYLES = `
+.pd-card{ margin:1.75rem 0; }
+.pdiag{ --pd-card:#ffffff; --pd-bg:#fbfaf7; --pd-ink:#1b1a17; --pd-muted:#857f74; --pd-line:#e3ded4; --pd-line2:#d3cdbf;
+  --pd-soft-bg:#efeae0; --pd-soft-ink:#1b1a17; --pd-solid-bg:#1a1a1a; --pd-solid-ink:#fff; --pd-accent:#e0792b;
+  --pd-blue:#2f6feb; --pd-green:#2f8a52; --pd-violet:#6d54c9; --pd-red:#c2453f; --pd-amber:#c67c1e; --pd-slate:#4a5568;
+  --pd-mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  border:1px solid var(--pd-line); border-radius:16px; background:var(--pd-bg); padding:24px 22px;
+  box-shadow:0 1px 2px rgba(20,18,14,.03),0 8px 30px -20px rgba(20,18,14,.16);
+  font-family:inherit; color:var(--pd-ink); }
+.dark .pdiag{ --pd-card:#131a24; --pd-bg:#0f141d; --pd-ink:#e8edf6; --pd-muted:#8b96ab; --pd-line:#27303f; --pd-line2:#33405280;
+  --pd-soft-bg:#1b2431; --pd-soft-ink:#e8edf6; --pd-solid-bg:#e8edf6; --pd-solid-ink:#10151d; --pd-accent:#f2a35a;
+  --pd-blue:#6fa8ff; --pd-green:#57d08a; --pd-violet:#a996f5; --pd-red:#f6857f; --pd-amber:#e6b45e; --pd-slate:#9aa6b8;
+  box-shadow:0 1px 2px rgba(0,0,0,.2),0 8px 30px -20px rgba(0,0,0,.5); }
+.pdiag *{ box-sizing:border-box; }
+.pdiag .pd-title{ font-family:var(--pd-mono); font-size:12.5px; color:var(--pd-muted); letter-spacing:.04em; margin-bottom:14px; }
+.pdiag .pd-title-inline{ margin-bottom:0; }
+.pdiag .pd-toolbar{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px; }
+.pdiag .pd-btn{ font-family:var(--pd-mono); font-size:12.5px; color:var(--pd-ink); background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:9px; padding:7px 13px; cursor:pointer; transition:border-color .2s,color .2s; }
+.pdiag .pd-btn:hover{ border-color:var(--pd-accent); color:var(--pd-accent); }
+.pdiag .pd-btn:focus-visible{ outline:2px solid var(--pd-accent); outline-offset:2px; }
+.pdiag .pd-goal{ font-family:var(--pd-mono); font-size:13px; background:var(--pd-soft-bg); border:1px solid var(--pd-line); border-radius:8px; padding:8px 14px; width:fit-content; max-width:100%; margin:0 auto 22px; text-align:center; }
+.pdiag .pd-toplabel{ text-align:center; font-size:13px; font-style:italic; color:var(--pd-muted); margin-bottom:8px; }
+.pdiag .pd-row{ display:flex; align-items:stretch; justify-content:center; flex-wrap:wrap; gap:4px; }
+.pdiag .pd-node{ position:relative; display:flex; align-items:center; gap:11px; background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:13px; padding:12px 15px; min-width:140px; opacity:0; transform:translateY(8px); transition:transform .22s,box-shadow .22s,border-color .22s,opacity .22s; }
+.pdiag .pd-node.pd-in{ opacity:1; transform:none; }
+.pdiag .pd-node:hover{ transform:translateY(-3px); border-color:var(--pd-accent); box-shadow:0 10px 30px -14px rgba(224,121,43,.45); }
+.pdiag .pd-node.pd-pulse{ border-color:var(--pd-accent); box-shadow:0 0 0 3px rgba(224,121,43,.15),0 12px 30px -12px rgba(224,121,43,.5); transform:translateY(-3px); opacity:1; }
+.pdiag .pd-lab{ font-weight:650; font-size:14px; }
+.pdiag .pd-sub{ font-size:12px; color:var(--pd-muted); font-family:var(--pd-mono); margin-top:1px; }
+.pdiag .pd-sub.is-italic{ font-style:italic; font-family:inherit; opacity:.75; }
+.pdiag .pd-node.pd-fill{ display:block; text-align:center; border:none; }
+.pdiag .pd-fill .pd-lab{ font-size:15px; }
+.pdiag .pd-fill.v-soft{ background:var(--pd-soft-bg); color:var(--pd-soft-ink); }
+.pdiag .pd-fill.v-solid{ background:var(--pd-solid-bg); color:var(--pd-solid-ink); }
+.pdiag .pd-fill.v-solid .pd-sub{ color:var(--pd-solid-ink); }
+.pdiag .pd-fill.v-accent{ background:color-mix(in srgb, var(--pd-accent) 16%, var(--pd-card)); color:var(--pd-accent); }
+.pdiag .pd-fill.v-accent .pd-sub, .pdiag .pd-fill.v-good .pd-sub, .pdiag .pd-fill.v-bad .pd-sub{ color:inherit; }
+.pdiag .pd-fill.v-good{ background:color-mix(in srgb, var(--pd-green) 16%, var(--pd-card)); color:var(--pd-green); }
+.pdiag .pd-fill.v-bad{ background:color-mix(in srgb, var(--pd-red) 16%, var(--pd-card)); color:var(--pd-red); }
+.pdiag .pd-fill.v-line{ background:var(--pd-card); border:1.5px solid var(--pd-line2); }
+.pdiag .pd-ic{ width:30px; height:30px; flex:none; display:inline-grid; place-items:center; border-radius:9px; background:var(--pd-soft-bg); color:var(--pd-slate); font-size:16px; }
+.pdiag .pd-ic svg{ width:60%; height:60%; }
+.pdiag .pd-ic.t-blue{ color:var(--pd-blue); background:color-mix(in srgb,var(--pd-blue) 14%,transparent); }
+.pdiag .pd-ic.t-green{ color:var(--pd-green); background:color-mix(in srgb,var(--pd-green) 15%,transparent); }
+.pdiag .pd-ic.t-violet{ color:var(--pd-violet); background:color-mix(in srgb,var(--pd-violet) 14%,transparent); }
+.pdiag .pd-ic.t-red{ color:var(--pd-red); background:color-mix(in srgb,var(--pd-red) 13%,transparent); }
+.pdiag .pd-ic.t-amber{ color:var(--pd-amber); background:color-mix(in srgb,var(--pd-amber) 16%,transparent); }
+.pdiag .pd-ic.t-accent{ color:var(--pd-accent); background:color-mix(in srgb,var(--pd-accent) 15%,transparent); }
+.pdiag .pd-ic.t-slate{ color:var(--pd-slate); background:color-mix(in srgb,var(--pd-slate) 13%,transparent); }
+.pdiag .pd-conn{ width:56px; align-self:center; }
+.pdiag .pd-conn .base{ stroke:var(--pd-line2); stroke-width:2; }
+.pdiag .pd-conn .head{ fill:none; stroke:var(--pd-muted); stroke-width:2; stroke-linecap:round; stroke-linejoin:round; }
+.pdiag .pd-conn .flow{ stroke:var(--pd-accent); stroke-width:2.4; stroke-linecap:round; stroke-dasharray:4 10; }
+@media (prefers-reduced-motion:no-preference){ .pdiag .pd-conn .flow{ animation:pd-dash .95s linear infinite; } }
+@keyframes pd-dash{ to{ stroke-dashoffset:-14; } }
+.pdiag .pd-loopback{ position:relative; height:60px; margin-top:6px; }
+.pdiag .pd-loopback svg{ width:100%; height:100%; overflow:visible; }
+.pdiag .pd-loopback .track{ fill:none; stroke:var(--pd-line2); stroke-width:1.6; }
+.pdiag .pd-lb-label{ position:absolute; left:50%; bottom:2px; transform:translateX(-50%); font-size:13px; font-style:italic; color:var(--pd-muted); background:var(--pd-bg); padding:0 10px; }
+.pdiag .pd-branch{ display:flex; justify-content:center; gap:56px; margin-top:8px; }
+.pdiag .pd-leg{ display:flex; flex-direction:column; align-items:center; gap:6px; }
+.pdiag .pd-down{ color:var(--pd-muted); font-size:20px; line-height:1; }
+.pdiag .pd-group{ border:1.5px solid var(--pd-line2); border-radius:16px; padding:14px 16px 18px; background:var(--pd-card); margin-top:16px; }
+.pdiag .pd-ghead{ display:flex; align-items:center; gap:10px; margin-bottom:14px; }
+.pdiag .pd-gtitle{ font-weight:700; font-size:15px; }
+.pdiag .pd-gsub{ font-size:12.5px; color:var(--pd-muted); font-family:var(--pd-mono); }
+.pdiag .pd-gbody{ display:flex; flex-wrap:wrap; gap:12px; }
+.pdiag .pd-nested{ display:flex; flex-wrap:wrap; gap:12px; }
+.pdiag .pd-nested .pd-group{ flex:1; min-width:210px; margin-top:0; }
+.pdiag .pd-group .pd-node{ opacity:1; transform:none; }
+.pdiag .pd-graph{ position:relative; display:flex; justify-content:space-between; align-items:center; gap:36px; padding:12px 4px; min-height:280px; }
+.pdiag .pd-edges{ position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0; overflow:visible; }
+.pdiag .pd-col{ display:flex; flex-direction:column; justify-content:center; gap:16px; z-index:1; }
+.pdiag .pd-graph .pd-node{ min-width:132px; cursor:default; }
+.pdiag .pd-edge{ fill:none; stroke:var(--pd-line2); stroke-width:2; transition:stroke .2s,opacity .2s; }
+.pdiag .pd-edge-flow{ fill:none; stroke:color-mix(in srgb,var(--pd-accent) 55%,var(--pd-line2)); stroke-width:2; stroke-dasharray:3 11; opacity:.8; }
+@media (prefers-reduced-motion:no-preference){ .pdiag .pd-edge-flow{ animation:pd-dash 1.1s linear infinite; } }
+.pdiag .pd-edge.hot,.pdiag .pd-edge-flow.hot{ stroke:var(--pd-accent); opacity:1; }
+.pdiag .pd-graph.pd-dim .pd-node.pd-faded{ opacity:.34; }
+.pdiag .pd-graph.pd-dim .pd-edge:not(.hot),.pdiag .pd-graph.pd-dim .pd-edge-flow:not(.hot){ opacity:.1; }
+.pdiag .pd-node.pd-hot{ border-color:var(--pd-accent); box-shadow:0 0 0 2px rgba(224,121,43,.16); }
+.pdiag .pd-pkt{ fill:var(--pd-accent); }
+@media (max-width:760px){ .pdiag .pd-row{ flex-direction:column; } .pdiag .pd-conn{ display:none; } .pdiag .pd-graph{ flex-direction:column; gap:14px; } .pdiag .pd-edges{ display:none; } }
+`;

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -96,19 +96,12 @@ function prefersReducedMotion(): boolean {
 
 function RowDiagram({ spec }: { spec: DiagramSpec }) {
   const nodes = spec.nodes ?? [];
-  const rowRef = useRef<HTMLDivElement>(null);
-  const nodeEls = useRef<HTMLElement[]>([]);
-  const [showTrace] = useState(spec.type === 'flow' && spec.trace !== false && nodes.length > 1);
-
-  useEffect(() => {
-    const els = Array.from(rowRef.current?.querySelectorAll<HTMLElement>('.pd-node') ?? []);
-    nodeEls.current = els;
-    els.forEach((e, i) => setTimeout(() => e.classList.add('pd-in'), 80 * i + 60));
-  }, []);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const showTrace = spec.type === 'flow' && spec.trace !== false && nodes.length > 1;
 
   const trace = () => {
     if (prefersReducedMotion()) return;
-    const els = nodeEls.current;
+    const els = Array.from(rootRef.current?.querySelectorAll<HTMLElement>('.pd-row .pd-node') ?? []);
     els.forEach((e) => e.classList.remove('pd-pulse'));
     els.forEach((e, i) =>
       setTimeout(() => {
@@ -119,8 +112,19 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
     );
   };
 
+  const row = (
+    <div className="pd-row">
+      {nodes.map((n, i) => (
+        <React.Fragment key={i}>
+          <NodeCard node={n} />
+          {i < nodes.length - 1 && <Conn />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+
   return (
-    <div className="pdiag">
+    <div className="pdiag" ref={rootRef}>
       {spec.title && <div className="pd-title">{spec.title}</div>}
       {showTrace && (
         <div className="pd-toolbar">
@@ -130,23 +134,20 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
         </div>
       )}
       {spec.goal && <div className="pd-goal">{spec.goal}</div>}
-      {spec.loopTop && <div className="pd-toplabel">{spec.loopTop}</div>}
-      <div className="pd-row" ref={rowRef}>
-        {nodes.map((n, i) => (
-          <React.Fragment key={i}>
-            <NodeCard node={n} />
-            {i < nodes.length - 1 && <Conn />}
-          </React.Fragment>
-        ))}
-      </div>
-      {spec.type === 'loop' && (
-        <div className="pd-loopback">
-          <svg viewBox="0 0 1000 62" preserveAspectRatio="none" aria-hidden="true">
-            <path className="track" d="M 960 8 C 960 56, 700 60, 500 60 C 300 60, 40 56, 40 12" />
-            <path className="track" d="M 40 12 l -7 10 M 40 12 l 9 6" />
-          </svg>
-          {spec.loopBack && <span className="pd-lb-label">{spec.loopBack}</span>}
+      {spec.type === 'loop' ? (
+        <div className="pd-loopwrap">
+          {spec.loopTop && <div className="pd-toplabel">{spec.loopTop}</div>}
+          {row}
+          <div className="pd-loopback">
+            <svg viewBox="0 0 1000 62" preserveAspectRatio="none" aria-hidden="true">
+              <path className="track" d="M 960 8 C 960 56, 700 60, 500 60 C 300 60, 40 56, 40 12" />
+              <path className="track" d="M 40 12 l -7 10 M 40 12 l 9 6" />
+            </svg>
+            {spec.loopBack && <span className="pd-lb-label">{spec.loopBack}</span>}
+          </div>
         </div>
+      ) : (
+        row
       )}
       {spec.type === 'branch' && spec.branch && spec.branch.length > 0 && (
         <div className="pd-branch">
@@ -356,7 +357,7 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
               return (
                 <div
                   key={id}
-                  className={'pd-node pd-in' + (dim ? ' pd-faded' : '') + (id === hovered ? ' pd-hot' : '')}
+                  className={'pd-node' + (dim ? ' pd-faded' : '') + (id === hovered ? ' pd-hot' : '')}
                   ref={(el) => {
                     nodeRefs.current[id] = el;
                   }}
@@ -457,8 +458,9 @@ const STYLES = `
 .pdiag .pd-goal{ font-family:var(--pd-mono); font-size:13px; background:var(--pd-soft-bg); border:1px solid var(--pd-line); border-radius:8px; padding:8px 14px; width:fit-content; max-width:100%; margin:0 auto 22px; text-align:center; }
 .pdiag .pd-toplabel{ text-align:center; font-size:13px; font-style:italic; color:var(--pd-muted); margin-bottom:8px; }
 .pdiag .pd-row{ display:flex; align-items:stretch; justify-content:center; flex-wrap:wrap; gap:4px; }
-.pdiag .pd-node{ position:relative; display:flex; align-items:center; gap:11px; background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:13px; padding:12px 15px; min-width:140px; opacity:0; transform:translateY(8px); transition:transform .22s,box-shadow .22s,border-color .22s,opacity .22s; }
-.pdiag .pd-node.pd-in{ opacity:1; transform:none; }
+.pdiag .pd-node{ position:relative; display:flex; align-items:center; gap:11px; background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:13px; padding:12px 15px; min-width:140px; transition:transform .22s,box-shadow .22s,border-color .22s; }
+@media (prefers-reduced-motion:no-preference){ .pdiag .pd-node{ animation:pd-enter .3s ease backwards; } }
+@keyframes pd-enter{ from{ opacity:0; transform:translateY(6px); } }
 .pdiag .pd-node:hover{ transform:translateY(-3px); border-color:var(--pd-accent); box-shadow:0 10px 30px -14px rgba(224,121,43,.45); }
 .pdiag .pd-node.pd-pulse{ border-color:var(--pd-accent); box-shadow:0 0 0 3px rgba(224,121,43,.15),0 12px 30px -12px rgba(224,121,43,.5); transform:translateY(-3px); opacity:1; }
 .pdiag .pd-lab{ font-weight:650; font-size:14px; }
@@ -489,6 +491,7 @@ const STYLES = `
 .pdiag .pd-conn .flow{ stroke:var(--pd-accent); stroke-width:2.4; stroke-linecap:round; stroke-dasharray:4 10; }
 @media (prefers-reduced-motion:no-preference){ .pdiag .pd-conn .flow{ animation:pd-dash .95s linear infinite; } }
 @keyframes pd-dash{ to{ stroke-dashoffset:-14; } }
+.pdiag .pd-loopwrap{ width:fit-content; max-width:100%; margin:0 auto; }
 .pdiag .pd-loopback{ position:relative; height:60px; margin-top:6px; }
 .pdiag .pd-loopback svg{ width:100%; height:100%; overflow:visible; }
 .pdiag .pd-loopback .track{ fill:none; stroke:var(--pd-line2); stroke-width:1.6; }

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -56,6 +56,7 @@ function NodeCard({ node }: { node: DiagramNode }) {
   if (node.variant) {
     return (
       <div className={'pd-node pd-fill v-' + node.variant}>
+        {node.status && <span className={'pd-dot s-' + node.status} />}
         <div className="pd-lab">{node.label}</div>
         {node.sub && <div className="pd-sub is-italic">{node.sub}</div>}
       </div>
@@ -63,6 +64,7 @@ function NodeCard({ node }: { node: DiagramNode }) {
   }
   return (
     <div className="pd-node">
+      {node.status && <span className={'pd-dot s-' + node.status} />}
       <PdIcon name={node.icon} tone={node.tone} />
       <div>
         <div className="pd-lab">{node.label}</div>
@@ -238,8 +240,18 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [paths, setPaths] = useState<EdgePath[]>([]);
   const [hovered, setHovered] = useState<string | null>(null);
+  const [pinned, setPinned] = useState<string | null>(null);
+  const active = pinned ?? hovered;
   const layer: Record<string, number> = {};
-  columns.forEach((col, ci) => col.forEach((n) => n.id && (layer[n.id] = ci)));
+  const byId: Record<string, DiagramNode> = {};
+  columns.forEach((col, ci) =>
+    col.forEach((n) => {
+      if (n.id) {
+        layer[n.id] = ci;
+        byId[n.id] = n;
+      }
+    })
+  );
 
   const draw = () => {
     const wrap = wrapRef.current;
@@ -293,7 +305,7 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
     });
     return set;
   };
-  const hi = hovered ? connected(hovered) : null;
+  const hi = active ? connected(active) : null;
 
   const firePacket = (pathEl: SVGPathElement, delay: number) => {
     setTimeout(() => {
@@ -337,7 +349,7 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
           </button>
         )}
       </div>
-      <div className={'pd-graph' + (hovered ? ' pd-dim' : '')} ref={wrapRef}>
+      <div className={'pd-graph' + (active ? ' pd-dim' : '')} ref={wrapRef}>
         <svg className="pd-edges" ref={svgRef} aria-hidden="true">
           {paths.map((p) => {
             const hot = hi && (hi.has(p.from) && hi.has(p.to) && (p.from === hovered || p.to === hovered));
@@ -368,13 +380,15 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
               return (
                 <div
                   key={id}
-                  className={'pd-node' + (dim ? ' pd-faded' : '') + (id === hovered ? ' pd-hot' : '')}
+                  className={'pd-node pd-clickable' + (dim ? ' pd-faded' : '') + (id === active ? ' pd-hot' : '')}
                   ref={(el) => {
                     nodeRefs.current[id] = el;
                   }}
                   onMouseEnter={() => setHovered(id)}
                   onMouseLeave={() => setHovered(null)}
+                  onClick={() => setPinned((p) => (p === id ? null : id))}
                 >
+                  {n.status && <span className={'pd-dot s-' + n.status} />}
                   <PdIcon name={n.icon} tone={n.tone} />
                   <div>
                     <div className="pd-lab">{n.label}</div>
@@ -386,6 +400,11 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
           </div>
         ))}
       </div>
+      {active && byId[active]?.detail && (
+        <div className="pd-detail">
+          <b>{byId[active].label}</b> {byId[active].detail}
+        </div>
+      )}
     </div>
   );
 }
@@ -532,6 +551,14 @@ const STYLES = `
 .pdiag .pd-graph.pd-dim .pd-node.pd-faded{ opacity:.34; }
 .pdiag .pd-graph.pd-dim .pd-edge:not(.hot),.pdiag .pd-graph.pd-dim .pd-edge-flow:not(.hot){ opacity:.1; }
 .pdiag .pd-node.pd-hot{ border-color:var(--pd-accent); box-shadow:0 0 0 2px rgba(224,121,43,.16); }
+.pdiag .pd-clickable{ cursor:pointer; }
+.pdiag .pd-dot{ position:absolute; top:8px; right:8px; width:8px; height:8px; border-radius:50%; box-shadow:0 0 0 3px var(--pd-card); }
+.pdiag .pd-dot.s-ok{ background:var(--pd-green); }
+.pdiag .pd-dot.s-warn{ background:var(--pd-amber); }
+.pdiag .pd-dot.s-down{ background:var(--pd-red); }
+.pdiag .pd-detail{ margin-top:14px; font-size:13px; color:var(--pd-muted); background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:10px; padding:10px 14px; animation:pd-pop .2s ease; }
+@keyframes pd-pop{ from{ opacity:0; transform:translateY(-3px); } }
+.pdiag .pd-detail b{ color:var(--pd-ink); font-weight:650; }
 .pdiag .pd-pkt{ fill:var(--pd-accent); }
 @media (max-width:760px){ .pdiag .pd-row{ flex-direction:column; } .pdiag .pd-conn{ display:none; } .pdiag .pd-graph{ flex-direction:column; gap:14px; } .pdiag .pd-edges{ display:none; } }
 `;

--- a/content/posts/neon-everything-on-your-branch-architecture.md
+++ b/content/posts/neon-everything-on-your-branch-architecture.md
@@ -56,15 +56,29 @@ Teams paper over this with scripts: a bucket-prefix-per-branch convention, a bes
 
 On Neon's platform preview, one branch carries the whole stack:
 
-```text
-main branch                          neon branches create + deploy
-┌─────────────────────────────┐      ┌─────────────────────────────┐
-│ Postgres  ── rows            │      │ Postgres  ── copy of rows    │
-│ Storage   ── files (bucket)  │ ───► │ Storage   ── copy of files   │
-│ Functions ── api URL         │ fork │ Functions ── its OWN api URL │
-│ AI Gateway── model config    │ all  │ AI Gateway── model config    │
-└─────────────────────────────┘      └─────────────────────────────┘
-        shared, production                 isolated, disposable
+```diagram
+{
+  "type": "infra",
+  "title": "one branch carries the whole stack",
+  "flow": [
+    { "label": "Production", "sub": "main branch", "icon": "database", "tone": "slate" },
+    { "label": "Fork", "sub": "instant, copy-on-write", "icon": "branch", "tone": "green" }
+  ],
+  "groups": [
+    {
+      "label": "A Neon branch",
+      "sub": "isolated, disposable",
+      "icon": "branch",
+      "tone": "green",
+      "nodes": [
+        { "label": "Postgres", "sub": "copy of rows", "icon": "database", "tone": "violet" },
+        { "label": "Storage", "sub": "copy of files", "icon": "box", "tone": "blue" },
+        { "label": "Functions", "sub": "own API URL", "icon": "gear", "tone": "amber" },
+        { "label": "AI Gateway", "sub": "model config", "icon": "net", "tone": "green" }
+      ]
+    }
+  ]
+}
 ```
 
 The database and storage are copy-on-write, so the branch starts as a reference to the parent's state and only stores what you change. The function redeploys onto the branch with its own URL. The gateway config comes along. Delete the branch and every layer goes with it.

--- a/content/posts/neon-functions-realtime-without-websockets.md
+++ b/content/posts/neon-functions-realtime-without-websockets.md
@@ -59,14 +59,14 @@ Here is the trap. A function under load does not run as one process; the runtime
   "title": "Postgres fans one NOTIFY out to every isolate",
   "columns": [
     [ { "id": "write", "label": "A write", "sub": "calls pg_notify", "icon": "box", "tone": "amber" } ],
-    [ { "id": "pg", "label": "Postgres", "sub": "LISTEN / NOTIFY", "icon": "database", "tone": "violet" } ],
+    [ { "id": "pg", "label": "Postgres", "sub": "LISTEN / NOTIFY", "icon": "database", "tone": "violet", "detail": "One pg_notify reaches every isolate that holds a LISTEN connection. That cross-isolate fan-out is exactly what an in-process broadcast cannot do." } ],
     [
-      { "id": "iso1", "label": "Isolate A", "sub": "its SSE clients", "icon": "gear", "tone": "blue" },
+      { "id": "iso1", "label": "Isolate A", "sub": "its SSE clients", "icon": "gear", "tone": "blue", "detail": "Keeps its own set of open SSE connections in memory, plus one LISTEN connection to Postgres." },
       { "id": "iso2", "label": "Isolate B", "sub": "its SSE clients", "icon": "gear", "tone": "blue" }
     ],
     [
-      { "id": "b1", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green" },
-      { "id": "b2", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green" }
+      { "id": "b1", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green", "status": "ok" },
+      { "id": "b2", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green", "status": "ok" }
     ]
   ],
   "edges": [["write", "pg", "pg_notify"], ["pg", "iso1", "LISTEN"], ["pg", "iso2", "LISTEN"], ["iso1", "b1", "SSE"], ["iso2", "b2", "SSE"]]

--- a/content/posts/neon-functions-realtime-without-websockets.md
+++ b/content/posts/neon-functions-realtime-without-websockets.md
@@ -53,6 +53,26 @@ Here is the trap. A function under load does not run as one process; the runtime
 
 `LISTEN`/`NOTIFY` is what closes that gap. Every isolate opens its own `LISTEN` connection to Postgres. When any code anywhere calls `NOTIFY`, Postgres delivers it to all of those connections, so every isolate gets the event and pushes it to its own clients. Postgres is the shared fan-out point that the isolates do not otherwise have.
 
+```diagram
+{
+  "type": "graph",
+  "title": "Postgres fans one NOTIFY out to every isolate",
+  "columns": [
+    [ { "id": "write", "label": "A write", "sub": "calls pg_notify", "icon": "box", "tone": "amber" } ],
+    [ { "id": "pg", "label": "Postgres", "sub": "LISTEN / NOTIFY", "icon": "database", "tone": "violet" } ],
+    [
+      { "id": "iso1", "label": "Isolate A", "sub": "its SSE clients", "icon": "gear", "tone": "blue" },
+      { "id": "iso2", "label": "Isolate B", "sub": "its SSE clients", "icon": "gear", "tone": "blue" }
+    ],
+    [
+      { "id": "b1", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green" },
+      { "id": "b2", "label": "Browsers", "sub": "EventSource", "icon": "globe", "tone": "green" }
+    ]
+  ],
+  "edges": [["write", "pg", "pg_notify"], ["pg", "iso1", "LISTEN"], ["pg", "iso2", "LISTEN"], ["iso1", "b1", "SSE"], ["iso2", "b2", "SSE"]]
+}
+```
+
 ```typescript
 // One dedicated LISTEN connection per isolate. LISTEN needs a real session,
 // so use the DIRECT (unpooled) URL, not the transaction pooler.

--- a/content/posts/neon-object-storage-branches-with-your-database.md
+++ b/content/posts/neon-object-storage-branches-with-your-database.md
@@ -52,6 +52,35 @@ People work around this with a bucket-prefix-per-branch convention and a script 
 
 ## How a Neon branch forks the bucket
 
+```diagram
+{
+  "type": "infra",
+  "title": "each branch gets its own database and its own bucket",
+  "groups": [
+    {
+      "label": "main",
+      "sub": "production",
+      "icon": "branch",
+      "tone": "slate",
+      "nodes": [
+        { "label": "Postgres", "sub": "rows", "icon": "database", "tone": "violet" },
+        { "label": "Bucket", "sub": "the real files", "icon": "box", "tone": "blue" }
+      ]
+    },
+    {
+      "label": "a branch",
+      "sub": "copy-on-write, isolated",
+      "icon": "branch",
+      "tone": "green",
+      "nodes": [
+        { "label": "Postgres", "sub": "copy of rows", "icon": "database", "tone": "violet" },
+        { "label": "Bucket", "sub": "copy of files", "icon": "box", "tone": "green" }
+      ]
+    }
+  ]
+}
+```
+
 On Neon, the bucket is declared alongside the database and the functions, so it is part of what a branch is:
 
 ```typescript

--- a/content/posts/neon-presigned-uploads-from-a-function.md
+++ b/content/posts/neon-presigned-uploads-from-a-function.md
@@ -67,7 +67,7 @@ The presigned pattern removes all three, because the large transfer never involv
       { "id": "pg", "label": "Postgres", "sub": "metadata row", "icon": "database", "tone": "violet" }
     ]
   ],
-  "edges": [["client", "fn"], ["client", "store"], ["fn", "pg"]]
+  "edges": [["client", "fn", "presign"], ["client", "store", "PUT bytes"], ["fn", "pg", "metadata"]]
 }
 ```
 

--- a/content/posts/neon-presigned-uploads-from-a-function.md
+++ b/content/posts/neon-presigned-uploads-from-a-function.md
@@ -51,14 +51,27 @@ The presigned pattern removes all three, because the large transfer never involv
 
 ## The flow
 
-```text
-1. client  ── "I want to upload notes.txt" ─────────►  function
-2. function ── presigned PUT url (valid 1h) ────────►  client
-3. client  ── PUT the bytes straight to storage ───►  object storage
-4. client  ── "done, here's the key + size" ───────►  function ── writes metadata row ──► Postgres
+```diagram
+{
+  "type": "graph",
+  "title": "presigned upload: the bytes bypass the function",
+  "columns": [
+    [
+      { "id": "client", "label": "Browser", "sub": "the client", "icon": "globe", "tone": "slate" }
+    ],
+    [
+      { "id": "fn", "label": "Function", "sub": "issues url + records", "icon": "gear", "tone": "blue" }
+    ],
+    [
+      { "id": "store", "label": "Object storage", "sub": "the bytes land here", "icon": "database", "tone": "green" },
+      { "id": "pg", "label": "Postgres", "sub": "metadata row", "icon": "database", "tone": "violet" }
+    ]
+  ],
+  "edges": [["client", "fn"], ["client", "store"], ["fn", "pg"]]
+}
 ```
 
-Steps 1, 2, and 4 are tiny JSON requests to the function. Step 3, the only large transfer, goes directly to storage and never touches your code.
+Hover the browser to see it in action: it talks to the function for a presigned URL and to write metadata, but the large transfer goes straight to object storage. Those function round trips are tiny JSON requests. The only large transfer, the bytes themselves, never touches your code.
 
 ## The code
 

--- a/content/posts/stop-prompting-start-looping.md
+++ b/content/posts/stop-prompting-start-looping.md
@@ -105,6 +105,44 @@ Loops are not free, and the cost does not grow linearly. Every iteration re-send
 
 That is not a reason to avoid loops. It is the reason you always give a loop a stop condition and a budget: a goal that can be checked, a maximum number of turns, or both. A loop that cannot end is not autonomy. It is an open tab.
 
+## Split the model: a cheap executor, an expert on call
+
+There is one more lever, and it is about cost. You do not have to run the whole loop on your most capable model. A pattern that keeps showing up is to run the loop on a fast, cheaper model, the executor, and have it consult a stronger, pricier model, the advisor, only when it hits something hard: a plan, a tricky review, an architectural call.
+
+The executor runs every turn and does the bulk of the work, so most of your tokens are billed at the lower rate. The advisor is a tool the executor calls on demand, a handful of times, for the decisions that actually need the extra capability. Advice comes back, the executor keeps going. You get expert-level judgement on the few steps that need it without paying expert rates for the whole run.
+
+```diagram
+{
+  "type": "graph",
+  "title": "the advisor pattern: a cheap executor, an expert on call",
+  "columns": [
+    [
+      {
+        "id": "exec",
+        "label": "Executor",
+        "sub": "Sonnet 5, every turn",
+        "icon": "gear",
+        "tone": "slate",
+        "detail": "Runs the loop and does the bulk of the work, so most of your tokens are billed at the lower rate."
+      }
+    ],
+    [
+      {
+        "id": "adv",
+        "label": "Advisor",
+        "sub": "Fable 5, on-demand",
+        "icon": "shield",
+        "tone": "accent",
+        "detail": "Consulted only for the hard calls: a plan, a tricky review, an architectural decision. Pricier per token, but you spend very few of them."
+      }
+    ]
+  ],
+  "edges": [["exec", "adv", "tool call"]]
+}
+```
+
+It is the same instinct as splitting the builder from the judge, applied to cost: put the expensive thinking where it earns its keep, and let a cheaper model carry the routine.
+
 ## Loops come in more than one shape
 
 Plan, build, judge is the general shape, but you will meet it wearing different clothes. A few worth knowing:

--- a/content/posts/stop-prompting-start-looping.md
+++ b/content/posts/stop-prompting-start-looping.md
@@ -45,6 +45,19 @@ A plain language model answers once and stops. You ask, it replies, the interact
 2. **Take an action.** Call one tool: read a file, edit code, run a command, run the tests.
 3. **Verify.** Check whether that action moved closer to the goal. If yes, stop. If no, loop.
 
+```diagram
+{
+  "type": "loop",
+  "nodes": [
+    { "label": "Gather context", "variant": "soft" },
+    { "label": "Take action", "variant": "solid" },
+    { "label": "Verify", "variant": "accent" }
+  ],
+  "loopTop": "goal met? stop",
+  "loopBack": "not met, go again"
+}
+```
+
 Most real tasks finish in three to eight of these iterations. Simple lookups take one or two. A gnarly multi-step change can take fifteen or more. The important shift is that the model is no longer the whole system. It is one step inside a loop that carries state forward and decides when the work is done.
 
 ```terminal
@@ -100,11 +113,19 @@ Plan, build, judge is the general shape, but you will meet it wearing different 
 
 **The experiment loop.** When the goal is "make this better" instead of "make this pass," the verifier becomes a metric instead of a test. Read the current code, propose one change, run a short measurement, and keep the change only if the number improved, otherwise roll it back. Andrej Karpathy has described tuning models this way: many small, cheap experiments running overnight, keeping the handful that help and throwing the rest away. The pattern generalizes to anything you can score, from query latency to bundle size.
 
-```text
-read  ->  propose one change  ->  measure  ->  better?
-                                              |-- yes --> keep the change
-                                              +-- no  --> roll back
-                                              then repeat
+```diagram
+{
+  "type": "branch",
+  "nodes": [
+    { "label": "Read", "icon": "box", "tone": "slate" },
+    { "label": "Propose change", "icon": "gear", "tone": "blue" },
+    { "label": "Measure", "icon": "activity", "tone": "amber" }
+  ],
+  "branch": [
+    { "label": "better, keep it", "variant": "good" },
+    { "label": "worse, roll back", "variant": "bad" }
+  ]
+}
 ```
 
 **The overnight triage loop.** The autonomous version starts with a discovery step: read the CI failures, the open issues, and the recent commits to find the work. Then, for each item, it plans a fix, makes it in an isolated git worktree so parallel agents cannot collide, verifies against tests, and opens a PR. You wake up to a queue of reviewed changes instead of a blank editor.

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -124,7 +124,13 @@ marked.use(
     highlight(code, lang) {
       // Interactive fences carry JSON/URLs for their renderers; leave the text
       // untouched so the code renderer below can parse it.
-      if (lang === 'chart' || lang === 'terminal' || lang === 'tabs' || lang === 'github')
+      if (
+        lang === 'chart' ||
+        lang === 'terminal' ||
+        lang === 'tabs' ||
+        lang === 'github' ||
+        lang === 'diagram'
+      )
         return code;
       const language = hljs.getLanguage(lang) ? lang : 'plaintext';
       return hljs.highlight(code, { language }).value;
@@ -198,6 +204,17 @@ marked.use({
           // fall through to a visible code block
         }
         return `<pre><code class="hljs language-tabs">${escapeHtml(text)}</code></pre>`;
+      }
+      if (lang === 'diagram') {
+        try {
+          const spec = JSON.parse(text);
+          if (spec && typeof spec === 'object' && typeof spec.type === 'string') {
+            return `<div class="post-diagram not-prose" data-diagram="${escapeHtml(JSON.stringify(spec))}"></div>`;
+          }
+        } catch {
+          // fall through to a visible code block
+        }
+        return `<pre><code class="hljs language-diagram">${escapeHtml(text)}</code></pre>`;
       }
       if (lang === 'github') {
         const slug = parseRepoSlug(text);

--- a/lib/post-diagram.ts
+++ b/lib/post-diagram.ts
@@ -1,0 +1,173 @@
+/**
+ * Spec for the ```diagram interactive fence, mirroring the ```chart / ```terminal
+ * / ```tabs systems. The body is JSON describing a clean, optionally animated
+ * diagram: linear flows, loops, branches, infrastructure groups, or a small
+ * node/edge graph.
+ *
+ * Parse failures fall back to a normal code block in the markdown renderer, so a
+ * typo never breaks a post build.
+ */
+
+export type DiagramTone =
+  | 'slate'
+  | 'blue'
+  | 'green'
+  | 'violet'
+  | 'red'
+  | 'amber'
+  | 'accent';
+
+export type DiagramVariant = 'soft' | 'solid' | 'accent' | 'good' | 'bad' | 'line';
+
+export interface DiagramNode {
+  id?: string;
+  label: string;
+  sub?: string;
+  icon?: string;
+  tone?: DiagramTone;
+  variant?: DiagramVariant;
+}
+
+export interface DiagramGroup {
+  label: string;
+  sub?: string;
+  icon?: string;
+  tone?: DiagramTone;
+  nodes?: DiagramNode[];
+  groups?: DiagramGroup[];
+}
+
+export type DiagramType = 'flow' | 'loop' | 'branch' | 'infra' | 'graph';
+
+export interface DiagramSpec {
+  type: DiagramType;
+  title?: string;
+  /** loop: a mono goal bar above the diagram. */
+  goal?: string;
+  /** loop: label over / under the loop-back arc. */
+  loopTop?: string;
+  loopBack?: string;
+  /** flow / loop / branch: the row of nodes. */
+  nodes?: DiagramNode[];
+  /** branch: the outcome nodes shown below the row. */
+  branch?: DiagramNode[];
+  /** infra: nested host / cluster boxes. */
+  groups?: DiagramGroup[];
+  /** infra: an optional request path shown above the groups. */
+  flow?: DiagramNode[];
+  /** graph: columns of nodes (each node needs an id). */
+  columns?: DiagramNode[][];
+  /** graph: directed edges as [fromId, toId] pairs. */
+  edges?: [string, string][];
+  /** flow / graph: show the Trace button and packet animation (default true). */
+  trace?: boolean;
+}
+
+const TONES: DiagramTone[] = ['slate', 'blue', 'green', 'violet', 'red', 'amber', 'accent'];
+const VARIANTS: DiagramVariant[] = ['soft', 'solid', 'accent', 'good', 'bad', 'line'];
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function node(v: unknown): DiagramNode | null {
+  if (!v || typeof v !== 'object') return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.label !== 'string') return null;
+  const tone = TONES.includes(o.tone as DiagramTone) ? (o.tone as DiagramTone) : undefined;
+  const variant = VARIANTS.includes(o.variant as DiagramVariant)
+    ? (o.variant as DiagramVariant)
+    : undefined;
+  return {
+    id: str(o.id),
+    label: o.label,
+    sub: str(o.sub),
+    icon: str(o.icon),
+    tone,
+    variant,
+  };
+}
+
+function nodes(v: unknown): DiagramNode[] {
+  if (!Array.isArray(v)) return [];
+  return v.map(node).filter((n): n is DiagramNode => n !== null);
+}
+
+function group(v: unknown): DiagramGroup | null {
+  if (!v || typeof v !== 'object') return null;
+  const o = v as Record<string, unknown>;
+  if (typeof o.label !== 'string') return null;
+  const g: DiagramGroup = {
+    label: o.label,
+    sub: str(o.sub),
+    icon: str(o.icon),
+    tone: TONES.includes(o.tone as DiagramTone) ? (o.tone as DiagramTone) : undefined,
+  };
+  if (Array.isArray(o.groups)) {
+    g.groups = o.groups.map(group).filter((x): x is DiagramGroup => x !== null);
+  } else {
+    g.nodes = nodes(o.nodes);
+  }
+  return g;
+}
+
+function edges(v: unknown): [string, string][] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter(
+      (e): e is [string, string] =>
+        Array.isArray(e) && typeof e[0] === 'string' && typeof e[1] === 'string'
+    )
+    .map((e) => [e[0], e[1]] as [string, string]);
+}
+
+export function parseDiagramSpec(raw: string): DiagramSpec | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!data || typeof data !== 'object') return null;
+  const o = data as Record<string, unknown>;
+  const type = o.type as DiagramType;
+  if (!['flow', 'loop', 'branch', 'infra', 'graph'].includes(type)) return null;
+
+  const spec: DiagramSpec = {
+    type,
+    title: str(o.title),
+    trace: o.trace !== false,
+  };
+
+  if (type === 'graph') {
+    if (!Array.isArray(o.columns)) return null;
+    const columns = o.columns.map(nodes).filter((c) => c.length > 0);
+    if (columns.length === 0) return null;
+    spec.columns = columns;
+    spec.edges = edges(o.edges);
+    return spec;
+  }
+
+  if (type === 'infra') {
+    if (!Array.isArray(o.groups)) return null;
+    const groups = o.groups.map(group).filter((g): g is DiagramGroup => g !== null);
+    if (groups.length === 0) return null;
+    spec.groups = groups;
+    if (Array.isArray(o.flow)) spec.flow = nodes(o.flow);
+    return spec;
+  }
+
+  // flow / loop / branch all need a nodes row
+  const row = nodes(o.nodes);
+  if (row.length === 0) return null;
+  spec.nodes = row;
+  if (type === 'loop') {
+    spec.goal = str(o.goal);
+    spec.loopTop = str(o.loopTop);
+    spec.loopBack = str(o.loopBack);
+  }
+  if (type === 'branch') {
+    spec.branch = nodes(o.branch);
+  }
+  return spec;
+}

--- a/lib/post-diagram.ts
+++ b/lib/post-diagram.ts
@@ -37,6 +37,9 @@ export interface DiagramGroup {
   groups?: DiagramGroup[];
 }
 
+/** A directed edge: [fromId, toId] with an optional short label (port, verb). */
+export type DiagramEdge = [string, string, string?];
+
 export type DiagramType = 'flow' | 'loop' | 'branch' | 'infra' | 'graph';
 
 export interface DiagramSpec {
@@ -57,8 +60,8 @@ export interface DiagramSpec {
   flow?: DiagramNode[];
   /** graph: columns of nodes (each node needs an id). */
   columns?: DiagramNode[][];
-  /** graph: directed edges as [fromId, toId] pairs. */
-  edges?: [string, string][];
+  /** graph: directed edges as [fromId, toId] or [fromId, toId, label]. */
+  edges?: DiagramEdge[];
   /** flow / graph: show the Trace button and packet animation (default true). */
   trace?: boolean;
 }
@@ -111,14 +114,16 @@ function group(v: unknown): DiagramGroup | null {
   return g;
 }
 
-function edges(v: unknown): [string, string][] {
+function edges(v: unknown): DiagramEdge[] {
   if (!Array.isArray(v)) return [];
   return v
     .filter(
-      (e): e is [string, string] =>
+      (e): e is unknown[] =>
         Array.isArray(e) && typeof e[0] === 'string' && typeof e[1] === 'string'
     )
-    .map((e) => [e[0], e[1]] as [string, string]);
+    .map((e) =>
+      (typeof e[2] === 'string' ? [e[0], e[1], e[2]] : [e[0], e[1]]) as DiagramEdge
+    );
 }
 
 export function parseDiagramSpec(raw: string): DiagramSpec | null {

--- a/lib/post-diagram.ts
+++ b/lib/post-diagram.ts
@@ -19,6 +19,9 @@ export type DiagramTone =
 
 export type DiagramVariant = 'soft' | 'solid' | 'accent' | 'good' | 'bad' | 'line';
 
+/** Health status shown as a small dot on the node. */
+export type DiagramStatus = 'ok' | 'warn' | 'down';
+
 export interface DiagramNode {
   id?: string;
   label: string;
@@ -26,6 +29,10 @@ export interface DiagramNode {
   icon?: string;
   tone?: DiagramTone;
   variant?: DiagramVariant;
+  /** Small status dot (ok = green, warn = amber, down = red). */
+  status?: DiagramStatus;
+  /** Extra text revealed when the node is hovered or tapped (graph mode). */
+  detail?: string;
 }
 
 export interface DiagramGroup {
@@ -68,6 +75,7 @@ export interface DiagramSpec {
 
 const TONES: DiagramTone[] = ['slate', 'blue', 'green', 'violet', 'red', 'amber', 'accent'];
 const VARIANTS: DiagramVariant[] = ['soft', 'solid', 'accent', 'good', 'bad', 'line'];
+const STATUSES: DiagramStatus[] = ['ok', 'warn', 'down'];
 
 function str(v: unknown): string | undefined {
   return typeof v === 'string' ? v : undefined;
@@ -88,6 +96,8 @@ function node(v: unknown): DiagramNode | null {
     icon: str(o.icon),
     tone,
     variant,
+    status: STATUSES.includes(o.status as DiagramStatus) ? (o.status as DiagramStatus) : undefined,
+    detail: str(o.detail),
   };
 }
 


### PR DESCRIPTION
A new `diagram` fence, wired into the markdown pipeline the same way as terminal/chart/tabs (parse in lib/post-diagram.ts, placeholder in lib/markdown.ts, hydrated by DiagramBlockWrapper). Author a small JSON block, get a clean, theme-aware, lightly animated diagram; a bad spec falls back to a code block.

Modes: **flow** (steps + flowing arrows), **loop** (loop-back arc + goal bar), **branch** (splits into outcomes), **infra** (nested host/cluster groups + icons), and **graph** (a non-linear DAG with drawn SVG edges, hover-to-isolate-path, and traced request packets). Nodes take an emoji or a built-in SVG icon + a colour tone. Flowing connectors, hover-lift, and trace all respect prefers-reduced-motion, and it works in light and dark.

Documented in the write-post skill, and used in the loops post (a loop and a branch diagram replace the ASCII ones). tsc clean for the new files; both post fences validated through the parser.

Since I can't next build on the Pi, the Cloudflare preview on this PR is the real render check.