### PR TITLE
Fix pnpm setup in weekly digest workflow

### DIFF
--- a/.github/workflows/generate-digest.yml
+++ b/.github/workflows/generate-digest.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

- remove the duplicate pnpm version from the weekly digest workflow
- let pnpm/action-setup use the exact pnpm@10.34.5 version declared in package.json
- avoid the pnpm/action-setup v6 multiple-version error

## Validation

- git diff --check
- confirmed the workflow no longer provides a version input
- confirmed package.json remains the single pnpm version source