### PR TITLE
Neon vs Supabase write-ups: chart tweaks

### DIFF
--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -86,11 +86,26 @@ function LineChart({ spec }: { spec: ChartSpec }) {
   const padB = 34;
   const points = Math.max(...series.map((s) => s.data.length));
   const all = series.flatMap((s) => s.data);
-  const maxV = Math.max(...all) * 1.06;
-  const minV = Math.min(0, Math.min(...all));
   const x = (i: number) => padL + (i / Math.max(1, points - 1)) * (width - padL - padR);
-  const y = (v: number) => padT + (1 - (v - minV) / (maxV - minV)) * (height - padT - padB);
-  const yTicks = [...Array(4).keys()].map((t) => minV + ((maxV - minV) * (t + 1)) / 4);
+
+  // Log axis (opt-in): spreads a squished low end next to a large spike. Falls
+  // back to linear when any value is <= 0, since log10 is undefined there.
+  const canLog = spec.log && all.every((v) => v > 0);
+  let y: (v: number) => number;
+  let yTicks: number[];
+  if (canLog) {
+    const loB = 10 ** Math.floor(Math.log10(Math.min(...all)));
+    const hiB = 10 ** Math.ceil(Math.log10(Math.max(...all)));
+    const lg = (v: number) => Math.log10(Math.max(v, loB));
+    y = (v: number) => padT + (1 - (lg(v) - lg(loB)) / (lg(hiB) - lg(loB))) * (height - padT - padB);
+    yTicks = [];
+    for (let t = loB; t <= hiB + 1e-6; t *= 10) yTicks.push(t);
+  } else {
+    const maxV = Math.max(...all) * 1.06;
+    const minV = Math.min(0, Math.min(...all));
+    y = (v: number) => padT + (1 - (v - minV) / (maxV - minV)) * (height - padT - padB);
+    yTicks = [...Array(4).keys()].map((t) => minV + ((maxV - minV) * (t + 1)) / 4);
+  }
   const labels = spec.x ?? [...Array(points).keys()].map((i) => i + 1);
   const labelStep = Math.ceil(labels.length / 8);
 

--- a/content/posts/neon-vs-supabase-operational-benchmarks.md
+++ b/content/posts/neon-vs-supabase-operational-benchmarks.md
@@ -187,22 +187,17 @@ The attach-vs-clone story makes a testable prediction: copy-on-write operations 
 
 ```chart
 {
-  "type": "line",
+  "type": "bar",
   "title": "Read replica creation as the database grows",
   "unit": "s",
-  "caption": "Median time to a replica answering queries at 100k, 1M, and 5M seeded rows.",
-  "x": ["100k rows", "1M rows", "5M rows"],
-  "series": [
-    {
-      "name": "Neon",
-      "color": "#10b981",
-      "data": [7.9, 8.0, 8.2]
-    },
-    {
-      "name": "Supabase",
-      "color": "#38bdf8",
-      "data": [181.0, 181.8, 202.7]
-    }
+  "caption": "Median time to a replica answering queries at 100k, 1M, and 5M seeded rows. Neon shares storage with the primary (flat); Supabase clones the database, so its time climbs with size.",
+  "rows": [
+    { "label": "Neon · 100k rows", "value": 7.9, "series": "Neon" },
+    { "label": "Supabase · 100k rows", "value": 181.0, "series": "Supabase" },
+    { "label": "Neon · 1M rows", "value": 8.0, "series": "Neon" },
+    { "label": "Supabase · 1M rows", "value": 181.8, "series": "Supabase" },
+    { "label": "Neon · 5M rows", "value": 8.2, "series": "Neon" },
+    { "label": "Supabase · 5M rows", "value": 202.7, "series": "Supabase" }
   ]
 }
 ```

--- a/content/posts/neon-vs-supabase-scaling-costs.md
+++ b/content/posts/neon-vs-supabase-scaling-costs.md
@@ -53,7 +53,8 @@ Disagree with the assumptions? Good: they are parameters, not conclusions. Clone
   "type": "line",
   "title": "Monthly cost of the same application as it grows",
   "unit": "$",
-  "caption": "List prices June 2026, verified against both pricing pages. Model and assumptions are open source; rerun with your own workload.",
+  "log": true,
+  "caption": "Log scale, so the early-stage gap stays visible next to the scale-stage spike. List prices June 2026, verified against both pricing pages. Model and assumptions are open source; rerun with your own workload.",
   "x": [
     "launch month",
     "first customers",

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -53,6 +53,9 @@ export interface ChartSpec {
   /** line */
   x?: Array<string | number>;
   series?: LineSeries[] | DotSeries[] | CdfSeries[];
+  /** line: use a log10 y-axis (values must be > 0). Spreads out a squished
+   *  low end next to a large spike. Opt-in; linear otherwise. */
+  log?: boolean;
 }
 
 export function parseChartSpec(raw: string): ChartSpec | null {


### PR DESCRIPTION
Log-scale cost chart and the replica-vs-size chart as bars, matching the dashboard updates.