### PR TITLE
Shorten the search-result title on 77 posts

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -51,7 +51,10 @@ export async function generateMetadata({
   // the meta tag stays in range without dropping keywords.
   return detailPageMetadata({
     path: `/posts/${post.slug}`,
-    title: post.title,
+    // Bing flags a <title> over 70 characters as liable to be truncated or
+    // ignored. `seoTitle` shortens it for search without touching the
+    // headline a reader sees, the same way guides and games already do.
+    title: post.seoTitle || post.title,
     description: truncateMetaDescription(post.excerpt),
     image: socialImage || post.image || '/og-image.png',
     article: {

--- a/content/posts/3-infrastructure-decisions-engineering-velocity.md
+++ b/content/posts/3-infrastructure-decisions-engineering-velocity.md
@@ -1,5 +1,6 @@
 ---
 title: "The 3 Infrastructure Decisions That Determine Your Engineering Velocity"
+seoTitle: 'The 3 Infrastructure Decisions That Set Engineering Velocity'
 excerpt: "Provisioning model, environment strategy, and deployment surface. Everything else is optimization. Here's how to make these foundational choices without killing your team's momentum."
 category:
   name: "DevOps"

--- a/content/posts/ai-agent-stack-one-cli-neon-platform.md
+++ b/content/posts/ai-agent-stack-one-cli-neon-platform.md
@@ -1,5 +1,6 @@
 ---
 title: 'I Gave an AI Agent a Database, Compute, Storage, and Models From One CLI'
+seoTitle: 'I Gave an AI Agent a Database, Storage and Models From One CLI'
 excerpt: 'An AI agent usually needs four accounts: a database, somewhere to run, object storage, and a model provider. I wired all four from a single Neon credential and had a deployed image-generating agent in a few minutes. Here is the actual build log, the config that ties it together, and the honest caveats.'
 category:
   name: 'DevOps'

--- a/content/posts/ai-sre-agents-what-they-fix-and-break.md
+++ b/content/posts/ai-sre-agents-what-they-fix-and-break.md
@@ -1,5 +1,6 @@
 ---
 title: 'AI SRE Agents: What They Actually Fix, and What They Will Happily Break'
+seoTitle: 'AI SRE Agents: What They Fix and What They Break'
 excerpt: 'AI SRE is now its own category, with every incident vendor shipping an agent that investigates and remediates on its own. Here is the honest split: where these agents genuinely earn their keep, where they are oversold, and the one risk nobody puts on the marketing page.'
 category:
   name: 'DevOps'

--- a/content/posts/ansible-automation-platform-credential-leak-cve-2026-11807.md
+++ b/content/posts/ansible-automation-platform-credential-leak-cve-2026-11807.md
@@ -1,5 +1,6 @@
 ---
 title: 'Your Automation Platform Is a Credential Honeypot: Ansible CVE-2026-11807'
+seoTitle: 'Ansible CVE-2026-11807: A Credential Honeypot in Your Platform'
 excerpt: 'A missing authorization check in Event-Driven Ansible lets any logged-in user pull plaintext vault passwords, SSH keys, and OAuth tokens out of Ansible Automation Platform. It is a CVSS 9.6, it is patched, and it is a reminder of what your automation control plane really holds.'
 category:
   name: 'Security'

--- a/content/posts/antv-npm-shai-hulud-wave-may-2026.md
+++ b/content/posts/antv-npm-shai-hulud-wave-may-2026.md
@@ -1,5 +1,6 @@
 ---
 title: 'AntV npm Compromise: The Shai-Hulud Worm Comes for Your Dashboards (May 19, 2026)'
+seoTitle: 'AntV npm Compromise: The Shai-Hulud Worm Returns'
 excerpt: 'A new Shai-Hulud wave landed at 01:56 UTC on May 19 and rode the @antv maintainer account through 323 packages including echarts-for-react. Here is what got published, what it steals, and the lockfile grep that tells you if you are exposed.'
 category:
   name: 'DevOps'

--- a/content/posts/argocd-cve-2026-42880-serversidediff-secret-leak.md
+++ b/content/posts/argocd-cve-2026-42880-serversidediff-secret-leak.md
@@ -1,5 +1,6 @@
 ---
 title: "Argo CD CVE-2026-42880: When Read-Only Means Read-Everything-Including-Secrets"
+seoTitle: 'Argo CD CVE-2026-42880: When Read-Only Exposes Your Secrets'
 excerpt: "A critical Argo CD bug (CVSS 9.6, disclosed May 7) lets any authenticated user pull plaintext Kubernetes Secrets out of any Application that has ServerSideDiff with mutation-webhook diffs enabled. Here is the upgrade matrix, the one-liner to find at-risk apps in your cluster, and the safe RBAC scope-down for teams that cannot patch today."
 category:
   name: 'Kubernetes'

--- a/content/posts/aws-cost-optimization.md
+++ b/content/posts/aws-cost-optimization.md
@@ -1,5 +1,6 @@
 ---
 title: 'How We Reduced Our AWS Bill by 73% While Actually Improving Performance'
+seoTitle: 'How We Cut Our AWS Bill by 73% and Improved Performance'
 excerpt: 'The counterintuitive strategies we used to slash cloud costs while actually improving application performance.'
 category:
   name: 'Cloud'

--- a/content/posts/aws-use1-az4-thermal-event-single-az-lessons.md
+++ b/content/posts/aws-use1-az4-thermal-event-single-az-lessons.md
@@ -1,5 +1,6 @@
 ---
 title: 'When One Data Center Room Got Hot: AWS US-EAST-1, Coinbase, and the DR Drill That Was Not'
+seoTitle: 'AWS US-EAST-1 Thermal Event: The DR Drill That Was Not'
 excerpt: 'On May 7, 2026, cooling failed in a single hall of one US-EAST-1 data center. Coinbase, FanDuel, and CME Group went down for hours, and Coinbase publicly confirmed their backup systems did not work as expected. Here is what happened, the multi-AZ checklist that would have caught it, and the AWS Fault Injection Simulator commands to run the drill before the next thermal event.'
 category:
   name: 'AWS'

--- a/content/posts/can-terraform-watch-directory-for-changes.md
+++ b/content/posts/can-terraform-watch-directory-for-changes.md
@@ -1,5 +1,6 @@
 ---
 title: 'Can Terraform Watch a Directory for Changes? Working With Dynamic Files'
+seoTitle: 'Can Terraform Watch a Directory for Changes?'
 excerpt: "Learn how to handle scenarios where you need Terraform to respond to file changes, and explore alternatives to automatic directory watching."
 category:
   name: 'Terraform'

--- a/content/posts/cannot-connect-to-docker-daemon.md
+++ b/content/posts/cannot-connect-to-docker-daemon.md
@@ -1,5 +1,6 @@
 ---
 title: 'Cannot Connect to Docker Daemon at unix:/var/run/docker.sock - Is the Docker Daemon Running?'
+seoTitle: 'Cannot Connect to the Docker Daemon at docker.sock: The Fix'
 excerpt: "Fix the common 'Cannot connect to the Docker daemon' error with practical solutions for Linux, macOS, and Windows. Learn why this happens and how to resolve permissions and service issues."
 category:
   name: 'Docker'

--- a/content/posts/cicd-pipeline-hardening-guide.md
+++ b/content/posts/cicd-pipeline-hardening-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 'CI/CD Pipeline Hardening: A Practical Guide to Securing Your Build Infrastructure'
+seoTitle: 'CI/CD Pipeline Hardening: Securing Your Build Infrastructure'
 excerpt: 'Your CI/CD pipeline has access to source code, secrets, and production environments. Here is how to harden it against supply chain attacks, secret exfiltration, and artifact tampering.'
 category:
   name: 'Security'

--- a/content/posts/cilium-1-19-clustermesh-policy-flip.md
+++ b/content/posts/cilium-1-19-clustermesh-policy-flip.md
@@ -1,5 +1,6 @@
 ---
 title: 'Cilium 1.19 ClusterMesh Policy Flip: The Silent Default That Will Drop Your Cross-Cluster Traffic'
+seoTitle: 'Cilium 1.19 ClusterMesh: The Default That Drops Your Traffic'
 excerpt: 'Cilium 1.19 changed how network policies without a cluster selector resolve in a ClusterMesh. East/West traffic that 1.18 implicitly allowed is now silently dropped. Here is how to find every affected policy before you upgrade.'
 category:
   name: 'Kubernetes'

--- a/content/posts/claude-code-source-leak-what-devops-engineers-should-learn.md
+++ b/content/posts/claude-code-source-leak-what-devops-engineers-should-learn.md
@@ -1,5 +1,6 @@
 ---
 title: 'Claude Code Source Leaked via npm Source Maps: Lessons for Every DevOps Team'
+seoTitle: 'Claude Code Source Leaked via npm Source Maps: The Lessons'
 excerpt: 'Anthropic accidentally shipped source maps in their npm package, exposing 512,000 lines of Claude Code source. Here is what went wrong and how to prevent it in your own CI/CD pipeline.'
 category:
   name: 'DevOps'

--- a/content/posts/compare-two-directory-trees-by-content.md
+++ b/content/posts/compare-two-directory-trees-by-content.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Compare Two Directory Trees and Find Files That Differ by Content'
+seoTitle: 'How to Compare Two Directory Trees by File Content'
 excerpt: "Learn different methods to compare two directory structures and identify which files have different content, using tools like diff, rsync, and custom scripts."
 category:
   name: 'Linux'

--- a/content/posts/composer-command-injection-cve-2026.md
+++ b/content/posts/composer-command-injection-cve-2026.md
@@ -1,5 +1,6 @@
 ---
 title: 'Two Composer Command Injection Flaws Let Attackers Run Arbitrary Code - Even Without Perforce'
+seoTitle: 'Two Composer Flaws Let Attackers Run Arbitrary Code'
 excerpt: 'CVE-2026-40176 and CVE-2026-40261 affect all Composer 2.x versions. A malicious composer.json or crafted package metadata can execute OS commands on your machine. Upgrade to 2.9.6 now.'
 category:
   name: 'Security'

--- a/content/posts/coolify-self-hosted-paas-digitalocean.md
+++ b/content/posts/coolify-self-hosted-paas-digitalocean.md
@@ -1,5 +1,6 @@
 ---
 title: 'Coolify: Self-Hosted PaaS on DigitalOcean - Deploy Apps Without Vendor Lock-In'
+seoTitle: 'Coolify: Self-Hosted PaaS on DigitalOcean, No Vendor Lock-In'
 excerpt: 'Set up Coolify on a DigitalOcean droplet and get your own Vercel-like platform for deploying Next.js apps, databases, and more - with auto SSL, GitHub auto-deploy, and no per-seat pricing.'
 category:
   name: 'DevOps'

--- a/content/posts/copy-fail-cve-2026-31431-linux-container-escape.md
+++ b/content/posts/copy-fail-cve-2026-31431-linux-container-escape.md
@@ -1,5 +1,6 @@
 ---
 title: 'CVE-2026-31431 Copy Fail: A 4-Byte Kernel Write That Escapes Containers'
+seoTitle: 'CVE-2026-31431 Copy Fail: A 4-Byte Container Escape'
 excerpt: 'A new Linux kernel bug lets any unprivileged process flip 4 bytes in the page cache and break out of a container. runtime-default seccomp does not block it. Here is what to do.'
 category:
   name: 'DevOps'

--- a/content/posts/dast-integration-guide.md
+++ b/content/posts/dast-integration-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Integrate DAST Into Your CI/CD Pipeline (With OWASP ZAP Examples)'
+seoTitle: 'How to Integrate DAST Into CI/CD With OWASP ZAP'
 excerpt: 'A practical guide to Dynamic Application Security Testing. Learn how DAST works, set up OWASP ZAP scans, compare it with Burp Suite, and automate security testing in your CI/CD pipeline with quality gates.'
 category:
   name: 'Security'

--- a/content/posts/deployment-strategies-guide.md
+++ b/content/posts/deployment-strategies-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 'Deployment Strategies: Blue-Green, Canary, and Rolling Deployments Explained'
+seoTitle: 'Deployment Strategies: Blue-Green, Canary and Rolling Explained'
 excerpt: 'Learn how to deploy applications safely using blue-green, canary, and rolling deployment strategies. Understand the theory, trade-offs, and decision-making behind each approach.'
 category:
   name: 'DevOps'

--- a/content/posts/designing-rate-limiting-for-apis.md
+++ b/content/posts/designing-rate-limiting-for-apis.md
@@ -1,5 +1,6 @@
 ---
 title: 'Designing Rate Limiting for APIs: Algorithms, Patterns, and Implementation'
+seoTitle: 'Designing Rate Limiting for APIs: Algorithms and Patterns'
 excerpt: 'A practical comparison of token bucket, leaky bucket, fixed window, and sliding window rate limiting, with copy-paste Redis and FastAPI code, nginx config, and guidance on which one to actually use.'
 category:
   name: 'DevOps'

--- a/content/posts/devops-engineer-career-paths-next-five-years.md
+++ b/content/posts/devops-engineer-career-paths-next-five-years.md
@@ -1,5 +1,6 @@
 ---
 title: 'DevOps Engineer, What''s Next? Five Career Paths for the Next Five Years'
+seoTitle: 'DevOps Engineer: Five Career Paths for the Next Five Years'
 excerpt: 'The generic "DevOps Engineer" title is splitting into specialized tracks. Here are five honest career paths for the next five years, what each one really involves, who thrives in it, and the first concrete step to take.'
 category:
   name: 'DevOps'

--- a/content/posts/difference-between-targetport-and-port-in-kubernetes-service-definition.md
+++ b/content/posts/difference-between-targetport-and-port-in-kubernetes-service-definition.md
@@ -1,5 +1,6 @@
 ---
 title: 'Difference Between targetPort and port in Kubernetes Service Definition'
+seoTitle: 'targetPort vs port in a Kubernetes Service Definition'
 excerpt: "Understand the distinction between targetPort and port in Kubernetes Service definitions, and learn how they impact your application's networking."
 category:
   name: 'Kubernetes'

--- a/content/posts/dirty-frag-cve-2026-43284-linux-root-escalation.md
+++ b/content/posts/dirty-frag-cve-2026-43284-linux-root-escalation.md
@@ -1,5 +1,6 @@
 ---
 title: 'Dirty Frag (CVE-2026-43284 + CVE-2026-43500): Local Root on Every Major Linux Distro'
+seoTitle: 'Dirty Frag (CVE-2026-43284): Local Root on Major Linux Distros'
 excerpt: 'A two-bug chain in the Linux kernel networking subsystems lets any unprivileged local user become root in a single command. The PoC is public, the embargo broke, and not all distros have a patch yet.'
 category:
   name: 'Security'

--- a/content/posts/distributed-tracing-opentelemetry-instrumentation-visualization.md
+++ b/content/posts/distributed-tracing-opentelemetry-instrumentation-visualization.md
@@ -1,5 +1,6 @@
 ---
 title: 'Distributed Tracing with OpenTelemetry: From Instrumentation to Visualization'
+seoTitle: 'Distributed Tracing with OpenTelemetry: A Practical Guide'
 excerpt: 'A walkthrough of instrumenting a real service with OpenTelemetry, running the Collector, and finding the slow span in Jaeger when a request hops across five microservices.'
 category:
   name: 'DevOps'

--- a/content/posts/dmarcbis-what-changed-new-dmarc.md
+++ b/content/posts/dmarcbis-what-changed-new-dmarc.md
@@ -1,5 +1,6 @@
 ---
 title: 'DMARCbis Is Here: What Changed in the New DMARC and What to Do to Your Records'
+seoTitle: 'DMARCbis Is Here: What Changed and What to Do to Your Records'
 excerpt: 'DMARC finally became a real internet standard in 2026. The pct tag is gone, there are two new tags, and the Public Suffix List is out. Here is what actually changed and the exact edits to make to your DNS.'
 category:
   name: 'Networking'

--- a/content/posts/docker-compose-always-recreate-containers.md
+++ b/content/posts/docker-compose-always-recreate-containers.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Get docker-compose to Always Re-create Containers from Fresh Images'
+seoTitle: 'Force docker-compose to Re-create Containers From Fresh Images'
 excerpt: 'Want to make sure docker-compose always uses the latest image and re-creates containers? Learn the right flags, workflow, and best practices to avoid stale containers in development and CI.'
 category:
   name: 'Docker'

--- a/content/posts/error-creating-iam-role-malformed-policy.md
+++ b/content/posts/error-creating-iam-role-malformed-policy.md
@@ -1,5 +1,6 @@
 ---
 title: 'Terraform: Error Creating IAM Role. MalformedPolicyDocument: Has Prohibited Field Resource'
+seoTitle: 'Terraform IAM Role Error: MalformedPolicyDocument'
 excerpt: "Learn how to resolve the 'MalformedPolicyDocument: Has prohibited field Resource' error when creating an IAM role in Terraform."
 category:
   name: 'Terraform'

--- a/content/posts/firebase-alternatives-2026.md
+++ b/content/posts/firebase-alternatives-2026.md
@@ -1,5 +1,6 @@
 ---
 title: 'Firebase Alternatives in 2026: Choose by Why You Are Leaving, Not by a Ranking'
+seoTitle: 'Firebase Alternatives in 2026: Choose by Why You Are Leaving'
 excerpt: 'Most "Firebase alternatives" lists rank tools you cannot compare, because Firebase is five products in a trench coat. The useful question is which part you are replacing and why you are leaving: the Firestore bill that scales with reads, or the data model you cannot port. Here is an honest map of Supabase, Appwrite, Convex, PocketBase, Nhost, Amplify and the rest, grouped by the reason you are actually switching.'
 category:
   name: 'Cloud'

--- a/content/posts/fix-error-acquiring-the-state-lock-conditionalcheckfailedexception.md
+++ b/content/posts/fix-error-acquiring-the-state-lock-conditionalcheckfailedexception.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Fix "Error acquiring the state lock: ConditionalCheckFailedException"'
+seoTitle: 'Fix "Error acquiring the state lock" in Terraform'
 excerpt: 'Learn how to diagnose and fix Terraform state lock errors that prevent your infrastructure deployments from running.'
 category:
   name: 'Terraform'

--- a/content/posts/get-current-date-time-and-custom-commands.md
+++ b/content/posts/get-current-date-time-and-custom-commands.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Get Current Date and Time in Linux Terminal and Create Custom Commands'
+seoTitle: 'Get the Current Date and Time in the Linux Terminal'
 excerpt: "Learn how to display the current date and time in various formats using the date command, and create custom shell aliases for quick access to your preferred formats."
 category:
   name: 'Linux'

--- a/content/posts/get-current-time-seconds-since-epoch-bash.md
+++ b/content/posts/get-current-time-seconds-since-epoch-bash.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Get the Current Time in Seconds Since the Epoch in Bash on Linux'
+seoTitle: 'Get the Current Time in Seconds Since the Epoch in Bash'
 excerpt: "Learn how to get Unix timestamps in Bash for logging, benchmarking, and time calculations. Includes examples of converting timestamps, measuring elapsed time, and practical use cases."
 category:
   name: 'Bash'

--- a/content/posts/get-logs-from-all-pods-replication-controller.md
+++ b/content/posts/get-logs-from-all-pods-replication-controller.md
@@ -1,5 +1,6 @@
 ---
 title: 'How Do I Get Logs from All Pods of a Kubernetes Replication Controller?'
+seoTitle: 'How to Get Logs From All Pods of a Replication Controller'
 excerpt: 'Learn how to retrieve logs from all Pods managed by a Kubernetes replication controller. Understand the commands and best practices for effective logging.'
 category:
   name: 'Kubernetes'

--- a/content/posts/github-rce-git-push-header-injection-cve-2026-3854.md
+++ b/content/posts/github-rce-git-push-header-injection-cve-2026-3854.md
@@ -1,5 +1,6 @@
 ---
 title: 'One git push to RCE: the anatomy of CVE-2026-3854 and the parsing bug behind it'
+seoTitle: 'One git push to RCE: The Anatomy of CVE-2026-3854'
 excerpt: 'A single git push could execute code on GitHub''s backend, with cross-tenant reach on github.com itself. The root cause is a bug you almost certainly have somewhere too: untrusted input smuggled through a delimited internal header.'
 category:
   name: 'CI/CD'

--- a/content/posts/gitops-argocd-repository-structure-multi-environment.md
+++ b/content/posts/gitops-argocd-repository-structure-multi-environment.md
@@ -1,5 +1,6 @@
 ---
 title: 'GitOps with Argo CD: Structuring Your Repository for Multi-Environment Deployments'
+seoTitle: 'GitOps with Argo CD: Multi-Environment Repository Structure'
 excerpt: 'A practical guide to laying out your Git repository for Argo CD across dev, staging, and production. See real folder structures, Kustomize and Helm patterns, and the pitfalls that bite teams in production.'
 category:
   name: 'DevOps'

--- a/content/posts/government-pulled-fable-mythos-what-builders-should-learn.md
+++ b/content/posts/government-pulled-fable-mythos-what-builders-should-learn.md
@@ -1,5 +1,6 @@
 ---
 title: 'The US Government Pulled Two Frontier Models Overnight. The Real Lesson Is About Your Stack'
+seoTitle: 'Two Frontier Models Pulled Overnight: The Lesson for Your Stack'
 excerpt: 'On June 12, 2026, an export-control directive forced Anthropic to disable Claude Fable 5 and Mythos 5 for every user worldwide, three days after launch. The policy fight is interesting. The operational lesson for anyone building on a single model provider is more urgent.'
 category:
   name: 'DevOps'

--- a/content/posts/healthz-convention-origin.md
+++ b/content/posts/healthz-convention-origin.md
@@ -1,5 +1,6 @@
 ---
 title: 'Where Does the Convention of Using /healthz for Application Health Checks Come From?'
+seoTitle: 'Where Does the /healthz Health Check Convention Come From?'
 excerpt: 'Discover the origins of the /healthz endpoint convention for application health checks and why it has become a standard in modern software development.'
 category:
   name: 'DevOps'

--- a/content/posts/hetzner-price-increases-2026.md
+++ b/content/posts/hetzner-price-increases-2026.md
@@ -1,5 +1,6 @@
 ---
 title: "Hetzner's Third Price Increase in Three Months: What DevOps Teams Should Do"
+seoTitle: 'Hetzner Raised Prices Three Times: What DevOps Teams Should Do'
 excerpt: 'Hetzner is changing dedicated server and cloud pricing again on June 15, 2026. Here is what changed, why customers are frustrated, and how to decide whether to stay, resize, or move workloads.'
 category:
   name: 'FinOps'

--- a/content/posts/hostnetwork-footgun-cve-2026-32193.md
+++ b/content/posts/hostnetwork-footgun-cve-2026-32193.md
@@ -1,5 +1,6 @@
 ---
 title: 'hostNetwork Is Still a Footgun: What CVE-2026-32193 Teaches Every Cluster'
+seoTitle: 'hostNetwork Is Still a Footgun: CVE-2026-32193'
 excerpt: 'A recent AKS advisory let an untrusted pod with hostNetwork break out to the worker node. The Azure-specific bug is patched, but the footgun that made it reachable lives on every Kubernetes cluster. Here is how the escape class works and what to actually lock down.'
 category:
   name: 'Kubernetes'

--- a/content/posts/how-to-determine-the-url-that-a-local-git-repository-was-originally-cloned-from.md
+++ b/content/posts/how-to-determine-the-url-that-a-local-git-repository-was-originally-cloned-from.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Determine the URL That a Local Git Repository Was Originally Cloned From'
+seoTitle: 'How to Find the URL a Local Git Repository Was Cloned From'
 excerpt: 'Find out where your Git repository came from by checking remote URLs. Learn how to view, verify, and manage remote repository connections using git remote commands.'
 category:
   name: 'Git'

--- a/content/posts/how-to-get-docker-host-ip-from-container.md
+++ b/content/posts/how-to-get-docker-host-ip-from-container.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Get the IP Address of the Docker Host from Inside a Docker Container'
+seoTitle: 'How to Get the Docker Host IP From Inside a Container'
 excerpt: "Need your container to talk to the Docker host? Learn practical ways to discover the host's IP address from inside a container, with examples for Linux, macOS, and Windows."
 category:
   name: 'Docker'

--- a/content/posts/how-to-make-git-forget-tracked-file-in-gitignore.md
+++ b/content/posts/how-to-make-git-forget-tracked-file-in-gitignore.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Make Git Forget About a File That Was Tracked But Is Now in .gitignore'
+seoTitle: 'Make Git Forget a Tracked File That Is Now in .gitignore'
 excerpt: 'Learn how to remove files from Git tracking while keeping them locally when you add them to .gitignore after they were already committed.'
 category:
   name: 'Git'

--- a/content/posts/how-to-manage-multiple-environments-in-kubernetes.md
+++ b/content/posts/how-to-manage-multiple-environments-in-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Manage Multiple Environments in Kubernetes (Staging, QA, Production)'
+seoTitle: 'How to Manage Multiple Environments in Kubernetes'
 excerpt: 'Learn practical strategies for managing multiple Kubernetes environments like staging, QA, and production. This guide covers namespace organization, configuration management, and deployment workflows.'
 category:
   name: 'Kubernetes'

--- a/content/posts/how-to-split-terraform-file.md
+++ b/content/posts/how-to-split-terraform-file.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Split a Terraform File (main.tf) into Several Files (No Modules)'
+seoTitle: 'How to Split a Terraform File Into Several Files'
 excerpt: 'Organizing Terraform configurations by splitting a single main.tf file into multiple files can improve readability and maintainability. Learn how to do this without using modules.'
 category:
   name: 'Terraform'

--- a/content/posts/ingress-nginx-eol-gateway-api-migration.md
+++ b/content/posts/ingress-nginx-eol-gateway-api-migration.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ingress-NGINX Is Retired: A Real Migration to Gateway API With ingress2gateway 1.0'
+seoTitle: 'Ingress-NGINX Is Retired: A Real Migration to Gateway API'
 excerpt: 'In March 2026 the Kubernetes project retired ingress-nginx with no replacement waiting in the wings. Roughly half of all clusters still run it. This post is the migration that does not involve a flag day: how to inventory your annotations, what ingress2gateway 1.0 translates and what it silently drops, the side-by-side cutover pattern with the actual PromQL, and how to pick between Envoy Gateway, kgateway, Cilium Gateway, and Istio.'
 category:
   name: 'Kubernetes'

--- a/content/posts/invalid-for-each-argument-in-terraform.md
+++ b/content/posts/invalid-for-each-argument-in-terraform.md
@@ -1,5 +1,6 @@
 ---
 title: 'Terraform Failing with Invalid for_each Argument / The Given "for_each" Argument Value is Unsuitable'
+seoTitle: 'Terraform: Invalid for_each Argument Value Is Unsuitable'
 excerpt: 'Learn how to troubleshoot and fix the "Invalid for_each argument" error in Terraform.'
 category:
   name: 'Terraform'

--- a/content/posts/karpenter-spot-storm-fallback-gap.md
+++ b/content/posts/karpenter-spot-storm-fallback-gap.md
@@ -1,5 +1,6 @@
 ---
 title: 'Karpenter Spot Storm Fallback Gap: The Production Loop Nobody Talks About'
+seoTitle: 'Karpenter Spot Storm Fallback Gap: The Production Loop'
 excerpt: 'When AWS spot capacity dries up in a region, Karpenter does not automatically fall back to on-demand. It retries the same dying offerings on a 3-minute loop. Here is why, and how to design around it.'
 category:
   name: 'Kubernetes'

--- a/content/posts/kubernetes-service-types-clusterip-nodeport-loadbalancer.md
+++ b/content/posts/kubernetes-service-types-clusterip-nodeport-loadbalancer.md
@@ -1,5 +1,6 @@
 ---
 title: 'Difference Between ClusterIP, NodePort and LoadBalancer Service Types in Kubernetes'
+seoTitle: 'ClusterIP vs NodePort vs LoadBalancer in Kubernetes'
 excerpt: 'Understand the key differences between ClusterIP, NodePort, and LoadBalancer service types in Kubernetes, when to use each, and how they expose applications.'
 category:
   name: 'Kubernetes'

--- a/content/posts/neon-per-branch-ai-spend-isolation.md
+++ b/content/posts/neon-per-branch-ai-spend-isolation.md
@@ -1,5 +1,6 @@
 ---
 title: 'Per-Branch AI Endpoints: Isolating Model Spend Across Prod, Preview, and CI'
+seoTitle: 'Per-Branch AI Endpoints: Isolating Model Spend'
 excerpt: 'When previews, CI, and production all call models with the same key, you cannot tell what a preview cost or notice a runaway test until the invoice. Because a Neon branch is its own deployment with a usage ledger that lives in the branch''s Postgres, model spend is attributed and isolated per environment. I proved it: a CI branch spent tokens while production stayed flat.'
 category:
   name: 'DevOps'

--- a/content/posts/neon-vs-supabase-operational-benchmarks.md
+++ b/content/posts/neon-vs-supabase-operational-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: 'Neon vs Supabase in Production: We Benchmarked the Operations That Page You at 3am'
+seoTitle: 'Neon vs Supabase: Benchmarking the Operations That Page You'
 excerpt: 'Two benchmark sessions against Neon and Supabase Pro measured what spec sheets never show: compute resizes cost 39 seconds of real downtime on one platform and zero on the other, read replicas differ by 23x, and branch creation has a tail you should know about.'
 category:
   name: 'DevOps'

--- a/content/posts/netease-fluid-30-second-llm-cold-starts-kubernetes.md
+++ b/content/posts/netease-fluid-30-second-llm-cold-starts-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: "How NetEase Games Cut LLM Cold Starts From 42 Minutes to 30 Seconds Using Fluid"
+seoTitle: 'NetEase Cut LLM Cold Starts From 42 Minutes to 30 Seconds'
 excerpt: "NetEase Games published a Kubernetes case study walking through how they took their serverless GPU inference cold-start time from 42 minutes down to under 30 seconds. The bottleneck isn't the GPU. It's the 60GB model weights crossing a region. Here is what they did with the CNCF Fluid project and how to apply the same pattern even if you are not on Kubernetes."
 category:
   name: 'Kubernetes'

--- a/content/posts/nginx-rift-cve-2026-42945-rewrite-rce.md
+++ b/content/posts/nginx-rift-cve-2026-42945-rewrite-rce.md
@@ -1,5 +1,6 @@
 ---
 title: "NGINX Rift (CVE-2026-42945): The 18-Year-Old Rewrite Bug That Hands an Attacker Your Worker Process"
+seoTitle: 'NGINX Rift (CVE-2026-42945): An 18-Year-Old Rewrite Bug'
 excerpt: "An autonomous code-audit tool found an 18-year-old heap overflow in NGINX's rewrite module. Affects every release from 0.6.27 through 1.30.0, plus NGINX Plus and the entire F5 product line. Full RCE PoC is public. Here is the one-line config grep that tells you whether you are exposed, the patch matrix, and what to do about the long tail of products that bundle the vulnerable nginx without a vendor patch yet."
 category:
   name: 'Networking'

--- a/content/posts/node-ipc-dns-exfil-supply-chain-may-2026.md
+++ b/content/posts/node-ipc-dns-exfil-supply-chain-may-2026.md
@@ -1,5 +1,6 @@
 ---
 title: "node-ipc DNS-Tunneling Supply Chain Attack: Your Egress Firewall Probably Missed This"
+seoTitle: 'node-ipc DNS Tunnelling: Your Egress Firewall Probably Missed It'
 excerpt: "On May 14, 2026, three malicious versions of the node-ipc npm package shipped a payload that hunts AWS, SSH, kubeconfig, and GitHub CLI credentials, then smuggles them out through DNS TXT queries. Most orgs filter HTTPS egress. Almost nobody filters DNS. Here is what the payload does and how to close the gap."
 category:
   name: 'DevOps'

--- a/content/posts/node-postgres-sslmode-silently-ignores-ssl-options.md
+++ b/content/posts/node-postgres-sslmode-silently-ignores-ssl-options.md
@@ -1,5 +1,6 @@
 ---
 title: 'node-postgres Silently Ignores Your TLS Config When the URL Says sslmode'
+seoTitle: 'node-postgres Ignores Your TLS Config When the URL Says sslmode'
 excerpt: 'If your connection string contains sslmode=require, the pg library throws away the ssl options object where you loaded your CA certificate, and verification fails with "self-signed certificate in certificate chain". Here is the trap, the fix, and the v9 changes coming.'
 category:
   name: 'DevOps'

--- a/content/posts/npm-v12-install-scripts-audit.md
+++ b/content/posts/npm-v12-install-scripts-audit.md
@@ -1,5 +1,6 @@
 ---
 title: 'npm v12 Will Stop Running Install Scripts. We Audited Our Repos to See What Actually Breaks'
+seoTitle: 'npm v12 Stops Install Scripts: We Audited Our Own Repos'
 excerpt: 'Starting with npm v12 (estimated July 2026), dependency install scripts will not run unless you allowlist them. We ran the new audit tooling on our own production repos: 65 packages flagged, 4 that matter, and a surprising amount of nothing breaking.'
 category:
   name: 'DevOps'

--- a/content/posts/opentelemetry-graduated-what-to-retire-this-quarter.md
+++ b/content/posts/opentelemetry-graduated-what-to-retire-this-quarter.md
@@ -1,5 +1,6 @@
 ---
 title: "OpenTelemetry Just Graduated: What to Retire from Your Stack This Quarter"
+seoTitle: 'OpenTelemetry Graduated: What to Retire From Your Stack'
 excerpt: "On May 21, 2026, CNCF graduated OpenTelemetry. All three core signals (traces, metrics, logs) are now production-ready, the project is the second-most-active in CNCF after Kubernetes itself, and Anthropic, Bloomberg, Capital One, eBay, and Heroku run it at scale. Here is the decision framework for what proprietary agents you can stop running, what is still risky, and the 90-day adoption checklist."
 category:
   name: 'DevOps'

--- a/content/posts/opentofu-2026-switch-from-terraform.md
+++ b/content/posts/opentofu-2026-switch-from-terraform.md
@@ -1,5 +1,6 @@
 ---
 title: 'OpenTofu in 2026: Should You Switch from Terraform (and What It Actually Costs You)'
+seoTitle: 'OpenTofu in 2026: Should You Switch from Terraform?'
 excerpt: 'OpenTofu has matured into a real Terraform alternative in 2026. Here is what the fork gives you, why the migration is easier than you think, and where the actual lock-in hides.'
 category:
   name: 'Terraform'

--- a/content/posts/pglayers-postgres-extensions-docker-layers.md
+++ b/content/posts/pglayers-postgres-extensions-docker-layers.md
@@ -1,5 +1,6 @@
 ---
 title: 'Stop Compiling Postgres Extensions in Your Dockerfile: How pglayers Works'
+seoTitle: 'Stop Compiling Postgres Extensions in Your Dockerfile'
 excerpt: 'Adding pgvector or PostGIS to a Postgres image usually means apt-get, build tools, and a fat, slow image. pglayers ships each extension as a scratch Docker layer you COPY in. Here is how it works and when to use it.'
 category:
   name: 'Docker'

--- a/content/posts/postgres-18-uuidv7-primary-keys.md
+++ b/content/posts/postgres-18-uuidv7-primary-keys.md
@@ -1,5 +1,6 @@
 ---
 title: 'Stop Using Random UUIDs as Primary Keys: uuidv7() Lands in PostgreSQL 18'
+seoTitle: 'Stop Using Random UUIDs as Keys: uuidv7() in PostgreSQL 18'
 excerpt: 'Random UUIDv4 primary keys quietly wreck insert speed and bloat indexes on large tables. PostgreSQL 18 ships a native time-ordered uuidv7() that keeps the upsides of UUIDs without the B-tree penalty. Here are the numbers and how to adopt it.'
 category:
   name: 'DevOps'

--- a/content/posts/postgres-k8s.md
+++ b/content/posts/postgres-k8s.md
@@ -1,5 +1,6 @@
 ---
 title: 'Why Running Postgres on Kubernetes Is Still a Bad Idea (And What to Do Instead)'
+seoTitle: 'Why Running Postgres on Kubernetes Is Still a Bad Idea'
 excerpt: 'Everyone wants to run databases on Kubernetes, but should you? We explore the real challenges of stateful workloads and better alternatives.'
 category:
   name: 'Kubernetes'

--- a/content/posts/postinstall-hidden-in-package-json-php-supply-chain-may-2026.md
+++ b/content/posts/postinstall-hidden-in-package-json-php-supply-chain-may-2026.md
@@ -1,5 +1,6 @@
 ---
 title: "When the Malicious Hook Is in the Other Manifest: 700+ Repos, 8 Packagist Packages, One package.json Trick"
+seoTitle: '700+ Repos Hit by a Malicious Hook Hidden in package.json'
 excerpt: "On May 22, 2026, Socket disclosed a Composer supply chain attack that hid an npm-style postinstall command inside package.json on PHP projects. composer.json was clean, the PHP review missed it, and 700+ GitHub repos pulled it in. Here is the exact payload, why ecosystem-boundary blindness keeps catching teams, and how to wire your CI to look at both manifests."
 category:
   name: 'DevOps'

--- a/content/posts/pre-commit-hooks-security-guide.md
+++ b/content/posts/pre-commit-hooks-security-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 'Pre-commit Hooks for Security: Stop Secrets Before They Hit Your Repository'
+seoTitle: 'Pre-commit Hooks for Security: Stop Secrets Before They Land'
 excerpt: 'Once a secret is committed to Git, it lives forever in the history. Pre-commit hooks with gitleaks, detect-secrets, and custom checks catch credentials before that happens.'
 category:
   name: 'Security'

--- a/content/posts/pwn-request-github-actions-checkout-v7.md
+++ b/content/posts/pwn-request-github-actions-checkout-v7.md
@@ -1,5 +1,6 @@
 ---
 title: 'The pwn request just got harder: what actions/checkout v7 changes, and what it does not'
+seoTitle: 'The pwn Request Got Harder: What checkout v7 Changes'
 excerpt: 'GitHub is backporting a fork-checkout block to actions/checkout, with enforcement on July 20, 2026. Here is what a pwn request actually is, what the change stops, and the three ways your pipeline is still exposed after you upgrade.'
 category:
   name: 'CI/CD'

--- a/content/posts/resource-type-attribute-access.md
+++ b/content/posts/resource-type-attribute-access.md
@@ -1,5 +1,6 @@
 ---
 title: 'Fixing "A Reference to Resource Type Must Be Followed by At Least One Attribute Access" in Terraform'
+seoTitle: 'Fix "Reference to Resource Type Must Be Followed by Attribute"'
 excerpt: "Learn how to resolve the error 'A reference to resource type must be followed by at least one attribute access' in Terraform."
 category:
   name: 'Terraform'

--- a/content/posts/secrets-management-guide.md
+++ b/content/posts/secrets-management-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 'Secrets Management Guide: Vault, AWS Secrets Manager, and Azure Key Vault'
+seoTitle: 'Secrets Management: Vault, AWS Secrets Manager, Key Vault'
 excerpt: 'Stop storing secrets in .env files and environment variables. This guide covers secrets management fundamentals, HashiCorp Vault dynamic secrets, AWS Secrets Manager rotation, and Azure Key Vault with practical code examples.'
 category:
   name: 'Security'

--- a/content/posts/security-focused-code-reviews.md
+++ b/content/posts/security-focused-code-reviews.md
@@ -1,5 +1,6 @@
 ---
 title: 'Security-Focused Code Reviews: Catching Vulnerabilities Before Production'
+seoTitle: 'Security-Focused Code Reviews: Catching Bugs Before Production'
 excerpt: 'Learn how to review code with a security mindset. This guide covers common vulnerability patterns, language-specific pitfalls, and practical checklists for finding injection flaws, auth bypass, and logic bugs that automated tools miss.'
 category:
   name: 'Security'

--- a/content/posts/security-profiles-operator-seccomp-boundary.md
+++ b/content/posts/security-profiles-operator-seccomp-boundary.md
@@ -1,5 +1,6 @@
 ---
 title: 'Build the Container Boundary You Do Not Have: Seccomp Profiles with the Security Profiles Operator'
+seoTitle: 'Seccomp Profiles with the Security Profiles Operator'
 excerpt: 'A container is not a security boundary out of the box, but you can build one. Here is a hands-on guide to recording, tuning, and enforcing seccomp profiles with the Security Profiles Operator, which just shipped v1.0.'
 category:
   name: 'Kubernetes'

--- a/content/posts/send-an-email-by-hand-raw-smtp.md
+++ b/content/posts/send-an-email-by-hand-raw-smtp.md
@@ -1,5 +1,6 @@
 ---
 title: 'Send an Email by Hand: The Raw SMTP Conversation (and Why You Should Not Do It in Production)'
+seoTitle: 'Send an Email by Hand: The Raw SMTP Conversation'
 excerpt: 'You can open a socket to a mail server and type an email one command at a time. Doing it once teaches you what every email API hides. Here is the full SMTP conversation, byte by byte, and the exact reasons production sending needs more than a telnet session.'
 category:
   name: 'Networking'

--- a/content/posts/should-terraform-lock-be-in-your-gitignore.md
+++ b/content/posts/should-terraform-lock-be-in-your-gitignore.md
@@ -1,5 +1,6 @@
 ---
 title: 'Should .terraform.lock.hcl Be in .gitignore? (The Answer Might Surprise You)'
+seoTitle: 'Should .terraform.lock.hcl Be in .gitignore?'
 excerpt: 'The .terraform.lock.hcl file causes confusion for many Terraform users. Learn why you should commit it to version control and how to handle it properly.'
 category:
   name: 'Terraform'

--- a/content/posts/spacex-cursor-acquisition-betting-on-one-ai-tool.md
+++ b/content/posts/spacex-cursor-acquisition-betting-on-one-ai-tool.md
@@ -1,5 +1,6 @@
 ---
 title: 'SpaceX Just Bought Cursor for $60B. What That Means If Your Team Lives in It'
+seoTitle: 'SpaceX Bought Cursor for $60B: What It Means for Your Team'
 excerpt: 'SpaceX is acquiring Anysphere, the maker of Cursor, in a $60 billion all-stock deal, the largest acquisition of a venture-backed startup ever. The number is the headline. The real question for engineering teams is what it means to build your daily workflow on a tool whose owner just changed.'
 category:
   name: 'DevOps'

--- a/content/posts/terraform-cloudwatch-log-subscription-lambda.md
+++ b/content/posts/terraform-cloudwatch-log-subscription-lambda.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Configure CloudWatch Logs Subscription Filter to Lambda With Terraform'
+seoTitle: 'Configure a CloudWatch Logs Subscription to Lambda in Terraform'
 excerpt: "Learn how to stream CloudWatch Logs to a Lambda function using Terraform, including proper permissions and error handling."
 category:
   name: 'Terraform'

--- a/content/posts/terraform-import-index-value-required-error.md
+++ b/content/posts/terraform-import-index-value-required-error.md
@@ -1,5 +1,6 @@
 ---
 title: 'How to Fix Terraform Import "Index Value Required" Error for String Keys'
+seoTitle: 'Fix Terraform Import "Index Value Required" for String Keys'
 excerpt: "Learn how to resolve the 'Index value required' error when importing resources with for_each in Terraform, and understand the correct syntax for string-based resource keys."
 category:
   name: 'Terraform'

--- a/content/posts/terraform-provider-checksum-mismatch.md
+++ b/content/posts/terraform-provider-checksum-mismatch.md
@@ -1,5 +1,6 @@
 ---
 title: 'Terraform: Failed to install provider, does not match checksums from dependency lock file'
+seoTitle: 'Terraform: Provider Does Not Match Checksums in the Lock File'
 excerpt: 'Troubleshoot the Terraform error about provider checksums not matching the dependency lock file and learn safe fixes and best practices.'
 category:
   name: 'Terraform'

--- a/content/posts/the-provided-execution-role-does-not-have-permissions-to-call-describenetworkinterfaces-on-ec2.md
+++ b/content/posts/the-provided-execution-role-does-not-have-permissions-to-call-describenetworkinterfaces-on-ec2.md
@@ -1,5 +1,6 @@
 ---
 title: 'The provided execution role does not have permissions to call DescribeNetworkInterfaces on EC2'
+seoTitle: 'Lambda Role Cannot Call DescribeNetworkInterfaces on EC2'
 excerpt: "Learn how to resolve the 'execution role does not have permissions to call DescribeNetworkInterfaces' error in AWS EC2."
 category:
   name: 'AWS'

--- a/content/posts/use-terraform-to-set-up-a-lambda-function-triggered-by-a-scheduled-event-source.md
+++ b/content/posts/use-terraform-to-set-up-a-lambda-function-triggered-by-a-scheduled-event-source.md
@@ -1,5 +1,6 @@
 ---
 title: 'Use Terraform to set up a Lambda function triggered by a scheduled event source'
+seoTitle: 'Terraform: A Lambda Function Triggered by a Scheduled Event'
 excerpt: 'Learn how to use Terraform to create an AWS Lambda function triggered by a scheduled event source, such as a cron job.'
 category:
   name: 'Terraform'

--- a/content/posts/vercel-april-2026-security-incident.md
+++ b/content/posts/vercel-april-2026-security-incident.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Vercel April 2026 Security Incident: What Happened and What to Do About It'
+seoTitle: 'The Vercel April 2026 Security Incident: What to Do About It'
 excerpt: 'Vercel disclosed a security incident that started with a compromised OAuth app at Context.ai, escalated through a Vercel employee Google Workspace account, and reached internal systems plus customer environment variables not marked sensitive. Here is the attack chain, what was exposed, and what to change in your deployments.'
 category:
   name: 'DevOps'

--- a/content/posts/why-your-ci-pipeline-is-slower.md
+++ b/content/posts/why-your-ci-pipeline-is-slower.md
@@ -1,5 +1,6 @@
 ---
 title: 'Why Your CI/CD Pipeline Is Slower Than It Should Be (and How to Fix It)'
+seoTitle: 'Why Your CI/CD Pipeline Is Slower Than It Should Be'
 excerpt: 'Small pipeline changes give big wins. Parallelize jobs, cache dependencies, pin images, reuse build artifacts, and run only the tests you need.'
 category:
   name: 'DevOps'

--- a/content/posts/write-simple-kubernetes-operator.md
+++ b/content/posts/write-simple-kubernetes-operator.md
@@ -1,5 +1,6 @@
 ---
 title: 'Understanding Kubernetes Operators: A Deep Dive with a Practical Example'
+seoTitle: 'Understanding Kubernetes Operators: A Practical Deep Dive'
 excerpt: 'Learn the concepts behind Kubernetes operators, why they exist, and how the control loop pattern works, then build one yourself to solidify your understanding.'
 category:
   name: 'Kubernetes'

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -13,6 +13,12 @@ const POSTS_DIR = path.join(process.cwd(), 'content', 'posts');
 // Define the expected Post type for type safety
 export type Post = {
   title: string;
+  /**
+   * Shorter title for the <title> tag only, leaving the headline a reader
+   * sees unchanged. Bing flags anything over 70 characters as liable to be
+   * truncated or ignored. Guides and games already have the same field.
+   */
+  seoTitle?: string;
   slug: string;
   excerpt?: string;
   content: string;

--- a/tests/title-length.test.ts
+++ b/tests/title-length.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getAllPosts } from '@/lib/posts';
+
+/**
+ * Bing flags any <title> over 70 characters as liable to be truncated or
+ * ignored, and it reported 36 of our pages. Google clips around the same
+ * point, so an over-long title mostly costs the end of the sentence in the
+ * result, which is usually the part that says what the page is.
+ *
+ * `seoTitle` shortens the tag without touching the headline a reader sees,
+ * the same field guides and games already use.
+ */
+const MAX_TITLE = 70;
+
+describe('search result titles', () => {
+  it('keeps every post title tag within the limit', async () => {
+    const posts = (await getAllPosts()) as Array<{
+      slug: string;
+      title: string;
+      seoTitle?: string;
+    }>;
+
+    const tooLong = posts
+      .map((p) => ({ slug: p.slug, title: p.seoTitle || p.title }))
+      .filter((p) => p.title.length > MAX_TITLE)
+      .map((p) => `${p.slug} (${p.title.length}): ${p.title}`);
+
+    // Fix by adding a shorter `seoTitle` to the post's frontmatter, not by
+    // rewriting the headline, unless the headline is genuinely too long.
+    expect(tooLong, `posts whose title tag exceeds ${MAX_TITLE} characters`).toEqual([]);
+  });
+
+  it('does not set a seoTitle that is longer than the title it replaces', async () => {
+    const posts = (await getAllPosts()) as Array<{
+      slug: string;
+      title: string;
+      seoTitle?: string;
+    }>;
+
+    const pointless = posts
+      .filter((p) => p.seoTitle && p.seoTitle.length >= p.title.length)
+      .map((p) => p.slug);
+
+    expect(pointless, 'seoTitle should be shorter than title').toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds a seoTitle field to posts, as guides and games already have, so the <title> tag can be shorter than the headline. Sets one on the 77 posts whose title exceeds 70 characters, and adds a test to keep it that way.