### PR TITLE
Load analytics under Consent Mode instead of gating it entirely

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { OrganizationSchema, WebsiteSchema } from '@/components/schema-markup';
 import { CookieBanner } from '@/components/cookie-banner';
 import { PWAInstaller } from '@/components/pwa-installer';
 import { SkipToContent } from '@/components/skip-to-content';
+import Script from 'next/script';
 import { SiteAnalytics } from '@/components/site-analytics';
 import { DeferredSiteExtras } from '@/components/deferred-site-extras';
 
@@ -119,6 +120,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Google Consent Mode v2. Must run before gtag.js, so it lives here
+            rather than in SiteAnalytics: `beforeInteractive` is only supported
+            in the root layout.
+
+            Analytics storage starts denied, so GA loads for every visitor but
+            sets no cookies until someone allows it. That gives cookieless
+            pings for everyone and full data after consent.
+
+            Before this, GA did not load at all without consent, so the site
+            counted only the few people who clicked the banner. Real traffic
+            was ~7k uniques a day while GA reported a couple of hundred. */}
+        <Script id="consent-mode-default" strategy="beforeInteractive">
+          {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}window.gtag=gtag;
+var c=null;try{c=localStorage.getItem('cookie-consent');if(c===null&&localStorage.getItem('cookieAccepted')==='true'){c='accepted';}}catch(e){}
+gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:c==='accepted'?'granted':'denied',functionality_storage:'granted',personalization_storage:'denied',security_storage:'granted',wait_for_update:500});`}
+        </Script>
         <link
           rel="alternate"
           type="application/rss+xml"

--- a/components/site-analytics.tsx
+++ b/components/site-analytics.tsx
@@ -1,9 +1,22 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useSyncExternalStore } from 'react';
 import Script from 'next/script';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { COOKIE_CONSENT_EVENT, getCookieConsent, type CookieConsent } from '@/lib/cookie-consent';
+
+/**
+ * gtag pushes its `arguments` object, not an array, and the two are not
+ * interchangeable. Writing it out here rather than calling `window.gtag`
+ * means a consent update still queues correctly if it happens before
+ * gtag.js has finished loading. GA drains the queue on load.
+ */
+function gtag(..._args: unknown[]) {
+  window.dataLayer = window.dataLayer || [];
+  // eslint-disable-next-line prefer-rest-params
+  window.dataLayer.push(arguments);
+}
 
 export function SiteAnalytics() {
   const consent = useSyncExternalStore<CookieConsent | null>(
@@ -19,17 +32,32 @@ export function SiteAnalytics() {
     () => null
   );
 
-  if (consent !== 'accepted') return null;
+  // Consent Mode: the default is set before gtag.js in the root layout, and
+  // this raises it once someone allows analytics. Rejecting is already the
+  // default, so there is nothing to send for that case.
+  useEffect(() => {
+    if (consent === 'accepted') {
+      gtag('consent', 'update', { analytics_storage: 'granted' });
+    }
+  }, [consent]);
 
   return (
     <>
+      {/* Loads for every visitor. Consent Mode keeps it cookieless until the
+          visitor allows analytics, so we still get aggregate numbers instead
+          of counting only the few people who click the banner. */}
       <GoogleAnalytics gaId="G-DRHMSC6G9R" />
-      <Script
-        id="ahrefs-analytics"
-        src="https://analytics.ahrefs.com/analytics.js"
-        data-key="DDU3onGEafDWd/obeLf2Pw"
-        strategy="lazyOnload"
-      />
+
+      {/* Ahrefs stays behind explicit consent. It is a separate vendor and
+          Consent Mode does not govern it. */}
+      {consent === 'accepted' && (
+        <Script
+          id="ahrefs-analytics"
+          src="https://analytics.ahrefs.com/analytics.js"
+          data-key="DDU3onGEafDWd/obeLf2Pw"
+          strategy="lazyOnload"
+        />
+      )}
     </>
   );
 }

--- a/tests/cookie-consent.test.ts
+++ b/tests/cookie-consent.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import {
   COOKIE_CONSENT_EVENT,
   COOKIE_CONSENT_KEY,
@@ -30,5 +32,56 @@ describe('cookie consent', () => {
     expect(getCookieConsent()).toBe('rejected');
     expect(listener).toHaveBeenCalledOnce();
     window.removeEventListener(COOKIE_CONSENT_EVENT, listener);
+  });
+});
+
+/**
+ * The 31 July consent change stopped GA loading at all without a click, so
+ * the site counted only the few visitors who accepted the banner. Cloudflare
+ * showed ~7k uniques a day while GA reported a couple of hundred.
+ *
+ * The fix is Google Consent Mode: gtag.js loads for everyone, with analytics
+ * storage denied until consent. These lock in the parts that broke.
+ */
+describe('analytics consent wiring', () => {
+  const layout = readFileSync(join(process.cwd(), 'app', 'layout.tsx'), 'utf-8');
+  const analytics = readFileSync(
+    join(process.cwd(), 'components', 'site-analytics.tsx'),
+    'utf-8',
+  );
+
+  it('loads Google Analytics for every visitor, not only after consent', () => {
+    // The regression was `if (consent !== 'accepted') return null;` above the
+    // GoogleAnalytics element, which made the whole component render nothing.
+    const gaIndex = analytics.indexOf('<GoogleAnalytics');
+    expect(gaIndex).toBeGreaterThan(-1);
+    const beforeGa = analytics.slice(0, gaIndex);
+    expect(beforeGa).not.toMatch(/return null/);
+  });
+
+  it('sets a Consent Mode default before gtag.js runs', () => {
+    expect(layout).toContain('consent-mode-default');
+    // beforeInteractive is what puts it ahead of gtag.js. Without it the
+    // default can land after the first ping and the ping sets a cookie.
+    expect(layout).toMatch(/id="consent-mode-default"[\s\S]{0,120}beforeInteractive/);
+    expect(layout).toContain("gtag('consent','default'");
+  });
+
+  it('denies analytics storage by default and grants it on consent', () => {
+    expect(layout).toContain("analytics_storage:c==='accepted'?'granted':'denied'");
+    expect(analytics).toContain("gtag('consent', 'update', { analytics_storage: 'granted' })");
+  });
+
+  it('reads the stored choice in the default, so a returning visitor is not downgraded', () => {
+    // Someone who already accepted must start granted, or their first
+    // pageview of every session is recorded cookielessly.
+    expect(layout).toContain("localStorage.getItem('cookie-consent')");
+    expect(layout).toContain("localStorage.getItem('cookieAccepted')");
+  });
+
+  it('keeps advertising signals denied, since the site does not run ads', () => {
+    for (const key of ['ad_storage', 'ad_user_data', 'ad_personalization']) {
+      expect(layout).toContain(`${key}:'denied'`);
+    }
   });
 });


### PR DESCRIPTION
Google Analytics stopped loading at all without a banner click on 31 July, so the site counted only visitors who accepted. Switches to Consent Mode v2: gtag.js loads for everyone with analytics storage denied until consent.