### PR TITLE
Harden content generation workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.34.5
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/generate-digest.yml
+++ b/.github/workflows/generate-digest.yml
@@ -6,6 +6,10 @@ on:
     # Run every Monday at 9:00 AM UTC
     - cron: '0 9 * * 1'
 
+concurrency:
+  group: generate-devops-weekly-digest
+  cancel-in-progress: false
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -20,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -41,7 +45,7 @@ jobs:
         id: week
         run: |
           WEEK=$(date +%V)
-          YEAR=$(date +%Y)
+          YEAR=$(date +%G)
           echo "week=$WEEK" >> $GITHUB_OUTPUT
           echo "year=$YEAR" >> $GITHUB_OUTPUT
 
@@ -58,9 +62,9 @@ jobs:
 
             Automated weekly digest for **Week ${{ steps.week.outputs.week }}, ${{ steps.week.outputs.year }}**
 
-            ### 🤖 Generated Content
+            ### ⚙️ Generated Content
 
-            This digest was automatically generated from 250+ DevOps sources using AI-powered classification and summarization.
+            This digest was automatically assembled from 250+ DevOps sources using the workflow's non-AI generation path.
 
             ### 📊 Stats
 

--- a/.github/workflows/generate-images.yml
+++ b/.github/workflows/generate-images.yml
@@ -3,6 +3,10 @@ name: Generate Content Images
 on:
   workflow_dispatch:
 
+concurrency:
+  group: generate-content-images
+  cancel-in-progress: false
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -17,12 +21,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.34.5
 
       - name: Setup Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
## Summary

- use package.json as the single pnpm version source across workflows
- move content generators to the repository-supported Node 22 runtime
- pair ISO week numbers with the ISO week-numbering year
- make the weekly digest PR copy accurately describe the non-AI generation path
- prevent overlapping digest and image-generation runs

## Validation

- git diff --check
- confirmed no workflow still declares a pnpm version input
- confirmed generator workflows no longer use Node 20 or calendar-year pairing for ISO weeks
- GitHub CI provides workflow syntax and setup validation