### PR TITLE
Fix broken diagram fences in recent posts

### DIFF
--- a/content/posts/devops-engineer-career-paths-next-five-years.md
+++ b/content/posts/devops-engineer-career-paths-next-five-years.md
@@ -26,7 +26,7 @@ This is not a "learn these 40 tools" post. It is a map of where the DevOps role 
 
 ```diagram
 {
-  "mode": "branch",
+  "type": "branch",
   "title": "Where the DevOps role forks",
   "nodes": [{ "label": "DevOps Engineer (today)", "icon": "gear" }],
   "branch": [

--- a/content/posts/github-rce-git-push-header-injection-cve-2026-3854.md
+++ b/content/posts/github-rce-git-push-header-injection-cve-2026-3854.md
@@ -74,9 +74,9 @@ Follow the data. The push option value is user-controlled. It gets concatenated 
 
 ```diagram
 {
-  "mode": "flow",
+  "type": "flow",
   "title": "From push option to injected field",
-  "steps": [
+  "nodes": [
     { "label": "git push -o \"tag=x;env=privileged\"", "icon": "branch" },
     { "label": "Front-end concatenates the value into X-Stat", "icon": "box" },
     { "label": "X-Stat: ...;tag=x;env=privileged", "icon": "net" },

--- a/content/posts/pglayers-postgres-extensions-docker-layers.md
+++ b/content/posts/pglayers-postgres-extensions-docker-layers.md
@@ -82,7 +82,7 @@ That is the whole thing. Each `pgx-*` image is built `FROM scratch` and contains
 
 ```diagram
 {
-  "mode": "infra",
+  "type": "flow",
   "title": "Composing a Postgres image with pglayers",
   "nodes": [
     { "label": "postgres:17 (official base)", "icon": "database" },

--- a/content/posts/pwn-request-github-actions-checkout-v7.md
+++ b/content/posts/pwn-request-github-actions-checkout-v7.md
@@ -70,9 +70,9 @@ An attacker opens a PR from a fork. Their `npm test`, or a `postinstall` script,
 
 ```diagram
 {
-  "mode": "flow",
+  "type": "flow",
   "title": "The pwn request",
-  "steps": [
+  "nodes": [
     { "label": "Attacker opens PR from a fork", "icon": "branch" },
     { "label": "pull_request_target fires in BASE repo context (secrets + write token)", "icon": "activity" },
     { "label": "Workflow checks out the fork's head commit", "icon": "box" },

--- a/content/posts/security-profiles-operator-seccomp-boundary.md
+++ b/content/posts/security-profiles-operator-seccomp-boundary.md
@@ -46,9 +46,9 @@ seccomp (secure computing mode) is a kernel feature that filters syscalls per pr
 
 ```diagram
 {
-  "mode": "flow",
+  "type": "flow",
   "title": "What a seccomp profile changes",
-  "steps": [
+  "nodes": [
     { "label": "Attacker gets code execution in the container", "icon": "cpu" },
     { "label": "Tries a container-escape syscall (unshare, keyctl, mount)", "icon": "activity" },
     { "label": "No profile: kernel runs it, escape proceeds", "icon": "server" },
@@ -133,9 +133,9 @@ Now deploy the workload with the matching label and, critically, **exercise it**
 
 ```diagram
 {
-  "mode": "loop",
+  "type": "loop",
   "title": "The record-review-enforce loop",
-  "steps": [
+  "nodes": [
     { "label": "Record: run the workload under a ProfileRecording", "icon": "activity" },
     { "label": "Exercise every code path (tests, jobs, edge cases)", "icon": "rocket" },
     { "label": "Review the generated SeccompProfile syscall list", "icon": "check" },


### PR DESCRIPTION
Five recent posts used `"mode"`/`"steps"` instead of the renderer's `"type"`/`"nodes"`, so their diagrams showed as raw JSON. Corrected across career-paths, pwn-request, Security Profiles Operator, GitHub RCE, and pglayers (also switched pglayers from infra to flow). Every diagram validated against the parser.