### PR TITLE
Revive two validation suites that had never run

### DIFF
--- a/tests/news-validation.test.ts
+++ b/tests/news-validation.test.ts
@@ -4,54 +4,65 @@ import path from 'path';
 import matter from 'gray-matter';
 import fg from 'fast-glob';
 
+/**
+ * This suite had never run. It globbed `*.md` at the top of content/news,
+ * but every digest lives in a year directory, so the glob matched nothing
+ * and `skipIf` skipped the whole file. It reported green for 41 files it
+ * had never opened.
+ *
+ * It also required `week` and `publishedAt`, which no digest has ever had.
+ * The real frontmatter is title, date and summary, so the assertions below
+ * are the ones that describe the content we actually publish.
+ */
 describe('News Content Validation', () => {
   const newsDir = path.join(process.cwd(), 'content/news');
-  const newsFiles = fs.existsSync(newsDir)
-    ? fg.sync('*.md', { cwd: newsDir })
-    : [];
+  // Recursive: the digests are in content/news/<year>/week-NN.md.
+  const newsFiles = fg.sync('**/*.md', { cwd: newsDir });
 
-  it.skipIf(newsFiles.length === 0)('should have at least one news item', () => {
+  it('finds the digests on disk', () => {
+    // Deliberately not skipIf. An empty result means the glob is wrong
+    // again, and silence is how this went unnoticed for months.
     expect(newsFiles.length).toBeGreaterThan(0);
   });
 
   newsFiles.forEach((file) => {
     describe(`News: ${file}`, () => {
       const filePath = path.join(newsDir, file);
-      const fileContent = fs.readFileSync(filePath, 'utf-8');
-      const { data, content } = matter(fileContent);
+      const { data, content } = matter(fs.readFileSync(filePath, 'utf-8'));
 
-      it('should have valid frontmatter', () => {
-        expect(data).toBeDefined();
-        expect(data.title).toBeDefined();
+      it('has a title', () => {
         expect(typeof data.title).toBe('string');
+        expect(data.title.trim().length).toBeGreaterThan(0);
       });
 
-      it('should have required fields', () => {
-        const requiredFields = [
-          'title',
-          'week',
-          'publishedAt',
-        ];
-
-        requiredFields.forEach((field) => {
-          expect(data[field]).toBeDefined();
-        });
+      it('has a valid date', () => {
+        expect(data.date).toBeDefined();
+        expect(Number.isNaN(new Date(data.date).getTime())).toBe(false);
       });
 
-      it('should have valid date format', () => {
-        expect(data.publishedAt).toBeDefined();
-        const date = new Date(data.publishedAt);
-        expect(date.toString()).not.toBe('Invalid Date');
+      it('has a summary', () => {
+        expect(typeof data.summary).toBe('string');
+        expect(data.summary.trim().length).toBeGreaterThan(0);
       });
 
-      it('should have content', () => {
-        expect(content).toBeDefined();
+      it('has body content', () => {
         expect(content.trim().length).toBeGreaterThan(0);
       });
 
-      it('should have week number', () => {
-        expect(data.week).toBeDefined();
-        expect(typeof data.week === 'string' || typeof data.week === 'number').toBe(true);
+      it('links every source with an absolute URL', () => {
+        // Only the "Read more" links, which always point at an outside
+        // source. Our own internal links such as /news and /feed.xml are
+        // relative on purpose and resolve fine.
+        //
+        // A feed that publishes relative links put one of these in the week
+        // 33 digest as `/2026/08/05/...`. The link checker read it as a
+        // broken internal link, which is what it was, and the build failed
+        // on main for every open PR until it was fixed.
+        const sourceLinks = [...content.matchAll(/\[\*\*🔗 Read more\*\*\]\(([^)]+)\)/g)].map(
+          (m) => m[1],
+        );
+        const notAbsolute = sourceLinks.filter((url) => !/^https?:\/\//.test(url));
+        expect(notAbsolute, `non-absolute source links in ${file}`).toEqual([]);
       });
     });
   });

--- a/tests/quiz-validation.test.ts
+++ b/tests/quiz-validation.test.ts
@@ -1,70 +1,93 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import matter from 'gray-matter';
 import fg from 'fast-glob';
+
+/**
+ * This suite had never run either. It globbed `*.md` and parsed frontmatter
+ * with gray-matter, but quizzes are JSON files. The glob matched nothing, so
+ * `skipIf` skipped everything and 44 quizzes went unchecked.
+ *
+ * The assertions were written against an imagined shape too: a top-level
+ * `difficulty`, which lives on each question instead, and `question.question`,
+ * which is actually `question.title`.
+ */
+
+interface QuizQuestion {
+  id?: string;
+  title?: string;
+  options?: unknown[];
+  correctAnswer?: unknown;
+  explanation?: string;
+}
+
+interface Quiz {
+  id?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  questions?: QuizQuestion[];
+}
 
 describe('Quiz Content Validation', () => {
   const quizzesDir = path.join(process.cwd(), 'content/quizzes');
-  const quizFiles = fs.existsSync(quizzesDir)
-    ? fg.sync('*.md', { cwd: quizzesDir })
-    : [];
+  const quizFiles = fg.sync('*.json', { cwd: quizzesDir });
 
-  it.skipIf(quizFiles.length === 0)('should have at least one quiz', () => {
+  it('finds the quizzes on disk', () => {
+    // Not skipIf. An empty result is the bug, not a reason to pass.
     expect(quizFiles.length).toBeGreaterThan(0);
   });
 
   quizFiles.forEach((file) => {
     describe(`Quiz: ${file}`, () => {
-      const filePath = path.join(quizzesDir, file);
-      const fileContent = fs.readFileSync(filePath, 'utf-8');
-      const { data, content } = matter(fileContent);
+      const raw = fs.readFileSync(path.join(quizzesDir, file), 'utf-8');
 
-      it('should have valid frontmatter', () => {
-        expect(data).toBeDefined();
-        expect(data.title).toBeDefined();
-        expect(typeof data.title).toBe('string');
+      it('is parseable JSON', () => {
+        expect(() => JSON.parse(raw) as Quiz).not.toThrow();
       });
 
-      it('should have required fields', () => {
-        const requiredFields = [
-          'title',
-          'description',
-          'category',
-          'difficulty',
-          'questions',
-        ];
+      const quiz = JSON.parse(raw) as Quiz;
 
-        requiredFields.forEach((field) => {
-          expect(data[field]).toBeDefined();
+      it('has the fields the quiz pages read', () => {
+        for (const field of ['id', 'title', 'description', 'category'] as const) {
+          expect(quiz[field], `${file} is missing ${field}`).toBeDefined();
+        }
+      });
+
+      it('has at least one question', () => {
+        expect(Array.isArray(quiz.questions)).toBe(true);
+        expect(quiz.questions!.length).toBeGreaterThan(0);
+      });
+
+      it('has a usable shape for every question', () => {
+        quiz.questions!.forEach((q, i) => {
+          const where = `${file} question ${i + 1}`;
+          expect(typeof q.title, `${where} title`).toBe('string');
+          expect(Array.isArray(q.options), `${where} options`).toBe(true);
+          // Fewer than two options is not a question.
+          expect(q.options!.length, `${where} option count`).toBeGreaterThanOrEqual(2);
         });
       });
 
-      it('should have questions array', () => {
-        expect(Array.isArray(data.questions)).toBe(true);
-        expect(data.questions.length).toBeGreaterThan(0);
-      });
-
-      it('should have valid questions structure', () => {
-        data.questions.forEach((question: any, index: number) => {
-          expect(question.question).toBeDefined();
-          expect(question.options).toBeDefined();
-          expect(Array.isArray(question.options)).toBe(true);
-          expect(question.options.length).toBeGreaterThanOrEqual(2);
-          expect(question.correctAnswer).toBeDefined();
-          expect(typeof question.correctAnswer).toBe('number');
-          expect(question.correctAnswer).toBeGreaterThanOrEqual(0);
-          expect(question.correctAnswer).toBeLessThan(question.options.length);
+      it('points correctAnswer at an option that exists', () => {
+        // The failure this catches is a question edited to remove an option
+        // without moving the index, which silently marks the wrong answer
+        // correct or crashes the page.
+        quiz.questions!.forEach((q, i) => {
+          const where = `${file} question ${i + 1}`;
+          expect(typeof q.correctAnswer, `${where} correctAnswer type`).toBe('number');
+          const idx = q.correctAnswer as number;
+          expect(Number.isInteger(idx), `${where} correctAnswer is an integer`).toBe(true);
+          expect(idx, `${where} correctAnswer lower bound`).toBeGreaterThanOrEqual(0);
+          expect(idx, `${where} correctAnswer upper bound`).toBeLessThan(q.options!.length);
         });
       });
 
-      it('should have valid difficulty level', () => {
-        const validDifficulties = ['beginner', 'intermediate', 'advanced'];
-        expect(validDifficulties).toContain(data.difficulty.toLowerCase());
-      });
-
-      it('should have at least 5 questions', () => {
-        expect(data.questions.length).toBeGreaterThanOrEqual(5);
+      it('has unique question ids, where ids are used', () => {
+        const ids = quiz.questions!.map((q) => q.id).filter(Boolean);
+        if (ids.length > 0) {
+          expect(new Set(ids).size, `${file} duplicate question ids`).toBe(ids.length);
+        }
       });
     });
   });


### PR DESCRIPTION
News and quiz validation both globbed for files that do not exist (top-level .md, when digests are in year folders and quizzes are JSON), so skipIf skipped them and 85 content files went unchecked. Both now glob what exists and assert the real schema.