### PR TITLE
Fix two more diagram fences (steps -> nodes)

### DIFF
--- a/content/posts/argo-cd-repo-server-unauthenticated-rce.md
+++ b/content/posts/argo-cd-repo-server-unauthenticated-rce.md
@@ -90,7 +90,7 @@ Code execution inside one container is bad. What makes this a cluster compromise
 {
   "type": "flow",
   "title": "From one pod to the whole cluster",
-  "steps": [
+  "nodes": [
     { "label": "Compromised pod", "sub": "any workload in the cluster", "icon": "pod" },
     { "label": "Unauth gRPC to repo-server", "sub": "GenerateManifest + malicious kustomize opts", "icon": "net" },
     { "label": "RCE in repo-server", "sub": "reads env, grabs REDIS_PASSWORD", "icon": "cpu" },

--- a/content/posts/build-a-terraform-provider-plugin-framework.md
+++ b/content/posts/build-a-terraform-provider-plugin-framework.md
@@ -46,7 +46,7 @@ Terraform does not call your API. It calls your provider binary over gRPC, and y
 {
   "type": "flow",
   "title": "Where a provider sits",
-  "steps": [
+  "nodes": [
     { "label": "terraform apply", "sub": "core computes the plan", "icon": "gear" },
     { "label": "Provider (gRPC)", "sub": "your Go binary", "icon": "box" },
     { "label": "API client", "sub": "HTTP + Bearer token", "icon": "net" },


### PR DESCRIPTION
Follow-up to #1492: the Terraform-provider and Argo CD posts used `"steps"` instead of `"nodes"`, so their flow diagrams rendered as raw JSON. A full site sweep is now clean.