### PR TITLE
fix: prevent long chart labels overlapping plots

### DIFF
--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -12,6 +12,7 @@ import {
   formatValue,
   formatAxisValue,
   niceAxisTicks,
+  wrapChartLabel,
   median,
   percentile,
   seriesColor,
@@ -24,8 +25,13 @@ import {
 function BarChart({ spec }: { spec: ChartSpec }) {
   const rows = spec.rows as BarRow[];
   const width = 720;
-  const rowH = 42;
-  const labelW = 190;
+  const labels = rows.map((row) => wrapChartLabel(row.label));
+  const hasWrappedLabel = labels.some((lines) => lines.length > 1);
+  const rowH = hasWrappedLabel ? 50 : 42;
+  const longestLabelLine = Math.max(
+    ...labels.flatMap((lines) => lines.map((line) => Array.from(line).length))
+  );
+  const labelW = Math.min(240, Math.max(150, longestLabelLine * 7.5 + 18));
   const valueW = spec.tickLabel ? 150 : 90;
   const pad = 6;
   const height = rows.length * rowH + pad * 2;
@@ -40,9 +46,22 @@ function BarChart({ spec }: { spec: ChartSpec }) {
     <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Bar chart'}>
       {rows.map((r, i) => {
         const cy = pad + i * rowH + rowH / 2;
+        const labelLines = labels[i];
         return (
           <g key={`${r.label}-${i}`}>
-            <text x={0} y={cy + 4} fontSize={13} className="fill-muted-foreground">{r.label}</text>
+            <title>{`${r.label}: ${formatValue(r.value, spec.unit)}`}</title>
+            <text
+              x={0}
+              y={labelLines.length > 1 ? cy - 3 : cy + 4}
+              fontSize={13}
+              className="fill-muted-foreground"
+            >
+              {labelLines.map((line, lineIndex) => (
+                <tspan x={0} dy={lineIndex === 0 ? 0 : 14} key={line}>
+                  {line}
+                </tspan>
+              ))}
+            </text>
             <line x1={labelW} y1={cy} x2={width - valueW} y2={cy} className="stroke-border" strokeOpacity={0.5} />
             <rect
               x={labelW}

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -105,6 +105,30 @@ export function niceAxisTicks(min: number, max: number, targetIntervals = 4): nu
   return Array.from({ length: count + 1 }, (_, i) => Number((first + i * step).toPrecision(12)));
 }
 
+/** Wrap a chart label at a word boundary and cap the second line so labels can
+ * never spill into the plot area. */
+export function wrapChartLabel(label: string, maxChars = 28): string[] {
+  const text = label.trim();
+  const chars = Array.from(text);
+  if (chars.length <= maxChars) return [text];
+
+  const candidate = chars.slice(0, maxChars + 1);
+  const whitespaceIndex = candidate.reduce(
+    (last, char, index) => (/\s/.test(char) ? index : last),
+    -1
+  );
+  const breakAt = whitespaceIndex >= Math.floor(maxChars * 0.55) ? whitespaceIndex : maxChars;
+  const first = chars.slice(0, breakAt).join('').trim();
+  const remainder = chars.slice(breakAt).join('').trim();
+  const remainderChars = Array.from(remainder);
+  const second =
+    remainderChars.length > maxChars
+      ? `${remainderChars.slice(0, Math.max(1, maxChars - 3)).join('').trimEnd()}...`
+      : remainder;
+
+  return second ? [first, second] : [first];
+}
+
 export function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { parseMarkdown } from '@/lib/markdown';
-import { parseChartSpec, formatValue, formatAxisValue, niceAxisTicks, median, percentile } from '@/lib/post-charts';
+import {
+  parseChartSpec,
+  formatValue,
+  formatAxisValue,
+  niceAxisTicks,
+  wrapChartLabel,
+  median,
+  percentile,
+} from '@/lib/post-charts';
 
 const BAR_SPEC = {
   type: 'bar',
@@ -71,6 +79,18 @@ describe('post chart embeds', () => {
     expect(niceAxisTicks(0, 1655.08)).toEqual([0, 500, 1000, 1500, 2000]);
     expect(niceAxisTicks(-8, 12)).toEqual([-10, -5, 0, 5, 10, 15]);
     expect(niceAxisTicks(5, 5)).toEqual([5]);
+  });
+
+  it('wraps long chart labels without losing the full first words', () => {
+    expect(wrapChartLabel('Cross-region to Postgres')).toEqual(['Cross-region to Postgres']);
+    expect(wrapChartLabel('Function to co-located Postgres database')).toEqual([
+      'Function to co-located',
+      'Postgres database',
+    ]);
+    expect(wrapChartLabel('a'.repeat(70))).toEqual([
+      'a'.repeat(28),
+      `${'a'.repeat(25)}...`,
+    ]);
   });
 
   it('accepts cdf specs and renders the fence placeholder', () => {


### PR DESCRIPTION
Makes horizontal bar charts reserve space from their rendered labels instead of a fixed gutter. Long labels wrap to two lines, rows expand automatically, and extreme labels truncate without entering the plot.

Adds focused coverage for normal, wrapped, and very long labels.