### PR TITLE
Fix wrapped post flowchart layouts

### DIFF
--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -264,10 +264,13 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
   const loopRef = useRef<HTMLDivElement>(null);
   const [loopGeometry, setLoopGeometry] = useState({ width: 1000, left: 40, right: 960 });
   const showTrace = spec.type === 'flow' && spec.trace !== false && nodes.length > 1;
+  const useStepGrid = spec.type === 'flow' && nodes.length > 4;
 
   const trace = () => {
     if (prefersReducedMotion()) return;
-    const els = Array.from(rootRef.current?.querySelectorAll<HTMLElement>('.pd-row .pd-node') ?? []);
+    const els = Array.from(
+      rootRef.current?.querySelectorAll<HTMLElement>('.pd-flow-content .pd-node') ?? []
+    );
     els.forEach((e) => e.classList.remove('pd-pulse'));
     els.forEach((e, i) =>
       setTimeout(() => {
@@ -278,10 +281,25 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
     );
   };
 
-  // Each connector is glued to the node it points into (.pd-seg), so on a wrap
-  // the arrow travels to the new line with its node instead of orphaning.
-  const row = (
-    <div className="pd-row" ref={rowRef}>
+  // A short flow remains a literal connected row. Longer flows cannot fit in
+  // an article column without misleading wrap-around arrows, so they become a
+  // compact numbered process grid with an explicit reading order.
+  const row = useStepGrid ? (
+    <ol className="pd-flow-grid pd-flow-content" aria-label={spec.title ?? 'Process flow'}>
+      {nodes.map((n, i) => (
+        <li className="pd-flow-step" key={i}>
+          <span className="pd-step-number" aria-hidden="true">
+            {String(i + 1).padStart(2, '0')}
+          </span>
+          <NodeCard node={n} />
+        </li>
+      ))}
+    </ol>
+  ) : (
+    <div
+      className={'pd-row' + (spec.type === 'flow' ? ' pd-flow-row pd-flow-content' : '')}
+      ref={rowRef}
+    >
       {nodes.length > 0 && <NodeCard node={nodes[0]} />}
       {nodes.slice(1).map((n, i) => (
         <div className="pd-seg" key={i + 1}>
@@ -340,13 +358,17 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
 
   return (
     <div className="pdiag" ref={rootRef}>
-      {spec.title && <div className="pd-title">{spec.title}</div>}
-      {showTrace && (
+      {spec.type === 'flow' && (spec.title || showTrace) ? (
         <div className="pd-toolbar">
-          <button type="button" className="pd-btn" onClick={trace}>
-            &#9654; Trace flow
-          </button>
+          {spec.title && <span className="pd-title pd-title-inline">{spec.title}</span>}
+          {showTrace && (
+            <button type="button" className="pd-btn" onClick={trace}>
+              &#9654; Trace flow
+            </button>
+          )}
         </div>
+      ) : (
+        spec.title && <div className="pd-title">{spec.title}</div>
       )}
       {spec.goal && <div className="pd-goal">{spec.goal}</div>}
       {spec.type === 'loop' ? (
@@ -707,6 +729,11 @@ const STYLES = `
 .pdiag .pd-goal{ font-family:var(--pd-mono); font-size:13px; background:var(--pd-soft-bg); border:1px solid var(--pd-line); border-radius:8px; padding:8px 14px; width:fit-content; max-width:100%; margin:0 auto 22px; text-align:center; }
 .pdiag .pd-toplabel{ text-align:center; font-size:13px; font-style:italic; color:var(--pd-muted); margin-bottom:8px; }
 .pdiag .pd-row{ display:flex; align-items:stretch; justify-content:center; flex-wrap:wrap; gap:4px; }
+.pdiag .pd-flow-row{ flex-wrap:nowrap; overflow-x:auto; justify-content:safe center; }
+.pdiag .pd-flow-grid{ list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr)); gap:12px; }
+.pdiag .pd-flow-step{ min-width:0; display:grid; grid-template-columns:30px minmax(0,1fr); align-items:start; gap:10px; }
+.pdiag .pd-step-number{ display:grid; place-items:center; width:30px; height:30px; margin-top:10px; border:1px solid color-mix(in srgb,var(--pd-accent) 42%,var(--pd-line2)); border-radius:9px; background:color-mix(in srgb,var(--pd-accent) 9%,var(--pd-card)); color:var(--pd-accent); font-family:var(--pd-mono); font-size:10.5px; font-weight:700; font-variant-numeric:tabular-nums; }
+.pdiag .pd-flow-step .pd-node{ width:100%; min-width:0; }
 .pdiag .pd-node{ position:relative; display:flex; align-items:center; gap:11px; background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:13px; padding:12px 15px; min-width:140px; transition:transform .22s,box-shadow .22s,border-color .22s; }
 @media (prefers-reduced-motion:no-preference){ .pdiag .pd-node{ animation:pd-enter .3s ease backwards; } }
 @keyframes pd-enter{ from{ opacity:0; transform:translateY(6px); } }
@@ -805,9 +832,11 @@ const STYLES = `
 .pdiag .pd-pkt{ fill:var(--pd-accent); }
 .pdiag .pd-gscroll{ overflow-x:auto; overflow-y:hidden; }
 @media (max-width:760px){
+  .pdiag .pd-toolbar{ align-items:flex-start; flex-wrap:wrap; }
   /* Simple flows stack; they read fine as a vertical list without arrows.
      display:contents flattens the segment so its node stacks like the rest. */
   .pdiag .pd-row{ flex-direction:column; }
+  .pdiag .pd-flow-row{ overflow-x:visible; }
   .pdiag .pd-seg{ display:contents; }
   .pdiag .pd-conn{ display:none; }
   /* Complex diagrams keep their real layout and scroll sideways instead of

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -53,11 +53,14 @@ function PdIcon({ name, tone }: { name?: string; tone?: string }) {
   return <span className={cls}>{name}</span>;
 }
 
-function NodeCard({ node }: { node: DiagramNode }) {
+function NodeCard({ node, step }: { node: DiagramNode; step?: number }) {
+  const statusLabel = node.status ? `Status: ${node.status}.` : null;
   if (node.variant) {
     return (
       <div className={'pd-node pd-fill v-' + node.variant}>
-        {node.status && <span className={'pd-dot s-' + node.status} />}
+        {step && <span className="pd-sr">Step {step}. </span>}
+        {node.status && <span className={'pd-dot s-' + node.status} aria-hidden="true" />}
+        {statusLabel && <span className="pd-sr">{statusLabel}</span>}
         <div className="pd-lab">{node.label}</div>
         {node.sub && <div className="pd-sub is-italic">{node.sub}</div>}
       </div>
@@ -65,7 +68,9 @@ function NodeCard({ node }: { node: DiagramNode }) {
   }
   return (
     <div className="pd-node">
-      {node.status && <span className={'pd-dot s-' + node.status} />}
+      {step && <span className="pd-sr">Step {step}. </span>}
+      {node.status && <span className={'pd-dot s-' + node.status} aria-hidden="true" />}
+      {statusLabel && <span className="pd-sr">{statusLabel}</span>}
       <PdIcon name={node.icon} tone={node.tone} />
       <div>
         <div className="pd-lab">{node.label}</div>
@@ -78,18 +83,9 @@ function NodeCard({ node }: { node: DiagramNode }) {
 function Conn() {
   return (
     <svg className="pd-conn" viewBox="0 0 58 24" height="24" preserveAspectRatio="none" aria-hidden="true">
-      {/* straight arrow, default */}
-      <g className="c-h">
-        <line className="base" x1="3" y1="12" x2="47" y2="12" />
-        <line className="flow" x1="3" y1="12" x2="47" y2="12" />
-        <path className="head" d="M45 8l6 4-6 4" />
-      </g>
-      {/* down-then-right elbow, shown when the arrow lands at a line break */}
-      <g className="c-w">
-        <path className="base" fill="none" d="M12 2 V9 Q12 17 24 17 H50" />
-        <path className="flow" fill="none" d="M12 2 V9 Q12 17 24 17 H50" />
-        <path className="head" d="M48 13l6 4-6 4" />
-      </g>
+      <line className="base" x1="3" y1="12" x2="47" y2="12" />
+      <line className="flow" x1="3" y1="12" x2="47" y2="12" />
+      <path className="head" d="M45 8l6 4-6 4" />
     </svg>
   );
 }
@@ -271,20 +267,37 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
   const flowNodeRefs = useRef<(HTMLDivElement | null)[]>([]);
   const flowNumberRefs = useRef<(HTMLSpanElement | null)[]>([]);
   const flowPathRefs = useRef<(SVGPathElement | null)[]>([]);
+  const flowRequiredWidthRef = useRef(0);
+  const traceTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [loopGeometry, setLoopGeometry] = useState({ width: 1000, left: 40, right: 960 });
   const [flowPaths, setFlowPaths] = useState<FlowGridPath[]>([]);
+  const [flowNeedsGrid, setFlowNeedsGrid] = useState(false);
+  const [staticTrace, setStaticTrace] = useState(false);
   const showTrace = spec.type === 'flow' && spec.trace !== false && nodes.length > 1;
-  const useStepGrid = spec.type === 'flow' && nodes.length > 4;
+  const useStepGrid = spec.type === 'flow' && (nodes.length > 4 || flowNeedsGrid);
+
+  const clearTrace = () => {
+    traceTimersRef.current.forEach(clearTimeout);
+    traceTimersRef.current = [];
+    flowPathRefs.current.forEach((path) => path?.classList.remove('is-tracing'));
+    rootRef.current
+      ?.querySelectorAll<HTMLElement>('.pd-flow-content .pd-node')
+      .forEach((node) => node.classList.remove('pd-pulse'));
+  };
 
   const trace = () => {
-    if (prefersReducedMotion()) return;
+    clearTrace();
+    if (prefersReducedMotion()) {
+      setStaticTrace(true);
+      traceTimersRef.current.push(setTimeout(() => setStaticTrace(false), 1600));
+      return;
+    }
+    setStaticTrace(false);
     const els = Array.from(
       rootRef.current?.querySelectorAll<HTMLElement>('.pd-flow-content .pd-node') ?? []
     );
-    flowPathRefs.current.forEach((path) => path?.classList.remove('is-tracing'));
-    els.forEach((e) => e.classList.remove('pd-pulse'));
-    els.forEach((e, i) =>
-      setTimeout(() => {
+    els.forEach((e, i) => {
+      const timer = setTimeout(() => {
         els.forEach((x) => x.classList.remove('pd-pulse'));
         e.classList.add('pd-pulse');
         const path = flowPathRefs.current[i - 1];
@@ -292,12 +305,60 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
           path.classList.remove('is-tracing');
           void path.getBoundingClientRect();
           path.classList.add('is-tracing');
-          setTimeout(() => path.classList.remove('is-tracing'), 560);
+          traceTimersRef.current.push(
+            setTimeout(() => path.classList.remove('is-tracing'), 560)
+          );
         }
-        if (i === els.length - 1) setTimeout(() => e.classList.remove('pd-pulse'), 620);
-      }, 500 * i)
-    );
+        if (i === els.length - 1) {
+          traceTimersRef.current.push(
+            setTimeout(() => e.classList.remove('pd-pulse'), 620)
+          );
+        }
+      }, 500 * i);
+      traceTimersRef.current.push(timer);
+    });
   };
+
+  useEffect(() => {
+    return () => {
+      traceTimersRef.current.forEach(clearTimeout);
+      traceTimersRef.current = [];
+    };
+  }, []);
+
+  // Short flows stay as connected rows while they fit. If their real content
+  // overflows the article column, switch to the same measured grid as a long
+  // flow; switch back automatically when the available width grows again.
+  useEffect(() => {
+    if (spec.type !== 'flow' || nodes.length > 4) return;
+    const measure = () => {
+      if (window.matchMedia('(max-width: 760px)').matches) {
+        setFlowNeedsGrid(false);
+        return;
+      }
+
+      const row = rowRef.current;
+      if (row) {
+        flowRequiredWidthRef.current = row.scrollWidth;
+        setFlowNeedsGrid(row.scrollWidth > row.clientWidth + 1);
+        return;
+      }
+
+      const grid = flowGridRef.current;
+      if (grid && grid.clientWidth >= flowRequiredWidthRef.current + 16) {
+        setFlowNeedsGrid(false);
+      }
+    };
+
+    measure();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+    if (ro && rootRef.current) ro.observe(rootRef.current);
+    window.addEventListener('resize', measure);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [flowNeedsGrid, nodes.length, spec.type]);
 
   useEffect(() => {
     if (!useStepGrid) return;
@@ -393,7 +454,7 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
                 flowNodeRefs.current[i] = el;
               }}
             >
-              <NodeCard node={n} />
+              <NodeCard node={n} step={i + 1} />
             </div>
           </li>
         ))}
@@ -404,32 +465,21 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
       className={'pd-row' + (spec.type === 'flow' ? ' pd-flow-row pd-flow-content' : '')}
       ref={rowRef}
     >
-      {nodes.length > 0 && <NodeCard node={nodes[0]} />}
+      {nodes.length > 0 && <NodeCard node={nodes[0]} step={1} />}
       {nodes.slice(1).map((n, i) => (
         <div className="pd-seg" key={i + 1}>
           <Conn />
-          <NodeCard node={n} />
+          <NodeCard node={n} step={i + 2} />
         </div>
       ))}
     </div>
   );
 
-  // Mark the connector of any segment that wrapped to a new line, so it can
-  // render a down-then-right elbow instead of a floating straight arrow.
+  // Keep the loop-back arc anchored to the first and last cards as it resizes.
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
-    const mark = () => {
-      root.querySelectorAll<HTMLElement>('.pd-row').forEach((rowEl) => {
-        const first = rowEl.firstElementChild as HTMLElement | null;
-        let prevTop = first ? first.offsetTop : 0;
-        rowEl.querySelectorAll<HTMLElement>(':scope > .pd-seg').forEach((seg) => {
-          const conn = seg.querySelector<HTMLElement>('.pd-conn');
-          if (conn) conn.classList.toggle('is-wrap', seg.offsetTop > prevTop + 4);
-          prevTop = seg.offsetTop;
-        });
-      });
-
+    const measureLoop = () => {
       const loop = loopRef.current;
       const rowNodes = rowRef.current?.querySelectorAll<HTMLElement>(':scope .pd-node');
       if (loop && rowNodes?.length) {
@@ -450,18 +500,18 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
         );
       }
     };
-    mark();
-    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(mark) : null;
+    measureLoop();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measureLoop) : null;
     if (ro) ro.observe(root);
-    window.addEventListener('resize', mark);
+    window.addEventListener('resize', measureLoop);
     return () => {
       if (ro) ro.disconnect();
-      window.removeEventListener('resize', mark);
+      window.removeEventListener('resize', measureLoop);
     };
   }, []);
 
   return (
-    <div className="pdiag" ref={rootRef}>
+    <div className={'pdiag' + (staticTrace ? ' pd-static-trace' : '')} ref={rootRef}>
       {spec.type === 'flow' && (spec.title || showTrace) ? (
         <div className="pd-toolbar">
           {spec.title && <span className="pd-title pd-title-inline">{spec.title}</span>}
@@ -731,7 +781,12 @@ function GraphDiagram({ spec }: { spec: DiagramSpec }) {
                   onMouseLeave={() => setHovered(null)}
                   onClick={() => setPinned((p) => (p === id ? null : id))}
                 >
-                  {n.status && <span className={'pd-dot s-' + n.status} />}
+                  {n.status && (
+                    <>
+                      <span className={'pd-dot s-' + n.status} aria-hidden="true" />
+                      <span className="pd-sr">Status: {n.status}.</span>
+                    </>
+                  )}
                   <PdIcon name={n.icon} tone={n.tone} />
                   <div>
                     <div className="pd-lab">{n.label}</div>
@@ -824,6 +879,7 @@ const STYLES = `
   --pd-blue:#6fa8ff; --pd-green:#57d08a; --pd-violet:#a996f5; --pd-red:#f6857f; --pd-amber:#e6b45e; --pd-slate:#9aa6b8;
   box-shadow:0 1px 2px rgba(0,0,0,.2),0 8px 30px -20px rgba(0,0,0,.5); }
 .pdiag *{ box-sizing:border-box; }
+.pdiag .pd-sr{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 .pdiag .pd-title{ font-family:var(--pd-mono); font-size:12.5px; color:var(--pd-muted); letter-spacing:.04em; margin-bottom:14px; }
 .pdiag .pd-title-inline{ margin-bottom:0; }
 .pdiag .pd-toolbar{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px; }
@@ -840,6 +896,7 @@ const STYLES = `
 .pdiag .pd-flow-link-head{ fill:none; stroke:var(--pd-muted); stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; }
 .pdiag .pd-flow-link-trace{ fill:none; stroke:var(--pd-accent); stroke-width:2.4; stroke-linecap:round; stroke-linejoin:round; stroke-dasharray:1; stroke-dashoffset:1; opacity:0; }
 .pdiag .pd-flow-link-trace.is-tracing{ opacity:1; animation:pd-flow-trace .52s ease-out forwards; }
+.pdiag.pd-static-trace .pd-flow-link-trace{ opacity:1; stroke-dashoffset:0; animation:none; }
 @keyframes pd-flow-trace{ to{ stroke-dashoffset:0; } }
 .pdiag .pd-flow-grid{ position:relative; z-index:1; list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr)); column-gap:14px; row-gap:38px; }
 .pdiag .pd-flow-step{ position:relative; min-width:0; display:grid; grid-template-columns:30px minmax(0,1fr); align-items:stretch; gap:10px; }
@@ -852,6 +909,7 @@ const STYLES = `
 @keyframes pd-enter{ from{ opacity:0; transform:translateY(6px); } }
 .pdiag .pd-node:hover{ transform:translateY(-3px); border-color:var(--pd-accent); box-shadow:0 10px 30px -14px rgba(224,121,43,.45); }
 .pdiag .pd-node.pd-pulse{ border-color:var(--pd-accent); box-shadow:0 0 0 3px rgba(224,121,43,.15),0 12px 30px -12px rgba(224,121,43,.5); transform:translateY(-3px); opacity:1; }
+.pdiag.pd-static-trace .pd-flow-content .pd-node{ border-color:color-mix(in srgb,var(--pd-accent) 62%,var(--pd-line2)); box-shadow:0 0 0 2px color-mix(in srgb,var(--pd-accent) 12%,transparent); }
 .pdiag .pd-lab{ font-weight:650; font-size:14px; }
 .pdiag .pd-sub{ font-size:12px; color:var(--pd-muted); font-family:var(--pd-mono); margin-top:1px; }
 .pdiag .pd-sub.is-italic{ font-style:italic; font-family:inherit; opacity:.75; }
@@ -879,10 +937,8 @@ const STYLES = `
 .pdiag .pd-conn .base{ stroke:var(--pd-line2); stroke-width:2; }
 .pdiag .pd-conn .head{ fill:none; stroke:var(--pd-muted); stroke-width:2; stroke-linecap:round; stroke-linejoin:round; }
 .pdiag .pd-conn .flow{ stroke:var(--pd-accent); stroke-width:2.4; stroke-linecap:round; stroke-dasharray:4 10; }
-.pdiag .pd-conn .c-w{ display:none; }
-.pdiag .pd-conn.is-wrap .c-h{ display:none; }
-.pdiag .pd-conn.is-wrap .c-w{ display:block; }
 @media (prefers-reduced-motion:no-preference){ .pdiag .pd-conn .flow{ animation:pd-dash .95s linear infinite; } }
+@media (prefers-reduced-motion:reduce){ .pdiag .pd-node{ transition:none; } }
 @keyframes pd-dash{ to{ stroke-dashoffset:-14; } }
 .pdiag .pd-loopwrap{ width:max-content; min-width:100%; margin:0 auto; }
 .pdiag .pd-loopback{ position:relative; height:54px; margin-top:0; }

--- a/components/post-diagram-blocks.tsx
+++ b/components/post-diagram-blocks.tsx
@@ -257,12 +257,22 @@ function BranchDiagram({ spec }: { spec: DiagramSpec }) {
 /* flow / loop                                                         */
 /* ------------------------------------------------------------------ */
 
+interface FlowGridPath {
+  d: string;
+  head: string;
+}
+
 function RowDiagram({ spec }: { spec: DiagramSpec }) {
   const nodes = spec.nodes ?? [];
   const rootRef = useRef<HTMLDivElement>(null);
   const rowRef = useRef<HTMLDivElement>(null);
   const loopRef = useRef<HTMLDivElement>(null);
+  const flowGridRef = useRef<HTMLDivElement>(null);
+  const flowNodeRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const flowNumberRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  const flowPathRefs = useRef<(SVGPathElement | null)[]>([]);
   const [loopGeometry, setLoopGeometry] = useState({ width: 1000, left: 40, right: 960 });
+  const [flowPaths, setFlowPaths] = useState<FlowGridPath[]>([]);
   const showTrace = spec.type === 'flow' && spec.trace !== false && nodes.length > 1;
   const useStepGrid = spec.type === 'flow' && nodes.length > 4;
 
@@ -271,30 +281,124 @@ function RowDiagram({ spec }: { spec: DiagramSpec }) {
     const els = Array.from(
       rootRef.current?.querySelectorAll<HTMLElement>('.pd-flow-content .pd-node') ?? []
     );
+    flowPathRefs.current.forEach((path) => path?.classList.remove('is-tracing'));
     els.forEach((e) => e.classList.remove('pd-pulse'));
     els.forEach((e, i) =>
       setTimeout(() => {
         els.forEach((x) => x.classList.remove('pd-pulse'));
         e.classList.add('pd-pulse');
+        const path = flowPathRefs.current[i - 1];
+        if (path) {
+          path.classList.remove('is-tracing');
+          void path.getBoundingClientRect();
+          path.classList.add('is-tracing');
+          setTimeout(() => path.classList.remove('is-tracing'), 560);
+        }
         if (i === els.length - 1) setTimeout(() => e.classList.remove('pd-pulse'), 620);
       }, 500 * i)
     );
   };
 
+  useEffect(() => {
+    if (!useStepGrid) return;
+    const draw = () => {
+      const grid = flowGridRef.current;
+      if (!grid) return;
+      const gr = grid.getBoundingClientRect();
+      const next: FlowGridPath[] = [];
+
+      for (let i = 0; i < nodes.length - 1; i++) {
+        const source = flowNodeRefs.current[i];
+        const targetNode = flowNodeRefs.current[i + 1];
+        const targetNumber = flowNumberRefs.current[i + 1];
+        if (!source || !targetNode || !targetNumber) continue;
+
+        const sr = source.getBoundingClientRect();
+        const nr = targetNode.getBoundingClientRect();
+        const tr = targetNumber.getBoundingClientRect();
+        const sameRow = Math.abs(sr.top - nr.top) < 4;
+
+        if (sameRow) {
+          const x1 = sr.right - gr.left;
+          const y1 = sr.top + sr.height / 2 - gr.top;
+          const x2 = tr.left - gr.left - 3;
+          const y2 = tr.top + tr.height / 2 - gr.top;
+          const bend = Math.max(5, (x2 - x1) * 0.45);
+          next.push({
+            d: `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`,
+            head: `M ${x2 - 5} ${y2 - 4} L ${x2} ${y2} L ${x2 - 5} ${y2 + 4}`,
+          });
+        } else {
+          const x1 = sr.left + sr.width / 2 - gr.left;
+          const y1 = sr.bottom - gr.top;
+          const x2 = tr.left + tr.width / 2 - gr.left;
+          const y2 = tr.top - gr.top - 3;
+          const midY = y1 + (y2 - y1) / 2;
+          next.push({
+            d: `M ${x1} ${y1} V ${midY} H ${x2} V ${y2}`,
+            head: `M ${x2 - 4} ${y2 - 5} L ${x2} ${y2} L ${x2 + 4} ${y2 - 5}`,
+          });
+        }
+      }
+
+      setFlowPaths(next);
+    };
+
+    draw();
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(draw) : null;
+    if (ro && flowGridRef.current) ro.observe(flowGridRef.current);
+    window.addEventListener('resize', draw);
+    return () => {
+      if (ro) ro.disconnect();
+      window.removeEventListener('resize', draw);
+    };
+  }, [nodes.length, useStepGrid]);
+
   // A short flow remains a literal connected row. Longer flows cannot fit in
   // an article column without misleading wrap-around arrows, so they become a
-  // compact numbered process grid with an explicit reading order.
+  // compact numbered process grid with measured connectors between its rows.
   const row = useStepGrid ? (
-    <ol className="pd-flow-grid pd-flow-content" aria-label={spec.title ?? 'Process flow'}>
-      {nodes.map((n, i) => (
-        <li className="pd-flow-step" key={i}>
-          <span className="pd-step-number" aria-hidden="true">
-            {String(i + 1).padStart(2, '0')}
-          </span>
-          <NodeCard node={n} />
-        </li>
-      ))}
-    </ol>
+    <div className="pd-flow-grid-wrap pd-flow-content" ref={flowGridRef}>
+      <svg className="pd-flow-links" aria-hidden="true">
+        {flowPaths.map((path, i) => (
+          <React.Fragment key={i}>
+            <path className="pd-flow-link" d={path.d} />
+            <path
+              className="pd-flow-link-trace"
+              d={path.d}
+              pathLength={1}
+              ref={(el) => {
+                flowPathRefs.current[i] = el;
+              }}
+            />
+            <path className="pd-flow-link-head" d={path.head} />
+          </React.Fragment>
+        ))}
+      </svg>
+      <ol className="pd-flow-grid" aria-label={spec.title ?? 'Process flow'}>
+        {nodes.map((n, i) => (
+          <li className="pd-flow-step" key={i}>
+            <span
+              className="pd-step-number"
+              aria-hidden="true"
+              ref={(el) => {
+                flowNumberRefs.current[i] = el;
+              }}
+            >
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <div
+              className="pd-flow-node"
+              ref={(el) => {
+                flowNodeRefs.current[i] = el;
+              }}
+            >
+              <NodeCard node={n} />
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
   ) : (
     <div
       className={'pd-row' + (spec.type === 'flow' ? ' pd-flow-row pd-flow-content' : '')}
@@ -730,10 +834,19 @@ const STYLES = `
 .pdiag .pd-toplabel{ text-align:center; font-size:13px; font-style:italic; color:var(--pd-muted); margin-bottom:8px; }
 .pdiag .pd-row{ display:flex; align-items:stretch; justify-content:center; flex-wrap:wrap; gap:4px; }
 .pdiag .pd-flow-row{ flex-wrap:nowrap; overflow-x:auto; justify-content:safe center; }
-.pdiag .pd-flow-grid{ list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr)); gap:12px; }
-.pdiag .pd-flow-step{ min-width:0; display:grid; grid-template-columns:30px minmax(0,1fr); align-items:start; gap:10px; }
-.pdiag .pd-step-number{ display:grid; place-items:center; width:30px; height:30px; margin-top:10px; border:1px solid color-mix(in srgb,var(--pd-accent) 42%,var(--pd-line2)); border-radius:9px; background:color-mix(in srgb,var(--pd-accent) 9%,var(--pd-card)); color:var(--pd-accent); font-family:var(--pd-mono); font-size:10.5px; font-weight:700; font-variant-numeric:tabular-nums; }
-.pdiag .pd-flow-step .pd-node{ width:100%; min-width:0; }
+.pdiag .pd-flow-grid-wrap{ position:relative; }
+.pdiag .pd-flow-links{ position:absolute; inset:0; width:100%; height:100%; pointer-events:none; overflow:visible; z-index:0; }
+.pdiag .pd-flow-link{ fill:none; stroke:var(--pd-line2); stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; }
+.pdiag .pd-flow-link-head{ fill:none; stroke:var(--pd-muted); stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; }
+.pdiag .pd-flow-link-trace{ fill:none; stroke:var(--pd-accent); stroke-width:2.4; stroke-linecap:round; stroke-linejoin:round; stroke-dasharray:1; stroke-dashoffset:1; opacity:0; }
+.pdiag .pd-flow-link-trace.is-tracing{ opacity:1; animation:pd-flow-trace .52s ease-out forwards; }
+@keyframes pd-flow-trace{ to{ stroke-dashoffset:0; } }
+.pdiag .pd-flow-grid{ position:relative; z-index:1; list-style:none; margin:0; padding:0; display:grid; grid-template-columns:repeat(auto-fit,minmax(min(260px,100%),1fr)); column-gap:14px; row-gap:38px; }
+.pdiag .pd-flow-step{ position:relative; min-width:0; display:grid; grid-template-columns:30px minmax(0,1fr); align-items:stretch; gap:10px; }
+.pdiag .pd-step-number{ position:relative; display:grid; place-items:center; width:30px; height:30px; margin-top:10px; border:1px solid color-mix(in srgb,var(--pd-accent) 42%,var(--pd-line2)); border-radius:9px; background:color-mix(in srgb,var(--pd-accent) 9%,var(--pd-card)); color:var(--pd-accent); font-family:var(--pd-mono); font-size:10.5px; font-weight:700; font-variant-numeric:tabular-nums; }
+.pdiag .pd-step-number::after{ content:""; position:absolute; left:100%; top:50%; width:10px; border-top:1px solid var(--pd-line2); }
+.pdiag .pd-flow-node{ min-width:0; height:100%; }
+.pdiag .pd-flow-node .pd-node{ width:100%; min-width:0; height:100%; }
 .pdiag .pd-node{ position:relative; display:flex; align-items:center; gap:11px; background:var(--pd-card); border:1px solid var(--pd-line2); border-radius:13px; padding:12px 15px; min-width:140px; transition:transform .22s,box-shadow .22s,border-color .22s; }
 @media (prefers-reduced-motion:no-preference){ .pdiag .pd-node{ animation:pd-enter .3s ease backwards; } }
 @keyframes pd-enter{ from{ opacity:0; transform:translateY(6px); } }
@@ -833,6 +946,9 @@ const STYLES = `
 .pdiag .pd-gscroll{ overflow-x:auto; overflow-y:hidden; }
 @media (max-width:760px){
   .pdiag .pd-toolbar{ align-items:flex-start; flex-wrap:wrap; }
+  .pdiag .pd-flow-links{ display:none; }
+  .pdiag .pd-flow-grid{ row-gap:12px; }
+  .pdiag .pd-flow-step:not(:last-child)::after{ content:""; position:absolute; left:14px; top:40px; bottom:-12px; border-left:1px solid var(--pd-line2); }
   /* Simple flows stack; they read fine as a vertical list without arrows.
      display:contents flattens the segment so its node stacks like the rest. */
   .pdiag .pd-row{ flex-direction:column; }


### PR DESCRIPTION
## Summary

- render long or genuinely overflowing post flows as compact, numbered responsive grids
- draw measured connectors between cards, including an explicit return path across wrapped rows
- use a continuous numbered timeline on mobile
- keep fitting short flows as connected rows and switch layouts automatically as width changes
- restart Trace cleanly when clicked repeatedly and provide a static highlighted route for reduced-motion users
- announce step numbers and node statuses to screen readers
- combine the diagram title and Trace control into one compact toolbar
- remove the obsolete wrapped-elbow connector code

## Context

Long flow diagrams could wrap a connector and its destination node onto a new line, leaving an orphaned elbow arrow at the far left: https://imgur.com/LAc0wYD

## Validation

- visually checked the six-step example in headless Chromium at desktop and narrow viewport sizes
- git diff --check
- GitHub build and test checks provide TypeScript/build validation because the local workspace has no Node runtime on PATH