### PR TITLE
Rebuild the sponsorship page as a media kit

### DIFF
--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -219,26 +219,46 @@ export default function SponsorshipPage() {
       <BreadcrumbSchema items={breadcrumbItems} />
 
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
-        {/* Hero */}
-        <div className="rounded-xl border border-border bg-card p-8 sm:p-10">
-          <div className="flex items-start justify-between gap-4">
+        {/* Hero. The rocket is decorative line art, drawn inline rather than
+            shipped as an asset so it inherits the accent colour and stays
+            crisp at any size. aria-hidden: it carries no meaning. */}
+        <div className="relative overflow-hidden rounded-xl border border-border bg-card p-8 sm:p-10">
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 240 240"
+            className="pointer-events-none absolute -right-6 top-1/2 hidden h-[300px] w-[300px] -translate-y-1/2 text-primary/20 lg:block"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M120 26c22 20 34 48 34 80 0 14-2 27-6 39h-56c-4-12-6-25-6-39 0-32 12-60 34-80z" />
+            <circle cx="120" cy="96" r="16" />
+            <path d="M86 116c-14 8-24 22-26 40 10-2 20-6 28-12" />
+            <path d="M154 116c14 8 24 22 26 40-10-2-20-6-28-12" />
+            <path d="M104 145h32l-6 16h-20z" />
+            <path d="M112 172c0 8 3 14 8 20 5-6 8-12 8-20" />
+          </svg>
+
+          <div className="relative flex items-start justify-between gap-4">
             <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
               Media kit 2026
             </span>
             <span className="font-mono text-[11px] text-muted-foreground">devops-daily.com</span>
           </div>
 
-          <h1 className="mt-8 text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl">
+          <h1 className="relative mt-8 max-w-3xl text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:max-w-[62%]">
             Reach the DevOps audience that{' '}
             <span className="text-primary">drives decisions</span>
           </h1>
 
-          <p className="mt-5 max-w-xl text-base leading-relaxed text-muted-foreground">
+          <p className="relative mt-5 max-w-xl text-base leading-relaxed text-muted-foreground">
             DevOps Daily is where developers, platform engineers, SREs and technical leaders go
             while they are deciding what to build with.
           </p>
 
-          <div className="mt-7 flex flex-wrap gap-3">
+          <div className="relative mt-7 flex flex-wrap gap-3">
             <Button asChild>
               <a href="mailto:sponsorship@devops-daily.com">
                 <Mail className="mr-2 h-4 w-4" />

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -16,6 +16,7 @@ import {
 import { SectionHeader } from '@/components/section-header';
 import { SectionSeparator } from '@/components/section-separator';
 import { BreadcrumbSchema } from '@/components/schema-markup';
+import { sponsors } from '@/lib/sponsors';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -217,286 +218,238 @@ export default function SponsorshipPage() {
     <>
       <BreadcrumbSchema items={breadcrumbItems} />
 
-      {/* Hero */}
-      <div className="relative overflow-hidden">
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 -z-10 opacity-[0.07] dark:opacity-[0.09]"
-          style={{
-            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-            backgroundSize: '24px 24px',
-            maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
-            WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)',
-          }}
-        />
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-primary/[0.04] via-transparent to-transparent" />
-
-        <div className="container relative mx-auto px-4 py-16 md:py-20">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="text-xs font-mono text-muted-foreground mb-3">// sponsorship</p>
-
-            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-md border border-primary/20 bg-primary/5 text-xs font-mono text-primary mb-6">
-              <Rocket className="w-3.5 h-3.5" strokeWidth={1.5} />
-              Limited slots available
-            </div>
-
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-6">
-              Reach{' '}
-              <span className="text-primary relative inline-block">
-                20,000+
-                <svg
-                  className="absolute -bottom-2 left-0 w-full h-3 text-primary/40"
-                  viewBox="0 0 200 12"
-                  preserveAspectRatio="none"
-                >
-                  <path
-                    d="M2 9 Q25 2 50 8 Q75 1 100 7 Q125 2 150 9 Q175 4 198 7"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    fill="none"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </span>{' '}
-              DevOps engineers
-              <br />
-              who decide what to buy.
-            </h1>
-
-            <p className="text-lg sm:text-xl text-muted-foreground max-w-2xl mx-auto mb-8 leading-relaxed">
-              DevOps Daily is where practicing platform engineers, SREs, and cloud architects come
-              to learn by doing. Your product lives inside real tutorials and interactive labs, not
-              next to cat videos.
-            </p>
-
-            <div className="flex flex-wrap justify-center gap-3">
-              <Button asChild size="lg">
-                <a
-                  href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry"
-                  className="group"
-                >
-                  <Mail className="mr-2 h-4 w-4" strokeWidth={1.5} />
-                  Get the media kit
-                  <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
-                </a>
-              </Button>
-              <Button asChild variant="outline" size="lg">
-                <a href="#packages">See packages</a>
-              </Button>
-            </div>
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+        {/* Hero */}
+        <div className="rounded-xl border border-border bg-card p-8 sm:p-10">
+          <div className="flex items-start justify-between gap-4">
+            <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+              Media kit 2026
+            </span>
+            <span className="font-mono text-[11px] text-muted-foreground">devops-daily.com</span>
           </div>
-        </div>
-      </div>
 
-      <div className="container mx-auto px-4">
-        <SectionSeparator command="cat audience.csv" />
+          <h1 className="mt-8 text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl">
+            Reach the DevOps audience that{' '}
+            <span className="text-primary">drives decisions</span>
+          </h1>
 
-        {/* Stats */}
-        <section className="my-12 max-w-5xl mx-auto">
-          <dl className="grid grid-cols-2 md:grid-cols-4 gap-px bg-border border rounded-md overflow-hidden">
-            {STATS.map((s) => (
-              <div key={s.label} className="bg-card p-5">
-                <dt className="text-[11px] uppercase tracking-wider text-muted-foreground font-mono">
-                  {s.label}
-                </dt>
-                <dd className="text-2xl sm:text-3xl font-bold tabular-nums mt-1 text-foreground">
-                  {s.value}
-                </dd>
-                <dd className="text-xs text-muted-foreground/80 mt-0.5 font-mono">{s.detail}</dd>
-              </div>
-            ))}
-          </dl>
-        </section>
-
-        {/* Audience breakdown */}
-        <section className="my-12 max-w-3xl mx-auto">
-          <SectionHeader
-            label="audience"
-            title="Who you're reaching"
-            description="Breakdown of who visits, based on reader surveys and subscription sign-ups."
-          />
-          <ul className="space-y-2 font-mono text-sm">
-            {AUDIENCE.map((a) => (
-              <li
-                key={a.label}
-                className="flex items-center justify-between gap-4 rounded-md border bg-card px-4 py-3"
-              >
-                <span className="text-foreground">{a.label}</span>
-                <span className="text-primary tabular-nums font-semibold">{a.share}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <SectionSeparator command="ls /placement-channels" />
-
-        {/* Channels */}
-        <section className="my-12 max-w-5xl mx-auto">
-          <SectionHeader
-            label="channels"
-            title="Where your brand shows up"
-            description="Four distinct surfaces, each with its own audience and format."
-          />
-          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
-            {CHANNELS.map((c) => {
-              const Icon = c.icon;
-              return (
-                <div key={c.title} className="bg-card p-5">
-                  <div className="flex items-start gap-3 mb-2">
-                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
-                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
-                    </div>
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between gap-2 mb-0.5">
-                        <h3 className="font-semibold">{c.title}</h3>
-                        <span className="text-[11px] font-mono tabular-nums text-primary shrink-0">
-                          {c.metric}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground leading-relaxed">
-                        {c.description}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        <SectionSeparator command="cat why-sponsor.md" />
-
-        {/* Why Sponsor */}
-        <section className="my-12 max-w-4xl mx-auto">
-          <SectionHeader label="why sponsor" title="Why sponsor DevOps Daily" />
-          <div className="grid gap-px sm:grid-cols-2 bg-border border rounded-md overflow-hidden">
-            {WHY.map((w) => {
-              const Icon = w.icon;
-              return (
-                <div key={w.title} className="bg-card p-5">
-                  <div className="flex items-start gap-3">
-                    <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center">
-                      <Icon className="w-5 h-5 text-primary" strokeWidth={1.5} />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold mb-1">{w.title}</h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">
-                        {w.description}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        <SectionSeparator command="ls /packages" />
-
-        {/* Packages */}
-        <section id="packages" className="my-12 max-w-5xl mx-auto scroll-mt-20">
-          <SectionHeader
-            label="packages"
-            title="Sponsorship packages"
-            description="Start with awareness, scale to category ownership. Cancel anytime."
-          />
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {PACKAGES.map((pkg) => (
-              <div
-                key={pkg.name}
-                className={`relative rounded-md border bg-card p-6 flex flex-col ${
-                  pkg.popular
-                    ? 'border-primary/50 bg-primary/[0.03] ring-1 ring-primary/20'
-                    : 'border-border'
-                }`}
-              >
-                {pkg.popular && (
-                  <span className="absolute -top-2.5 right-4 px-2 py-0.5 text-[10px] font-mono tabular-nums uppercase tracking-wider text-primary bg-background border border-primary/40 rounded">
-                    most popular
-                  </span>
-                )}
-                <p className="text-xs font-mono text-muted-foreground mb-1">// {pkg.name.toLowerCase()}</p>
-                <h3 className="text-xl font-bold mb-1">{pkg.name}</h3>
-                <p className="text-sm text-muted-foreground mb-4">{pkg.description}</p>
-                <div className="mb-5 font-mono tabular-nums">
-                  <span className="text-3xl font-bold text-foreground">{pkg.price}</span>
-                  {pkg.cadence && (
-                    <span className="text-sm text-muted-foreground">{pkg.cadence}</span>
-                  )}
-                </div>
-                <ul className="space-y-2 flex-1 mb-6">
-                  {pkg.features.map((f) => (
-                    <li key={f} className="flex items-start gap-2 text-sm">
-                      <CheckCircle2
-                        className="h-4 w-4 text-primary mt-0.5 shrink-0"
-                        strokeWidth={1.5}
-                      />
-                      <span className="text-foreground">{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  asChild
-                  variant={pkg.popular ? 'default' : 'outline'}
-                  className="w-full"
-                >
-                  <a
-                    href={`mailto:info@devops-daily.com?subject=Sponsorship Inquiry - ${pkg.name}`}
-                  >
-                    {pkg.price === 'Custom' ? 'Get a quote' : `Start with ${pkg.name}`}
-                  </a>
-                </Button>
-              </div>
-            ))}
-          </div>
-          <p className="text-xs text-muted-foreground text-center mt-6 font-mono">
-            All packages include monthly reporting with impressions, clicks, and top-referring content.
+          <p className="mt-5 max-w-xl text-base leading-relaxed text-muted-foreground">
+            DevOps Daily is where developers, platform engineers, SREs and technical leaders go
+            while they are deciding what to build with.
           </p>
-        </section>
 
-        <SectionSeparator command="cat faq.md" />
-
-        {/* FAQ */}
-        <section className="my-12 max-w-3xl mx-auto">
-          <SectionHeader label="faq" title="Frequently asked" />
-          <div className="space-y-3">
-            {FAQ.map((f) => (
-              <div key={f.q} className="rounded-md border bg-card p-5">
-                <h3 className="font-semibold mb-2">{f.q}</h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">{f.a}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* Final CTA */}
-        <section className="my-16 max-w-3xl mx-auto">
-          <div className="rounded-md border bg-primary/5 p-8 text-center">
-            <div className="inline-flex items-center gap-2 mb-4">
-              <Users className="w-5 h-5 text-primary" strokeWidth={1.5} />
-              <p className="text-xs font-mono text-primary uppercase tracking-wider">
-                Let&apos;s talk
-              </p>
-            </div>
-            <h2 className="text-2xl sm:text-3xl font-bold mb-3">
-              Ready to reach engineers who build?
-            </h2>
-            <p className="text-muted-foreground mb-6">
-              Tell us about your product and who you want to reach. We respond within 24 hours with
-              a media kit and available slots.
-            </p>
-            <Button asChild size="lg">
-              <a
-                href="mailto:info@devops-daily.com?subject=Sponsorship Inquiry"
-                className="group"
-              >
-                <Mail className="mr-2 h-4 w-4" strokeWidth={1.5} />
-                info@devops-daily.com
-                <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button asChild>
+              <a href="mailto:sponsorship@devops-daily.com">
+                <Mail className="mr-2 h-4 w-4" />
+                sponsorship@devops-daily.com
+              </a>
+            </Button>
+            <Button asChild variant="outline">
+              <a href="#packages">
+                See packages
+                <ArrowRight className="ml-2 h-4 w-4" />
               </a>
             </Button>
           </div>
-        </section>
+        </div>
+
+        {/* Reach. Each figure names what it measures and over what window, so
+            none of it falls apart when a sponsor asks what is behind it. */}
+        <div className="mt-6">
+          <h2 className="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+            Our reach
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {STATS.map((stat) => (
+              <div key={stat.label} className="rounded-xl border border-border bg-card p-5">
+                <div className="text-3xl font-bold leading-none tracking-tight">{stat.value}</div>
+                <div className="mt-3 text-sm font-medium">{stat.label}</div>
+                <div className="mt-1 text-xs text-muted-foreground">{stat.detail}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Audience */}
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          <div className="rounded-xl border border-border bg-card p-6">
+            <h2 className="mb-5 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+              Who we reach
+            </h2>
+            <div className="space-y-3">
+              {AUDIENCE.map((role) => (
+                <div key={role.label}>
+                  <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                    <span className="text-sm">{role.label}</span>
+                    <span className="font-mono text-xs text-muted-foreground">{role.share}</span>
+                  </div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div className="h-full rounded-full bg-primary" style={{ width: role.share }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p className="mt-5 border-t border-border pt-4 text-xs text-muted-foreground">
+              From our reader survey. Engineers who evaluate tools as part of the job.
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-6">
+            <h2 className="mb-5 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+              How your content gets distributed
+            </h2>
+            <ol className="space-y-2.5">
+              {[
+                'We write the technical piece',
+                'Published on DevOps Daily',
+                'Amplified on daily.dev',
+                'Featured in the weekly newsletter',
+                'Indexed by search engines, compounding',
+              ].map((step, i) => (
+                <li key={step} className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-primary/10 font-mono text-[10px] text-primary">
+                    {i + 1}
+                  </span>
+                  <span className="text-sm leading-snug">{step}</span>
+                </li>
+              ))}
+            </ol>
+            <p className="mt-5 border-t border-border pt-4 text-xs text-muted-foreground">
+              We do not sell banner ads. We write technical content developers want to read.
+            </p>
+          </div>
+        </div>
+
+        {/* Why */}
+        <div className="mt-6 grid gap-3 md:grid-cols-3">
+          {WHY.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div key={item.title} className="rounded-xl border border-border bg-card p-6">
+                <Icon className="h-5 w-5 text-primary" />
+                <h3 className="mt-4 text-sm font-semibold">{item.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {item.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Channels */}
+        <div className="mt-6">
+          <h2 className="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+            Where your brand appears
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {CHANNELS.map((channel) => {
+              const Icon = channel.icon;
+              return (
+                <div key={channel.title} className="rounded-xl border border-border bg-card p-6">
+                  <div className="flex items-start justify-between gap-4">
+                    <Icon className="h-5 w-5 text-primary" />
+                    <span className="font-mono text-[11px] text-muted-foreground">
+                      {channel.metric}
+                    </span>
+                  </div>
+                  <h3 className="mt-4 text-sm font-semibold">{channel.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {channel.description}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Packages */}
+        <div id="packages" className="mt-6 scroll-mt-24">
+          <h2 className="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+            Packages
+          </h2>
+          <div className="grid gap-3 lg:grid-cols-3">
+            {PACKAGES.map((pkg) => (
+              <div
+                key={pkg.name}
+                className={
+                  pkg.popular
+                    ? 'rounded-xl border border-primary/40 bg-primary/5 p-6'
+                    : 'rounded-xl border border-border bg-card p-6'
+                }
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">{pkg.name}</h3>
+                  {pkg.popular && (
+                    <span className="rounded-full border border-primary/40 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-primary">
+                      Most picked
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 flex items-baseline gap-1">
+                  <span className="text-3xl font-bold tracking-tight">{pkg.price}</span>
+                  <span className="text-sm text-muted-foreground">{pkg.cadence}</span>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">{pkg.description}</p>
+                <ul className="mt-5 space-y-2 border-t border-border pt-5">
+                  {pkg.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2 text-sm">
+                      <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+                      <span className="leading-snug text-muted-foreground">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-center text-xs text-muted-foreground">
+            Custom packages available. Tell us what you are launching and we will work out what fits.
+          </p>
+        </div>
+
+        {/* Current sponsors */}
+        <div className="mt-6 rounded-xl border border-border bg-card p-6">
+          <h2 className="mb-4 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+            Current sponsors
+          </h2>
+          <div className="flex flex-wrap items-center gap-6">
+            {sponsors.map((sponsor) => (
+              <span key={sponsor.name} className="text-sm font-medium text-muted-foreground">
+                {sponsor.name}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <SectionSeparator command="cat /sponsorship/faq.md" />
+
+        {/* FAQ */}
+        <div className="mt-6">
+          <SectionHeader label="faq" title="Questions we get asked" />
+          <div className="mt-6 grid gap-3 md:grid-cols-2">
+            {FAQ.map((item) => (
+              <div key={item.q} className="rounded-xl border border-border bg-card p-6">
+                <h3 className="text-sm font-semibold">{item.q}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="mt-6 rounded-xl border border-primary/30 bg-primary/5 p-8 text-center">
+          <Rocket className="mx-auto h-6 w-6 text-primary" />
+          <h2 className="mt-4 text-xl font-bold">Let us build something great together.</h2>
+          <p className="mx-auto mt-2 max-w-lg text-sm text-muted-foreground">
+            Tell us what you are launching and who you need to reach. We reply within a day.
+          </p>
+          <Button asChild className="mt-6">
+            <a href="mailto:sponsorship@devops-daily.com">
+              <Mail className="mr-2 h-4 w-4" />
+              sponsorship@devops-daily.com
+            </a>
+          </Button>
+        </div>
       </div>
     </>
   );

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -19,16 +19,16 @@ import { BreadcrumbSchema } from '@/components/schema-markup';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Sponsorship - Reach 25,000+ DevOps Engineers',
+  title: 'Sponsorship - Reach 20,000+ DevOps Engineers',
   description:
-    'Partner with DevOps Daily to reach 25,000+ monthly readers, 5,000+ newsletter subscribers, and a highly engaged audience of DevOps engineers, SREs, and technical decision-makers.',
+    'Partner with DevOps Daily to reach 20,000+ monthly readers, 1,500 newsletter subscribers, and 23.7M syndicated impressions across an audience of DevOps engineers, SREs, and technical decision-makers.',
   alternates: {
     canonical: '/sponsorship',
   },
   openGraph: {
-    title: 'Sponsor DevOps Daily - Reach 25,000+ DevOps Engineers',
+    title: 'Sponsor DevOps Daily - Reach 20,000+ DevOps Engineers',
     description:
-      'Partner with DevOps Daily to connect with 25,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
+      'Partner with DevOps Daily to connect with 20,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
     url: '/sponsorship',
     type: 'website',
     images: [
@@ -42,18 +42,22 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Sponsor DevOps Daily - Reach 25,000+ DevOps Engineers',
+    title: 'Sponsor DevOps Daily - Reach 20,000+ DevOps Engineers',
     description:
-      'Partner with DevOps Daily to reach 25,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
+      'Partner with DevOps Daily to reach 20,000+ DevOps engineers, SREs, and technical decision-makers monthly.',
     images: ['/og-image.png'],
   },
 };
 
+// Figures a sponsor could ask us to back up, so each one names what it
+// measures and over what window. Syndicated reach is listed separately from
+// owned audience on purpose: rolling them into one number reads better and
+// falls apart the moment someone asks which is which.
 const STATS = [
-  { value: '25,000+', label: 'Monthly readers', detail: 'organic + newsletter' },
-  { value: '5,000+', label: 'Newsletter subs', detail: 'weekly digest' },
+  { value: '23.7M', label: 'Syndicated impressions', detail: 'daily.dev, 45 days to 2 Aug 2026' },
+  { value: '20,000+', label: 'Monthly readers', detail: 'devops-daily.com' },
+  { value: '1,500', label: 'Newsletter subscribers', detail: 'weekly, every Monday' },
   { value: '600+', label: 'Content pieces', detail: 'posts, guides, labs' },
-  { value: '85%', label: 'Senior engineers', detail: 'mid-to-staff level' },
 ];
 
 const AUDIENCE = [
@@ -68,7 +72,7 @@ const CHANNELS = [
   {
     title: 'Weekly Newsletter',
     description:
-      '5,000+ engineers get a curated DevOps digest every Monday. Sponsored slot with copy you control.',
+      '1,500 engineers get a curated DevOps digest every Monday. Sponsored slot with copy you control.',
     icon: Newspaper,
     metric: '45%+ open rate',
   },
@@ -239,7 +243,7 @@ export default function SponsorshipPage() {
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.1] mb-6">
               Reach{' '}
               <span className="text-primary relative inline-block">
-                25,000+
+                20,000+
                 <svg
                   className="absolute -bottom-2 left-0 w-full h-3 text-primary/40"
                   viewBox="0 0 200 12"

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -204,7 +204,7 @@ const PACKAGES = [
       'Dedicated newsletter slot (weekly)',
       'One sponsored tutorial or tool spotlight post',
       'Simulator/game inline mention on 3 pages',
-      'Priority response + monthly call',
+      'Priority response over email',
     ],
     popular: true,
   },
@@ -277,27 +277,58 @@ export default function SponsorshipPage() {
         <div className="relative overflow-hidden rounded-xl border border-border bg-card p-8 sm:p-10">
           <svg
             aria-hidden="true"
-            viewBox="0 0 240 240"
-            className="pointer-events-none absolute -right-6 top-1/2 hidden h-[300px] w-[300px] -translate-y-1/2 text-primary/20 lg:block"
+            viewBox="0 0 300 300"
+            className="pointer-events-none absolute -right-8 bottom-0 hidden h-full w-auto text-primary lg:block"
             fill="none"
             stroke="currentColor"
             strokeWidth="2.5"
             strokeLinecap="round"
             strokeLinejoin="round"
           >
-            <path d="M120 26c22 20 34 48 34 80 0 14-2 27-6 39h-56c-4-12-6-25-6-39 0-32 12-60 34-80z" />
-            <circle cx="120" cy="96" r="16" />
-            <path d="M86 116c-14 8-24 22-26 40 10-2 20-6 28-12" />
-            <path d="M154 116c14 8 24 22 26 40-10-2-20-6-28-12" />
-            <path d="M104 145h32l-6 16h-20z" />
-            <path d="M112 172c0 8 3 14 8 20 5-6 8-12 8-20" />
+            <defs>
+              <pattern id="sponsor-dots" width="15" height="15" patternUnits="userSpaceOnUse">
+                <circle cx="1.5" cy="1.5" r="1.5" fill="currentColor" stroke="none" />
+              </pattern>
+              {/* Fades the dot field out toward the headline so it never
+                  competes with the text it sits behind. */}
+              <linearGradient id="sponsor-fade" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0" stopColor="white" stopOpacity="0" />
+                <stop offset="0.65" stopColor="white" stopOpacity="1" />
+              </linearGradient>
+              <mask id="sponsor-mask">
+                <rect width="300" height="300" fill="url(#sponsor-fade)" />
+              </mask>
+            </defs>
+            <rect
+              width="300"
+              height="300"
+              fill="url(#sponsor-dots)"
+              stroke="none"
+              mask="url(#sponsor-mask)"
+              className="text-primary/25"
+            />
+
+            <g className="text-primary/40" transform="rotate(32 172 118)">
+              <path d="M172 42c17 21 26 47 26 76 0 18-2 34-7 48h-38c-5-14-7-30-7-48 0-29 9-55 26-76z" />
+              <circle cx="172" cy="108" r="14" />
+              <path d="M146 128c-13 9-22 24-24 42 10-2 19-7 26-14" />
+              <path d="M198 128c13 9 22 24 24 42-10-2-19-7-26-14" />
+              <path d="M155 166h34l-5 18h-24z" />
+              <path d="M163 192l-9 26" />
+              <path d="M172 194l-3 30" />
+              <path d="M181 192l7 26" />
+            </g>
+
+            <g className="text-primary/30">
+              <path d="M96 268c-3-16 11-29 26-25 4-19 24-29 41-19 9-14 30-12 37 4 15-3 28 9 28 25" />
+              <path d="M28 288c-2-11 8-20 18-17 3-13 17-20 28-13 6-9 20-8 25 3" />
+            </g>
           </svg>
 
-          <div className="relative flex items-start justify-between gap-4">
+          <div className="relative">
             <span className="font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
               Media kit 2026
             </span>
-            <span className="font-mono text-[11px] text-muted-foreground">devops-daily.com</span>
           </div>
 
           <h1 className="relative mt-8 max-w-3xl text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:max-w-[62%]">

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -12,6 +12,19 @@ import {
   BookOpen,
   Rocket,
   ArrowRight,
+  Eye,
+  Code2,
+  Boxes,
+  ShieldCheck,
+  Server,
+  Cloud,
+  UserRound,
+  PenLine,
+  Globe,
+  Link2,
+  Search,
+  Scale,
+  Heart,
 } from 'lucide-react';
 import { SectionHeader } from '@/components/section-header';
 import { SectionSeparator } from '@/components/section-separator';
@@ -55,10 +68,49 @@ export const metadata: Metadata = {
 // owned audience on purpose: rolling them into one number reads better and
 // falls apart the moment someone asks which is which.
 const STATS = [
-  { value: '23.7M', label: 'Syndicated impressions', detail: 'daily.dev, 45 days to 2 Aug 2026' },
-  { value: '20,000+', label: 'Monthly readers', detail: 'devops-daily.com' },
-  { value: '1,500', label: 'Newsletter subscribers', detail: 'weekly, every Monday' },
-  { value: '600+', label: 'Content pieces', detail: 'posts, guides, labs' },
+  { value: '23.7M', label: 'Syndicated impressions', detail: 'daily.dev, 45 days to 2 Aug 2026', icon: Eye },
+  { value: '20,000+', label: 'Monthly readers', detail: 'devops-daily.com', icon: Users },
+  { value: '1,500', label: 'Newsletter subscribers', detail: 'weekly, every Monday', icon: Mail },
+  { value: '600+', label: 'Content pieces', detail: 'posts, guides, labs', icon: TrendingUp },
+];
+
+/** Roles from the reader survey, with an icon each for the audience row. */
+const AUDIENCE_ICONS: Record<string, typeof Code2> = {
+  'DevOps / Platform engineers': Code2,
+  'Site reliability engineers (SRE)': ShieldCheck,
+  'Cloud / infra architects': Cloud,
+  'Backend / fullstack engineers': Server,
+  'Engineering managers / leadership': UserRound,
+};
+
+/** The path a sponsored piece travels, which is the product being sold. */
+const DISTRIBUTION = [
+  { label: 'We write the technical piece', icon: PenLine },
+  { label: 'Published on DevOps Daily', icon: Globe },
+  { label: 'Amplified on daily.dev', icon: Link2 },
+  { label: 'Featured in the newsletter', icon: Mail },
+  { label: 'Indexed by search engines', icon: Search },
+];
+
+const WHAT_WE_CREATE = [
+  {
+    title: 'Technical tutorials',
+    description:
+      'Hands-on guides that solve a real problem, with your product used the way someone actually would.',
+    icon: BookOpen,
+  },
+  {
+    title: 'Comparison pages',
+    description:
+      'Side-by-side evaluations that catch people mid-decision. The highest-intent traffic we have.',
+    icon: Scale,
+  },
+  {
+    title: 'Interactive simulators',
+    description:
+      'Browser simulators that teach a primitive by making the reader operate it. Your product taught, not advertised.',
+    icon: Gamepad2,
+  },
 ];
 
 const AUDIENCE = [
@@ -283,7 +335,10 @@ export default function SponsorshipPage() {
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {STATS.map((stat) => (
               <div key={stat.label} className="rounded-xl border border-border bg-card p-5">
-                <div className="text-3xl font-bold leading-none tracking-tight">{stat.value}</div>
+                <stat.icon className="h-6 w-6 text-primary" />
+                <div className="mt-4 text-3xl font-bold leading-none tracking-tight">
+                  {stat.value}
+                </div>
                 <div className="mt-3 text-sm font-medium">{stat.label}</div>
                 <div className="mt-1 text-xs text-muted-foreground">{stat.detail}</div>
               </div>
@@ -292,52 +347,83 @@ export default function SponsorshipPage() {
         </div>
 
         {/* Audience */}
-        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <div className="mt-6">
           <div className="rounded-xl border border-border bg-card p-6">
             <h2 className="mb-5 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
               Who we reach
             </h2>
-            <div className="space-y-3">
-              {AUDIENCE.map((role) => (
-                <div key={role.label}>
-                  <div className="mb-1.5 flex items-baseline justify-between gap-3">
-                    <span className="text-sm">{role.label}</span>
-                    <span className="font-mono text-xs text-muted-foreground">{role.share}</span>
+            <div className="grid grid-cols-2 gap-y-6 sm:grid-cols-3 lg:grid-cols-5">
+              {AUDIENCE.map((role) => {
+                const Icon = AUDIENCE_ICONS[role.label] ?? Code2;
+                return (
+                  <div
+                    key={role.label}
+                    className="flex flex-col items-center px-2 text-center lg:border-r lg:border-border lg:last:border-r-0"
+                  >
+                    <Icon className="h-6 w-6 text-primary" />
+                    {/* flex-1 keeps the percentages on one line when a role label wraps */}
+                    <span className="mt-3 flex-1 text-xs leading-snug">{role.label}</span>
+                    <span className="mt-1.5 font-mono text-sm font-semibold text-primary">
+                      {role.share}
+                    </span>
                   </div>
-                  <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                    <div className="h-full rounded-full bg-primary" style={{ width: role.share }} />
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
-            <p className="mt-5 border-t border-border pt-4 text-xs text-muted-foreground">
-              From our reader survey. Engineers who evaluate tools as part of the job.
+            <p className="mt-6 border-t border-border pt-4 text-center text-xs text-muted-foreground">
+              From our reader survey. An engaged technical audience actively evaluating tools.
             </p>
           </div>
 
-          <div className="rounded-xl border border-border bg-card p-6">
+          {/* Distribution, as the chain it actually is. */}
+          <div className="mt-6 rounded-xl border border-border bg-card p-6">
             <h2 className="mb-5 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
               How your content gets distributed
             </h2>
-            <ol className="space-y-2.5">
-              {[
-                'We write the technical piece',
-                'Published on DevOps Daily',
-                'Amplified on daily.dev',
-                'Featured in the weekly newsletter',
-                'Indexed by search engines, compounding',
-              ].map((step, i) => (
-                <li key={step} className="flex items-start gap-3">
-                  <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-primary/40 bg-primary/10 font-mono text-[10px] text-primary">
-                    {i + 1}
-                  </span>
-                  <span className="text-sm leading-snug">{step}</span>
-                </li>
+            <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-5">
+              {DISTRIBUTION.map((step, i) => (
+                <div key={step.label} className="relative">
+                  <div className="flex h-full flex-col items-center rounded-lg border border-border bg-background p-4 text-center">
+                    <step.icon className="h-5 w-5 text-primary" />
+                    <span className="mt-3 text-xs leading-snug">{step.label}</span>
+                  </div>
+                  {i < DISTRIBUTION.length - 1 && (
+                    <ArrowRight
+                      aria-hidden="true"
+                      className="absolute -right-2.5 top-1/2 hidden h-4 w-4 -translate-y-1/2 text-primary/50 lg:block"
+                    />
+                  )}
+                </div>
               ))}
-            </ol>
-            <p className="mt-5 border-t border-border pt-4 text-xs text-muted-foreground">
-              We do not sell banner ads. We write technical content developers want to read.
-            </p>
+            </div>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-background/50 p-3">
+                <Users className="h-4 w-4 shrink-0 text-primary" />
+                <span className="text-xs">Developers discover your product</span>
+              </div>
+              <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-background/50 p-3">
+                <TrendingUp className="h-4 w-4 shrink-0 text-primary" />
+                <span className="text-xs">Evergreen traffic keeps compounding</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* What we create */}
+        <div className="mt-6">
+          <h2 className="mb-3 font-mono text-[11px] uppercase tracking-[0.15em] text-primary">
+            What we create
+          </h2>
+          <div className="grid gap-3 md:grid-cols-3">
+            {WHAT_WE_CREATE.map((item) => (
+              <div key={item.title} className="rounded-xl border border-border bg-card p-6">
+                <item.icon className="h-6 w-6 text-primary" />
+                <h3 className="mt-4 text-sm font-semibold text-primary">{item.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {item.description}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
 
@@ -439,6 +525,18 @@ export default function SponsorshipPage() {
               </span>
             ))}
           </div>
+        </div>
+
+        {/* The positioning statement, given its own bar so it lands. */}
+        <div className="mt-6 flex flex-col items-center gap-3 rounded-xl border border-border bg-card p-5 text-center sm:flex-row sm:justify-center sm:gap-6 sm:text-left">
+          <div className="flex items-center gap-2.5">
+            <Heart className="h-4 w-4 shrink-0 fill-primary text-primary" />
+            <span className="text-sm font-semibold">We don&apos;t sell ads.</span>
+          </div>
+          <span className="hidden h-5 w-px bg-border sm:block" />
+          <span className="text-sm text-muted-foreground">
+            We write technical content <span className="text-primary">developers want to read.</span>
+          </span>
         </div>
 
         <SectionSeparator command="cat /sponsorship/faq.md" />

--- a/app/sponsorship/page.tsx
+++ b/app/sponsorship/page.tsx
@@ -281,47 +281,23 @@ export default function SponsorshipPage() {
             className="pointer-events-none absolute -right-8 bottom-0 hidden h-full w-auto text-primary lg:block"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2.5"
+            strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
           >
-            <defs>
-              <pattern id="sponsor-dots" width="15" height="15" patternUnits="userSpaceOnUse">
-                <circle cx="1.5" cy="1.5" r="1.5" fill="currentColor" stroke="none" />
-              </pattern>
-              {/* Fades the dot field out toward the headline so it never
-                  competes with the text it sits behind. */}
-              <linearGradient id="sponsor-fade" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0" stopColor="white" stopOpacity="0" />
-                <stop offset="0.65" stopColor="white" stopOpacity="1" />
-              </linearGradient>
-              <mask id="sponsor-mask">
-                <rect width="300" height="300" fill="url(#sponsor-fade)" />
-              </mask>
-            </defs>
-            <rect
-              width="300"
-              height="300"
-              fill="url(#sponsor-dots)"
-              stroke="none"
-              mask="url(#sponsor-mask)"
-              className="text-primary/25"
-            />
-
-            <g className="text-primary/40" transform="rotate(32 172 118)">
-              <path d="M172 42c17 21 26 47 26 76 0 18-2 34-7 48h-38c-5-14-7-30-7-48 0-29 9-55 26-76z" />
-              <circle cx="172" cy="108" r="14" />
-              <path d="M146 128c-13 9-22 24-24 42 10-2 19-7 26-14" />
-              <path d="M198 128c13 9 22 24 24 42-10-2-19-7-26-14" />
-              <path d="M155 166h34l-5 18h-24z" />
-              <path d="M163 192l-9 26" />
-              <path d="M172 194l-3 30" />
-              <path d="M181 192l7 26" />
+            <g className="text-primary/70" transform="rotate(35 172 120)">
+              <path d="M172 36C192 58 204 90 204 124c0 22-4 40-10 54h-44c-6-14-10-32-10-54 0-34 12-66 32-88z" />
+              <circle cx="172" cy="106" r="15" />
+              <path d="M140 132c-18 10-30 30-32 52 12-2 26-10 35-20" />
+              <path d="M204 132c18 10 30 30 32 52-12-2-26-10-35-20" />
+              <path d="M152 178h40l-6 20h-28z" />
+              <path d="M160 206l-12 38" />
+              <path d="M172 208l-4 42" />
+              <path d="M184 206l10 38" />
             </g>
-
-            <g className="text-primary/30">
-              <path d="M96 268c-3-16 11-29 26-25 4-19 24-29 41-19 9-14 30-12 37 4 15-3 28 9 28 25" />
-              <path d="M28 288c-2-11 8-20 18-17 3-13 17-20 28-13 6-9 20-8 25 3" />
+            <g className="text-primary/50">
+              <path d="M96 288c-18 0-24-20-10-30-4-20 18-34 34-24 8-20 38-24 50-4 18-8 38 6 34 26 16 4 16 32-2 32z" />
+              <path d="M18 296c-12 0-16-14-7-21-3-14 12-24 23-17 6-14 26-16 34-3z" />
             </g>
           </svg>
 


### PR DESCRIPTION
Two commits: correct the figures, then rebuild the page.

**Figures.** Subscribers read 5,000+ against an actual 1,500; monthly readers read 25,000+ against roughly 20,000. Both were in the hero, the stat block, the page title, the meta description and the OG/Twitter cards, so they were the first thing a prospective sponsor saw and the snippet search engines showed. Syndicated reach is now its own stat rather than folded into "monthly readers": 23.7M daily.dev impressions over 45 days is a strong number, but blending it into owned audience invites the one question you don't want asked on a media kit.

**Layout.** Reach up front, audience with the survey split, how a sponsored piece actually travels from writing to compounding search traffic, where a brand appears, packages, current sponsors, FAQ. Every data structure is unchanged; only presentation moved, so the survey figures, channels, packages and FAQ copy are the same content in a form a sponsor can scan in one pass.

No testimonial. There isn't a real one yet, and a named quote from someone at a sponsor who didn't write it isn't something to place on the page that sells your credibility.

`tsc` at the 528 baseline. SEO, metadata and data-integrity suites green (2284).