### PR TITLE
Link posts to the simulators that teach the same thing

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -11,6 +11,8 @@ import { ArticleSchema, BreadcrumbSchema } from '@/components/schema-markup';
 import { RelatedPosts } from '@/components/related-posts';
 import { RelatedAcrossTypes } from '@/components/related-across-types';
 import { getRelatedAcrossTypes } from '@/lib/related-cross-type';
+import { RelatedSimulators } from '@/components/related-simulators';
+import { getRelatedSimulators } from '@/lib/related-simulators';
 import { ReadingProgressBar } from '@/components/reading-progress-bar';
 import { ReportIssue } from '@/components/report-issue';
 import { GiscusComments } from '@/components/giscus-comments';
@@ -95,6 +97,14 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   // exercises, flashcards, or interview questions on the same topic. The
   // within-type "Related Posts" section above stays; this is the "also worth
   // your time" mix that nudges readers between content kinds.
+  // Hands-on simulators matching this post's topic. Kept separate from the
+  // cross-type mix above because that section caps each type at one of three
+  // slots, so a simulator regularly lost to a quiz or checklist.
+  const relatedSimulators = await getRelatedSimulators({
+    tags: post.tags ?? [],
+    categorySlug: post.category?.slug,
+  });
+
   const crossTypeRelated = await getRelatedAcrossTypes({
     current: {
       type: 'post',
@@ -150,6 +160,13 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
                 </div>
               )}
               <PostContent content={post.content} />
+
+              {relatedSimulators.length > 0 && (
+                <RelatedSimulators
+                  simulators={relatedSimulators}
+                  className="mt-12 pt-8 border-t border-border"
+                />
+              )}
 
               {/* Inline Sponsors */}
               <InlineSponsors variant="full" />

--- a/components/related-simulators.tsx
+++ b/components/related-simulators.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { Terminal, Play } from 'lucide-react';
+import type { RelatedSimulator } from '@/lib/related-simulators';
+
+interface RelatedSimulatorsProps {
+  simulators: RelatedSimulator[];
+  /** Section heading. */
+  title?: string;
+  className?: string;
+}
+
+/**
+ * Sits directly under the article body rather than below the comments, where
+ * the other related sections live. A reader who has just finished a Docker
+ * article is at the point of wanting to try the commands, and a link that far
+ * down the page reaches neither them nor much crawl equity.
+ */
+export function RelatedSimulators({
+  simulators,
+  title = 'Try it hands-on',
+  className,
+}: RelatedSimulatorsProps) {
+  if (!simulators.length) return null;
+
+  return (
+    <section className={cn('', className)} aria-labelledby="related-simulators-heading">
+      <div className="flex items-center gap-2 mb-4">
+        <Terminal className="w-5 h-5 text-primary" aria-hidden="true" />
+        <h2 id="related-simulators-heading" className="text-2xl font-bold">
+          {title}
+        </h2>
+      </div>
+      <p className="text-sm text-muted-foreground mb-4">
+        Run the commands from this article in the browser. Nothing to install.
+      </p>
+      <div
+        className={cn(
+          'grid gap-4',
+          simulators.length > 1 ? 'md:grid-cols-2' : 'md:grid-cols-1',
+        )}
+      >
+        {simulators.map((sim) => (
+          <Link
+            key={sim.id}
+            href={sim.href}
+            className="group flex flex-col rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all"
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 text-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider">
+                <Play className="w-3 h-3" aria-hidden="true" />
+                {sim.type === 'simulator' ? 'Simulator' : 'Interactive'}
+              </span>
+            </div>
+            <h3 className="font-semibold line-clamp-2 group-hover:text-primary transition-colors">
+              {sim.title}
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground line-clamp-3">
+              {sim.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/lib/related-simulators.ts
+++ b/lib/related-simulators.ts
@@ -1,0 +1,235 @@
+/**
+ * Matches a post to the hands-on simulators that teach the same thing.
+ *
+ * The simulators are the strongest content on the site and the least linked
+ * to: 8 of 519 posts pointed at one before this existed. They were also the
+ * only content type missing from `getRelatedAcrossTypes`, so nothing surfaced
+ * them automatically either.
+ *
+ * This is deliberately separate from the cross-type related section rather
+ * than folded into it. That section caps each type at one item out of three
+ * total, so a simulator competes with quizzes and checklists and often loses.
+ * Simulators get their own slot so a Docker post always reaches the Docker
+ * terminal, which is the entire point.
+ */
+
+import { getActiveGames, type Game } from './games';
+
+export interface RelatedSimulator {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  /** 'simulator' or 'game', used for the label on the card. */
+  type: 'game' | 'simulator';
+  iconName: string;
+  color: string;
+}
+
+export interface SimulatorMatchInput {
+  /** Post tags, any casing. */
+  tags?: string[];
+  /** Post category slug, e.g. 'docker'. */
+  categorySlug?: string;
+  /** Post title, used only as a weak fallback signal. */
+  title?: string;
+}
+
+/**
+ * Two tag matches, or one tag match that is also the post's category.
+ *
+ * Set by measuring against the real corpus. Requiring a single tag match
+ * links roughly nine posts in ten but produces matches like a post tagged
+ * 'security' landing on the DDoS simulator, which is a worse link than none.
+ * Requiring three drops coverage below a third. Weak internal links dilute
+ * the signal they are meant to create, so the bar is deliberately high.
+ */
+const MIN_SCORE = 20;
+const TAG_POINTS = 10;
+/** A category hit is worth as much as a tag hit; it is the stronger signal. */
+const CATEGORY_POINTS = 10;
+/** Enough to put the canonical simulator first regardless of tag overlap. */
+const PRIMARY_POINTS = 100;
+
+/**
+ * The canonical simulator for a topic, keyed by post tag or category slug.
+ *
+ * Tag overlap alone gets this wrong in a way that matters. A post tagged
+ * Linux and Bash matches the fork bomb simulator on two tags but the Linux
+ * terminal on one, so the fork bomb wins: 91 posts pointed at it before this
+ * map existed, and a general Linux article should reach the Linux terminal.
+ * Same shape for Docker, where the under-the-hood simulator outscored the
+ * terminal 182 to 122 despite being the more advanced of the two.
+ *
+ * Only topics with an unambiguous best destination belong here. Everything
+ * else falls through to tag scoring below.
+ */
+const PRIMARY_SIMULATORS: Record<string, string> = {
+  docker: 'docker-terminal-simulator',
+  containers: 'docker-terminal-simulator',
+  'docker-compose': 'docker-terminal-simulator',
+  kubernetes: 'kubernetes-terminal-simulator',
+  kubectl: 'kubernetes-terminal-simulator',
+  k8s: 'kubernetes-terminal-simulator',
+  terraform: 'terraform-terminal-simulator',
+  'infrastructure-as-code': 'terraform-terminal-simulator',
+  git: 'git-concepts-simulator',
+  'version-control': 'git-concepts-simulator',
+  linux: 'linux-terminal',
+  bash: 'linux-terminal',
+  shell: 'linux-terminal',
+  sql: 'sql-terminal-simulator',
+  postgres: 'postgres-terminal-simulator',
+  postgresql: 'postgres-terminal-simulator',
+  psql: 'postgres-terminal-simulator',
+  mongodb: 'mongodb-terminal-simulator',
+  nosql: 'mongodb-terminal-simulator',
+  dns: 'dns-simulator',
+  aws: 'aws-vpc-simulator',
+  vpc: 'aws-vpc-simulator',
+  smtp: 'smtp-flow-simulator',
+  email: 'smtp-flow-simulator',
+  deliverability: 'bounce-triage-simulator',
+  oauth: 'oauth-oidc-flow-simulator',
+  oidc: 'oauth-oidc-flow-simulator',
+  authentication: 'oauth-oidc-flow-simulator',
+  tls: 'ssl-tls-handshake',
+  ssl: 'ssl-tls-handshake',
+  prometheus: 'promql-playground',
+  promql: 'promql-playground',
+  observability: 'promql-playground',
+  logging: 'log-aggregation-pipeline-simulator',
+  logs: 'log-aggregation-pipeline-simulator',
+  kafka: 'message-queue-simulator',
+  rabbitmq: 'message-queue-simulator',
+  redis: 'caching-simulator',
+  caching: 'caching-simulator',
+  webhooks: 'webhook-delivery-simulator',
+  gitops: 'gitops-workflow',
+  argocd: 'gitops-workflow',
+  istio: 'service-mesh-simulator',
+  'service-mesh': 'service-mesh-simulator',
+  microservices: 'microservices-simulator',
+  graphql: 'rest-vs-graphql',
+  'load-balancing': 'load-balancer-simulator',
+  'rate-limiting': 'rate-limit-simulator',
+  scaling: 'scaling-simulator',
+  'auto-scaling': 'scaling-simulator',
+  deployment: 'deployment-strategies',
+  'ci-cd': 'deployment-strategies',
+};
+
+/**
+ * Tags that carry no topical information and so cannot justify a link.
+ *
+ * Two kinds. The meta tags ('educational', 'interactive') exist on almost
+ * every game and describe format rather than subject. The broad tags
+ * ('devops', 'infrastructure') are true of most of the site.
+ *
+ * Leaving them in produced exactly the filler links this is meant to avoid:
+ * an article about AI résumé screening matched the disaster-recovery
+ * simulator on 'devops' and 'infrastructure' alone, which helps nobody and
+ * dilutes the links that are real.
+ */
+const NON_DISCRIMINATING = new Set([
+  'devops',
+  'infrastructure',
+  'educational',
+  'interactive',
+  'tutorial',
+  'beginner',
+  'backend',
+  'cloud',
+  'visualization',
+  'real-time',
+  'game',
+  'fun',
+  'humor',
+  'arcade',
+  'strategy',
+  'performance',
+  'security',
+  'networking',
+  'monitoring',
+  'database',
+  'sre',
+]);
+
+function normalise(values: readonly string[]): Set<string> {
+  return new Set(
+    values
+      .map((v) => v.toLowerCase().trim())
+      .filter((v) => v && !NON_DISCRIMINATING.has(v)),
+  );
+}
+
+function toRelated(game: Game): RelatedSimulator {
+  return {
+    id: game.id,
+    title: game.title,
+    description: game.description,
+    href: game.href,
+    type: game.type ?? 'game',
+    iconName: game.iconName,
+    color: game.color,
+  };
+}
+
+/**
+ * Scores one game against one post. Exported for the tests, which assert the
+ * threshold behaviour directly rather than through the async loader.
+ */
+export function scoreSimulator(game: Game, input: SimulatorMatchInput): number {
+  const gameTags = normalise(game.tags ?? []);
+  if (gameTags.size === 0) return 0;
+
+  const postTags = normalise(input.tags ?? []);
+  let score = 0;
+
+  for (const tag of postTags) {
+    if (gameTags.has(tag)) score += TAG_POINTS;
+  }
+
+  // A canonical topic hit outranks any amount of incidental tag overlap.
+  const category = input.categorySlug?.toLowerCase().trim();
+  const topics = new Set(postTags);
+  if (category) topics.add(category);
+  for (const topic of topics) {
+    if (PRIMARY_SIMULATORS[topic] === game.id) {
+      score += PRIMARY_POINTS;
+      break;
+    }
+  }
+
+  // The category slug is a tag by another name as far as matching goes:
+  // a post in the 'docker' category and a game tagged 'docker' belong
+  // together whether or not the author also tagged the post Docker.
+  if (category && gameTags.has(category)) {
+    score += CATEGORY_POINTS;
+  }
+
+  return score;
+}
+
+/**
+ * Returns up to `limit` simulators worth linking from this post, best first.
+ * Returns an empty array rather than padding with weak matches.
+ */
+export async function getRelatedSimulators(
+  input: SimulatorMatchInput,
+  limit = 2,
+): Promise<RelatedSimulator[]> {
+  const games = await getActiveGames();
+
+  return games
+    .map((game) => ({ game, score: scoreSimulator(game, input) }))
+    .filter((s) => s.score >= MIN_SCORE)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Stable across builds. Without this, two equally-scored simulators can
+      // swap places between deploys and the rendered page churns for no reason.
+      return a.game.id.localeCompare(b.game.id);
+    })
+    .slice(0, limit)
+    .map((s) => toRelated(s.game));
+}

--- a/tests/related-simulators.test.ts
+++ b/tests/related-simulators.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { getActiveGames, type Game } from '@/lib/games';
+import { getAllPosts } from '@/lib/posts';
+import { getRelatedSimulators, scoreSimulator } from '@/lib/related-simulators';
+
+/**
+ * These assert the two failure modes found while building this against the
+ * real corpus, both of which produced links that were worse than no link:
+ *
+ * 1. Tag overlap alone sent 91 Linux posts to the fork bomb simulator,
+ *    because a Linux+Bash post matches two of its tags and the Linux
+ *    terminal only one.
+ * 2. Broad tags matched anything. An article about AI resume screening
+ *    reached the disaster-recovery simulator on 'devops' and
+ *    'infrastructure', which are true of most of the site.
+ */
+
+function gameById(games: Game[], id: string): Game {
+  const g = games.find((x) => x.id === id);
+  if (!g) throw new Error(`fixture drift: no game with id ${id}`);
+  return g;
+}
+
+describe('related simulators', () => {
+  it('sends a Docker post to the Docker terminal, not the deeper internals one', async () => {
+    const result = await getRelatedSimulators({
+      tags: ['Docker', 'Containers'],
+      categorySlug: 'docker',
+    });
+    expect(result[0]?.id).toBe('docker-terminal-simulator');
+  });
+
+  it('sends a Linux/Bash post to the Linux terminal rather than the fork bomb', async () => {
+    const result = await getRelatedSimulators({
+      tags: ['Linux', 'Bash'],
+      categorySlug: 'linux',
+    });
+    expect(result[0]?.id).toBe('linux-terminal');
+  });
+
+  it.each([
+    ['kubernetes', ['Kubernetes'], 'kubernetes-terminal-simulator'],
+    ['terraform', ['Terraform'], 'terraform-terminal-simulator'],
+    ['git', ['Git'], 'git-concepts-simulator'],
+  ])('routes a %s post to its canonical simulator', async (category, tags, expected) => {
+    const result = await getRelatedSimulators({ tags, categorySlug: category });
+    expect(result[0]?.id).toBe(expected);
+  });
+
+  it('returns nothing for a post with no simulator-worthy topic', async () => {
+    // Career and opinion pieces. Matching these to anything is filler.
+    const result = await getRelatedSimulators({
+      tags: ['Career', 'Hiring'],
+      categorySlug: 'devops',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('does not match on broad tags alone', async () => {
+    const games = await getActiveGames();
+    const bcdr = gameById(games, 'bcdr-simulator');
+    // The exact input that used to produce a link.
+    const score = scoreSimulator(bcdr, {
+      tags: ['DevOps', 'Infrastructure'],
+      categorySlug: 'devops',
+    });
+    expect(score).toBe(0);
+  });
+
+  it('never returns more than the requested limit', async () => {
+    const result = await getRelatedSimulators({ tags: ['Docker', 'Kubernetes'] }, 2);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  it('is stable across calls, so the rendered page does not churn', async () => {
+    const input = { tags: ['Kubernetes', 'Networking'], categorySlug: 'kubernetes' };
+    const a = await getRelatedSimulators(input);
+    const b = await getRelatedSimulators(input);
+    expect(a.map((x) => x.id)).toEqual(b.map((x) => x.id));
+  });
+
+  it('every canonical target names a game that exists', async () => {
+    // The map is hand-written, so a renamed or retired game would otherwise
+    // silently stop being reachable rather than failing loudly.
+    const games = await getActiveGames();
+    const ids = new Set(games.map((g) => g.id));
+    const targets = new Set<string>();
+    for (const tag of ['docker', 'kubernetes', 'terraform', 'git', 'linux', 'postgres', 'mongodb', 'dns', 'aws', 'oauth', 'redis', 'kafka', 'istio', 'graphql']) {
+      const result = await getRelatedSimulators({ tags: [tag] });
+      result.forEach((r) => targets.add(r.id));
+    }
+    expect(targets.size).toBeGreaterThan(0);
+    for (const t of targets) expect(ids.has(t)).toBe(true);
+  });
+
+  it('every returned href points at a real games route', async () => {
+    const games = await getActiveGames();
+    const hrefs = new Set(games.map((g) => g.href));
+    const result = await getRelatedSimulators({ tags: ['Docker'], categorySlug: 'docker' });
+    for (const r of result) {
+      expect(r.href.startsWith('/games/')).toBe(true);
+      expect(hrefs.has(r.href)).toBe(true);
+    }
+  });
+
+  it('links a meaningful share of the corpus without linking all of it', async () => {
+    // Both ends matter. Near-zero means the matcher is broken; near-total
+    // means it is matching things it should not.
+    const posts = await getAllPosts();
+    let matched = 0;
+    for (const p of posts as { tags?: string[]; category?: { slug?: string } }[]) {
+      const r = await getRelatedSimulators({ tags: p.tags ?? [], categorySlug: p.category?.slug });
+      if (r.length > 0) matched += 1;
+    }
+    const share = matched / posts.length;
+    expect(share).toBeGreaterThan(0.6);
+    expect(share).toBeLessThan(0.95);
+  });
+});


### PR DESCRIPTION
The simulators had almost no internal links pointing at them: 8 of 519 posts mentioned one. They were also the only content type missing from `getRelatedAcrossTypes`, so nothing surfaced them automatically either. A reader finishing a Docker article had no path to the Docker terminal.

Adds `lib/related-simulators.ts` and a block under the article body. **454 of 519 posts now reach a simulator, and 27 simulators gain inbound links.**

## Why it isn't just tag overlap

Matching on tags alone was wrong twice when measured against the real corpus, so both are handled and tested:

- A post tagged Linux and Bash matches two of the fork bomb simulator's tags but only one of the Linux terminal's, so the fork bomb won for 91 posts. A canonical topic map now pins the obvious destinations (`docker` to the Docker terminal, and so on).
- Broad tags matched anything. An article on AI resume screening reached the disaster-recovery simulator on `devops` and `infrastructure` alone, which are true of most of the site. Those no longer score.

The 65 posts that still match nothing are career and platform pieces with no hands-on equivalent. They render nothing, which is intended: a weak link dilutes the real ones.

## Placement

Directly under the article body rather than with the other related sections, which currently sit below the Giscus embed. Someone who just read a Docker article is at the point of wanting to run the commands.

## Verification

- 12 new tests, including the two regressions above and a corpus-wide check that coverage stays between 60% and 95%
- Full suite 5,785 passing
- `tsc` unchanged at the 526 baseline

Not done here: 19 simulators still have no post that could link to them, including MongoDB, message queue, caching, microservices and load balancer. That is a content gap rather than a matcher bug.