### PR TITLE
Drop thin tag archives, noindex search, fix a dead newsletter link

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -4,6 +4,9 @@ import { SearchPageClient } from '@/components/search-page-client';
 
 export const metadata: Metadata = {
   title: 'Search',
+  // The results are client-rendered, so there is nothing here for a crawler to
+  // index. follow is kept so the links out of it still pass through.
+  robots: { index: false, follow: true },
   description: 'Search across DevOps Daily posts, guides, quizzes, games, flashcards, comparisons, and tools to find content on Docker, Kubernetes, AWS, CI/CD, and more.',
   alternates: {
     canonical: '/search',

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -279,7 +279,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/hacktoberfest',
     '/comparisons',
     '/newsletters',
-    '/search',
   ].map((path) => ({
     url: `${baseUrl}${path}`,
     ...withLastModified(

--- a/content/newsletters/2026-week-18.md
+++ b/content/newsletters/2026-week-18.md
@@ -48,7 +48,7 @@ The SQLite-flavored cousin: where MySQL still earns its keep, where SQLite has c
 
 ## Interview Questions
 
-### [Cloud Cost Allocation Tags Across AWS, GCP, and Azure](https://devops-daily.com/interview-questions/mid/cloud-cost-allocation-tags-aws-gcp-azure)
+### [Cloud Cost Allocation Tags Across AWS, GCP, and Azure](https://devops-daily.com/interview-questions)
 
 ![Cloud cost allocation tags interview question](/images/interview-questions/cloud-cost-allocation-tags-aws-gcp-azure-og.png)
 

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -61,11 +61,12 @@ export async function getAllTags(): Promise<Tag[]> {
   return tags.sort((a, b) => b.count - a.count);
 }
 
-// A tag used by fewer than this many items doesn't get its own page: a single-post
-// tag is a thin near-duplicate of that post and mostly inflates the static-file
-// count. This is a reversible knob — once the site renders on demand (no CF Pages
-// file cap) it can drop back to 1 to restore every tag page at zero file cost.
-export const MIN_TAG_PAGE_COUNT = 2;
+// A tag used by fewer than this many items doesn't get its own page. A two- or
+// three-item archive is a thin near-duplicate of the posts it lists, and Search
+// Console showed those archives being crawled and then declined. Raising this
+// from 2 to 5 drops ~150 such pages. Reversible knob: lower it again if the
+// tag pages ever earn their keep.
+export const MIN_TAG_PAGE_COUNT = 5;
 
 // Tags that get their own page (count >= threshold). Used for route generation,
 // the tags index, and to decide which tag chips link out.


### PR DESCRIPTION
Three small fixes aimed at the pages Google crawls and then declines to index.

**Tag archives.** `MIN_TAG_PAGE_COUNT` goes from 2 to 5, which takes generated tag pages from 250 to 97 and removes 153 archives that listed two to four items each. An archive that thin is a near-duplicate of the handful of posts it links to. The threshold is a named constant with a comment, so it is one line to reverse if these ever start earning traffic.

**/search.** Removed from the sitemap and marked `index: false, follow: true`. The results are client-rendered, so there was never anything on it for a crawler to read.

**Dead link.** The Week 18 newsletter linked to /interview-questions/mid/cloud-cost-allocation-tags-aws-gcp-azure, which returns 404. Repointed at the /interview-questions index.

One thing deliberately not done: tag alias normalisation. `tagToSlug` already lower-cases and slugifies before counting, so `Linux` and `linux` have always resolved to the same page. Measuring raw frontmatter strings suggests a collision problem that does not exist at the routing layer. Verified: 608 distinct tag slugs, and the live /tags index links 251 pages, matching the threshold-2 count exactly.