### PR TITLE
Use Svix's tracked link for sponsor CTAs

### DIFF
--- a/app/games/webhook-delivery-simulator/page.tsx
+++ b/app/games/webhook-delivery-simulator/page.tsx
@@ -59,7 +59,7 @@ function WebhookDeliveryEducational() {
           turns this flow into a typed sender and receiver you can build from. This simulator uses
           the published{' '}
           <a
-            href="https://www.svix.com/?ref=devops-daily"
+            href="https://link.svix.com/devopsdaily"
             className="font-medium text-primary underline underline-offset-2"
             target="_blank"
             rel="noopener noreferrer sponsored"

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -78,6 +78,10 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     'amzn.to', // Amazon short links
     'amazon.com/.*tag=', // Amazon affiliate tags
     '[?&]ref=devops-daily', // Partner referral links
+    // Sponsors' own tracked short links. These carry no ref= param, so
+    // without an entry here a post could lose its disclosure banner purely
+    // by switching to the link the sponsor asked us to use.
+    'link\\.svix\\.com',
   ];
   const hasAffiliateLinks = affiliatePatterns.some((pattern) =>
     new RegExp(pattern).test(post.content)

--- a/components/games/webhook-delivery-simulator.tsx
+++ b/components/games/webhook-delivery-simulator.tsx
@@ -875,7 +875,7 @@ svix-signature: ${signatureHeader || 'computing...'}`}
           </p>
         </div>
         <a
-          href="https://www.svix.com/?ref=devops-daily"
+          href="https://link.svix.com/devopsdaily"
           target="_blank"
           rel="noopener noreferrer sponsored"
           className="inline-flex shrink-0 items-center gap-2 text-sm font-semibold text-primary hover:underline"

--- a/content/posts/reliable-webhook-delivery-retries-signatures-idempotency.md
+++ b/content/posts/reliable-webhook-delivery-retries-signatures-idempotency.md
@@ -51,7 +51,7 @@ None of these are webhook problems. They are delivery problems, and they are the
 - Node.js 20 or newer, for the examples
 - Comfort with HTTP semantics: status codes, timeouts, request bodies
 - A rough idea of HMAC (a keyed hash; same input plus same key gives the same digest)
-- Optional: a free [Svix](https://www.svix.com/?ref=devops-daily) account, if you want to run the sending half against the real API
+- Optional: a free [Svix](https://link.svix.com/devopsdaily) account, if you want to run the sending half against the real API
 
 ## Why a POST is not a delivery
 
@@ -469,6 +469,6 @@ The delivery problems are the same everywhere, so the checklist is portable whet
 6. **Prefer sequence numbers over strict ordering.** Strict FIFO buys you head-of-line blocking.
 7. **Build the log before you need it,** and let customers read it.
 
-If those mechanics are product infrastructure rather than your product, [Svix Dispatch](https://www.svix.com/?ref=devops-daily) packages them behind one API and gives your customers a polished place to configure endpoints, inspect attempts, and replay failures themselves. It also builds on the [Standard Webhooks](https://www.standardwebhooks.com/) signing model, so receivers get a documented verification contract instead of a proprietary signature scheme. Their [docs](https://docs.svix.com/) publish the operational details, including retry timing and ordering tradeoffs, which makes the service easier to evaluate against a home-grown implementation.
+If those mechanics are product infrastructure rather than your product, [Svix Dispatch](https://link.svix.com/devopsdaily) packages them behind one API and gives your customers a polished place to configure endpoints, inspect attempts, and replay failures themselves. It also builds on the [Standard Webhooks](https://www.standardwebhooks.com/) signing model, so receivers get a documented verification contract instead of a proprietary signature scheme. Their [docs](https://docs.svix.com/) publish the operational details, including retry timing and ordering tradeoffs, which makes the service easier to evaluate against a home-grown implementation.
 
 For an interactive walkthrough of retries, signatures, and duplicate handling, try the [webhook delivery simulator](/games/webhook-delivery-simulator). For related reading on the same underlying problem, our post on [designing automation with failure in mind](/posts/designing-automation-with-failure-in-mind) covers the general pattern, and the [message queue simulator](/games/message-queue-simulator) is a good way to build intuition for at-least-once delivery before you have to debug it in production.

--- a/lib/sponsors.ts
+++ b/lib/sponsors.ts
@@ -29,7 +29,7 @@ export const sponsors: Sponsor[] = [
     name: 'Svix',
     logo: '/svix-brand.svg',
     darkLogo: '/svix-brand-light.svg',
-    url: 'https://www.svix.com/?ref=devops-daily',
+    url: 'https://link.svix.com/devopsdaily',
     tagline: 'Webhooks as a service',
     description:
       'Svix Dispatch sends your webhooks for you: retries with exponential backoff, signed payloads, idempotency keys, and a delivery log your customers can see.',


### PR DESCRIPTION
Swaps the five Svix calls to action to `link.svix.com/devopsdaily`, the link they asked us to use so the placement is attributable on their side.

Docs citations stay on `docs.svix.com`: those are references the reader should follow, not CTAs, and putting a campaign redirect on a citation is wrong on both counts.

The load-bearing bit is the one-line change in `app/posts/[slug]/page.tsx`. The affiliate disclosure banner is triggered by pattern-matching the post body, and `[?&]ref=devops-daily` was the only pattern the sponsored article matched. Swapping the links would have removed the disclosure from a paid placement without anything failing. `link.svix.com` is now a recognised pattern, and I verified the banner still renders.

Checked: `tsc` identical to clean main (528 both, same errors), and the redirect resolves 200.