### PR TITLE
Add the Pro link to the nav and footer, move News into More

### DIFF
--- a/components/footer/footer-data.ts
+++ b/components/footer/footer-data.ts
@@ -20,6 +20,8 @@ export interface SocialLink {
 export interface FooterLink {
   href: string;
   label: string;
+  /** Set for links that leave the site, e.g. the platform subdomain. */
+  external?: boolean;
 }
 
 export interface FooterSection {
@@ -106,6 +108,7 @@ export const contentSection: FooterSection = {
 export const resourcesSection: FooterSection = {
   title: 'Resources',
   links: [
+    { href: 'https://learning.devops-daily.com', label: 'DevOps Daily Pro', external: true },
     { href: '/roadmap', label: 'Career Roadmap' },
     { href: '/roadmaps', label: 'Learning Roadmaps' },
     { href: '/toolbox', label: 'Toolbox' },

--- a/components/footer/footer-section.tsx
+++ b/components/footer/footer-section.tsx
@@ -24,6 +24,8 @@ export function FooterSection({ section, label }: FooterSectionProps) {
           <li key={link.href}>
             <Link
               href={link.href}
+              target={link.external ? '_blank' : undefined}
+              rel={link.external ? 'noopener noreferrer' : undefined}
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
             >
               {link.label}

--- a/components/header/desktop-navigation.tsx
+++ b/components/header/desktop-navigation.tsx
@@ -15,9 +15,13 @@ export function DesktopNavigation() {
       <div className="hidden lg:flex lg:items-center lg:gap-1">
         {/* Main Navigation Links */}
         {mainNavigation.map((item) => (
+          // External entries leave the site, so they render as a plain anchor
+          // with the usual noopener guard rather than a client-routed Link.
           <Link
             key={item.href}
             href={item.href}
+            target={item.external ? '_blank' : undefined}
+            rel={item.external ? 'noopener noreferrer' : undefined}
             className={cn(
               'flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-xl transition-all duration-300',
               'hover:bg-primary/8 hover:text-primary hover:shadow-sm',

--- a/components/header/dropdown-menu.tsx
+++ b/components/header/dropdown-menu.tsx
@@ -68,17 +68,17 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
               sections.length > 1 ? 'w-[680px] max-w-[90vw]' : 'w-[340px] max-w-[90vw]'
             )}
           >
-            <div className="p-5 bg-linear-to-br from-background/50 to-muted/20">
+            <div className="p-4 bg-linear-to-br from-background/50 to-muted/20">
               <div
                 className={cn(
-                  'grid gap-6',
+                  'grid gap-5',
                   sections.length > 1 ? 'grid-cols-2' : 'grid-cols-1'
                 )}
               >
                 {sections.map((section, sectionIndex) => (
-                  <div key={sectionIndex} className="space-y-3">
+                  <div key={sectionIndex} className="space-y-2.5">
                     {/* Section Header */}
-                    <div className="flex items-center gap-2.5 pb-3 border-b border-border/60">
+                    <div className="flex items-center gap-2.5 pb-2.5 border-b border-border/60">
                       {section.icon && (
                         <div
                           className={cn(
@@ -124,14 +124,14 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
                     </div>
 
                     {/* Section Items */}
-                    <div className="grid grid-cols-1 gap-2">
+                    <div className="grid grid-cols-1 gap-1">
                       {section.items.map((item, itemIndex) => (
                         <Link
                           key={itemIndex}
                           href={item.href}
                           onClick={onClose}
                           className={cn(
-                            'group flex items-center gap-3 p-3 rounded-xl transition-all duration-300 border',
+                            'group flex items-center gap-3 p-2.5 rounded-xl transition-all duration-300 border',
                             'hover:bg-linear-to-r hover:from-primary/5 hover:to-purple-500/5 hover:shadow-md hover:scale-[1.01] hover:border-primary/20',
                             'border-transparent hover:border-primary/10',
                             item.featured &&
@@ -142,7 +142,7 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
                         >
                           <div
                             className={cn(
-                              'shrink-0 w-9 h-9 rounded-xl flex items-center justify-center transition-all duration-300',
+                              'shrink-0 w-8 h-8 rounded-xl flex items-center justify-center transition-all duration-300',
                               item.featured
                                 ? 'bg-linear-to-br from-primary/20 to-purple-500/20 text-primary group-hover:bg-primary/30 border border-primary/20'
                                 : 'bg-linear-to-br from-muted to-muted/50 group-hover:bg-linear-to-br group-hover:from-primary/15 group-hover:to-purple-500/15 text-muted-foreground group-hover:text-primary border border-border/50'
@@ -156,7 +156,7 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
                           </div>
 
                           <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2 mb-1">
+                            <div className="flex items-center gap-2 mb-0.5">
                               <h4
                                 className={cn(
                                   'font-semibold text-sm transition-colors',
@@ -176,7 +176,7 @@ export function DropdownMenu({ sections, isOpen, onClose }: DropdownMenuProps) {
                               {item.featured && <Sparkles className="w-3 h-3 text-primary" />}
                             </div>
                             {item.description && (
-                              <p className="text-xs font-medium leading-relaxed text-muted-foreground group-hover:text-muted-foreground/80">
+                              <p className="text-xs font-medium leading-snug text-muted-foreground group-hover:text-muted-foreground/80">
                                 {item.description}
                               </p>
                             )}

--- a/components/header/mobile-menu.tsx
+++ b/components/header/mobile-menu.tsx
@@ -57,6 +57,8 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
                     <Link
                       key={item.href}
                       href={item.href}
+                      target={item.external ? '_blank' : undefined}
+                      rel={item.external ? 'noopener noreferrer' : undefined}
                       className="flex items-center gap-4 px-4 text-base font-semibold leading-7 transition-all duration-300 border border-transparent rounded-2xl hover:bg-linear-to-r hover:from-primary/10 hover:to-purple-500/10 hover:shadow-md hover:border-primary/20"
                       onClick={onClose}
                     >

--- a/components/header/nav-items.ts
+++ b/components/header/nav-items.ts
@@ -1,5 +1,6 @@
 import {
   BookOpen,
+  GraduationCap,
   FileText,
   Map,
   Target,
@@ -31,6 +32,11 @@ export interface NavItem {
   external?: boolean;
   badge?: string;
   featured?: boolean;
+}
+
+/** Main-nav entries always render an icon, unlike dropdown items. */
+export interface MainNavItem extends NavItem {
+  icon: NonNullable<NavItem['icon']>;
 }
 
 export interface NavSection {
@@ -88,11 +94,18 @@ export const sectionColors = {
 } as const;
 
 // Main navigation items (no dropdowns)
-export const mainNavigation = [
+export const mainNavigation: MainNavItem[] = [
   { label: 'Home', href: '/', icon: Home },
   { label: 'Posts', href: '/posts', icon: FileText },
   { label: 'Guides', href: '/guides', icon: BookOpen },
-  { label: 'News', href: '/news', icon: Newspaper, badge: 'New' },
+  // The paid platform lives on its own subdomain, so this one leaves the site.
+  {
+    label: 'Pro',
+    href: 'https://learning.devops-daily.com',
+    icon: GraduationCap,
+    external: true,
+    badge: 'New',
+  },
 ];
 
 // Dropdown navigation data
@@ -198,6 +211,12 @@ export const dropdownNavigation: Record<string, NavSection[]> = {
       description: 'Discover by topic and author',
       color: 'purple',
       items: [
+        {
+          label: 'News',
+          href: '/news',
+          description: 'Weekly DevOps news roundups',
+          icon: Newspaper,
+        },
         {
           label: 'Categories',
           href: '/categories',


### PR DESCRIPTION
Puts the paid platform in the main nav and the footer's Resources column, and moves News into the More dropdown to make room.

The subdomain is external, and neither the main-nav nor the footer renderer handled external links before, so both now set target and rel. Dropdown items already did.

mainNavigation is typed as MainNavItem[] so `external` is on the type. It extends NavItem with a required icon, since main-nav entries always render one and NavItem's is optional.

tsc is at 526, two below the 528 baseline, because typing that array resolved two pre-existing inference errors.

Not rendered locally (no builds on the Pi), so worth a look at the header spacing with five main items before merging.