### PR TITLE
Revert analytics consent gating

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,6 @@ import { OrganizationSchema, WebsiteSchema } from '@/components/schema-markup';
 import { CookieBanner } from '@/components/cookie-banner';
 import { PWAInstaller } from '@/components/pwa-installer';
 import { SkipToContent } from '@/components/skip-to-content';
-import Script from 'next/script';
 import { SiteAnalytics } from '@/components/site-analytics';
 import { DeferredSiteExtras } from '@/components/deferred-site-extras';
 
@@ -120,22 +119,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Google Consent Mode v2. Must run before gtag.js, so it lives here
-            rather than in SiteAnalytics: `beforeInteractive` is only supported
-            in the root layout.
-
-            Analytics storage starts denied, so GA loads for every visitor but
-            sets no cookies until someone allows it. That gives cookieless
-            pings for everyone and full data after consent.
-
-            Before this, GA did not load at all without consent, so the site
-            counted only the few people who clicked the banner. Real traffic
-            was ~7k uniques a day while GA reported a couple of hundred. */}
-        <Script id="consent-mode-default" strategy="beforeInteractive">
-          {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}window.gtag=gtag;
-var c=null;try{c=localStorage.getItem('cookie-consent');if(c===null&&localStorage.getItem('cookieAccepted')==='true'){c='accepted';}}catch(e){}
-gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:c==='accepted'?'granted':'denied',functionality_storage:'granted',personalization_storage:'denied',security_storage:'granted',wait_for_update:500});`}
-        </Script>
         <link
           rel="alternate"
           type="application/rss+xml"

--- a/components/cookie-banner.tsx
+++ b/components/cookie-banner.tsx
@@ -66,9 +66,9 @@ export function CookieBanner() {
 
         {/* Content */}
         <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-          Allow analytics cookies to help us understand and improve site usage.
+          We use cookies to analyse site usage and improve DevOps Daily.
           <br className="hidden sm:block" />
-          You can continue without enabling analytics.
+          See our <a href="/privacy" className="underline hover:text-foreground">Privacy Policy</a> for details.
         </p>
 
         {/* Action buttons */}
@@ -86,7 +86,7 @@ export function CookieBanner() {
             "
           >
             <Check className="h-3.5 w-3.5" />
-            Allow analytics
+            Got it
           </button>
           <button
             onClick={dismissBanner}
@@ -97,7 +97,7 @@ export function CookieBanner() {
               focus:outline-none focus:ring-2 focus:ring-muted focus:ring-offset-2
             "
           >
-            Continue without
+            Dismiss
           </button>
         </div>
       </div>

--- a/components/site-analytics.tsx
+++ b/components/site-analytics.tsx
@@ -1,63 +1,35 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useSyncExternalStore } from 'react';
 import Script from 'next/script';
 import { GoogleAnalytics } from '@next/third-parties/google';
-import { COOKIE_CONSENT_EVENT, getCookieConsent, type CookieConsent } from '@/lib/cookie-consent';
 
 /**
- * gtag pushes its `arguments` object, not an array, and the two are not
- * interchangeable. Writing it out here rather than calling `window.gtag`
- * means a consent update still queues correctly if it happens before
- * gtag.js has finished loading. GA drains the queue on load.
+ * Analytics for the site.
+ *
+ * This deliberately carries no consent gating. Two earlier attempts at it both
+ * measured far less than the site actually gets: gating gtag.js entirely (31
+ * July) collapsed GA to a couple of hundred visitors a day, and Consent Mode
+ * with analytics storage denied by default (PR #1548) did not recover it,
+ * because GA only models denied traffic once a property clears Google's
+ * thresholds, one of which is 1,000 daily consented users on 7 of the previous
+ * 28 days. This site does not clear that, so denied pageviews stayed invisible.
+ *
+ * Cloudflare remains the source of truth for traffic volume. It is server side,
+ * so it counts adblocked visitors that no script here ever will.
  */
-function gtag(..._args: unknown[]) {
-  window.dataLayer = window.dataLayer || [];
-  // eslint-disable-next-line prefer-rest-params
-  window.dataLayer.push(arguments);
-}
-
 export function SiteAnalytics() {
-  const consent = useSyncExternalStore<CookieConsent | null>(
-    (onStoreChange) => {
-      window.addEventListener(COOKIE_CONSENT_EVENT, onStoreChange);
-      window.addEventListener('storage', onStoreChange);
-      return () => {
-        window.removeEventListener(COOKIE_CONSENT_EVENT, onStoreChange);
-        window.removeEventListener('storage', onStoreChange);
-      };
-    },
-    getCookieConsent,
-    () => null
-  );
-
-  // Consent Mode: the default is set before gtag.js in the root layout, and
-  // this raises it once someone allows analytics. Rejecting is already the
-  // default, so there is nothing to send for that case.
-  useEffect(() => {
-    if (consent === 'accepted') {
-      gtag('consent', 'update', { analytics_storage: 'granted' });
-    }
-  }, [consent]);
-
   return (
     <>
-      {/* Loads for every visitor. Consent Mode keeps it cookieless until the
-          visitor allows analytics, so we still get aggregate numbers instead
-          of counting only the few people who click the banner. */}
       <GoogleAnalytics gaId="G-DRHMSC6G9R" />
 
-      {/* Ahrefs stays behind explicit consent. It is a separate vendor and
-          Consent Mode does not govern it. */}
-      {consent === 'accepted' && (
-        <Script
-          id="ahrefs-analytics"
-          src="https://analytics.ahrefs.com/analytics.js"
-          data-key="DDU3onGEafDWd/obeLf2Pw"
-          strategy="lazyOnload"
-        />
-      )}
+      {/* lazyOnload so it does not compete with first paint or early
+          interactions (INP). */}
+      <Script
+        id="ahrefs-analytics"
+        src="https://analytics.ahrefs.com/analytics.js"
+        data-key="DDU3onGEafDWd/obeLf2Pw"
+        strategy="lazyOnload"
+      />
     </>
   );
 }

--- a/tests/cookie-consent.test.ts
+++ b/tests/cookie-consent.test.ts
@@ -36,52 +36,48 @@ describe('cookie consent', () => {
 });
 
 /**
- * The 31 July consent change stopped GA loading at all without a click, so
- * the site counted only the few visitors who accepted the banner. Cloudflare
- * showed ~7k uniques a day while GA reported a couple of hundred.
+ * Analytics has been through two failed consent designs. Gating gtag.js behind
+ * a click (31 July) collapsed GA to a couple of hundred visitors a day against
+ * ~7k real ones. Consent Mode with analytics storage denied (PR #1548) did not
+ * recover it either, because GA only models denied traffic once a property
+ * clears Google's thresholds, one of which is 1,000 daily consented users on 7
+ * of the previous 28 days. This site does not clear that bar.
  *
- * The fix is Google Consent Mode: gtag.js loads for everyone, with analytics
- * storage denied until consent. These lock in the parts that broke.
+ * Analytics now loads unconditionally. These tests lock that in, and check the
+ * banner does not claim to offer a choice the code no longer honours.
  */
-describe('analytics consent wiring', () => {
+describe('analytics wiring', () => {
   const layout = readFileSync(join(process.cwd(), 'app', 'layout.tsx'), 'utf-8');
   const analytics = readFileSync(
     join(process.cwd(), 'components', 'site-analytics.tsx'),
     'utf-8',
   );
+  const banner = readFileSync(
+    join(process.cwd(), 'components', 'cookie-banner.tsx'),
+    'utf-8',
+  );
 
-  it('loads Google Analytics for every visitor, not only after consent', () => {
-    // The regression was `if (consent !== 'accepted') return null;` above the
-    // GoogleAnalytics element, which made the whole component render nothing.
+  it('loads Google Analytics for every visitor', () => {
     const gaIndex = analytics.indexOf('<GoogleAnalytics');
     expect(gaIndex).toBeGreaterThan(-1);
-    const beforeGa = analytics.slice(0, gaIndex);
-    expect(beforeGa).not.toMatch(/return null/);
+    // Both regressions worked by returning early above this element.
+    expect(analytics.slice(0, gaIndex)).not.toMatch(/return null/);
   });
 
-  it('sets a Consent Mode default before gtag.js runs', () => {
-    expect(layout).toContain('consent-mode-default');
-    // beforeInteractive is what puts it ahead of gtag.js. Without it the
-    // default can land after the first ping and the ping sets a cookie.
-    expect(layout).toMatch(/id="consent-mode-default"[\s\S]{0,120}beforeInteractive/);
-    expect(layout).toContain("gtag('consent','default'");
+  it('does not gate analytics on a stored consent choice', () => {
+    expect(analytics).not.toContain('cookie-consent');
+    expect(analytics).not.toMatch(/consent === 'accepted'/);
   });
 
-  it('denies analytics storage by default and grants it on consent', () => {
-    expect(layout).toContain("analytics_storage:c==='accepted'?'granted':'denied'");
-    expect(analytics).toContain("gtag('consent', 'update', { analytics_storage: 'granted' })");
+  it('no longer sets a Consent Mode default', () => {
+    expect(layout).not.toContain('consent-mode-default');
+    expect(layout).not.toContain("gtag('consent','default'");
   });
 
-  it('reads the stored choice in the default, so a returning visitor is not downgraded', () => {
-    // Someone who already accepted must start granted, or their first
-    // pageview of every session is recorded cookielessly.
-    expect(layout).toContain("localStorage.getItem('cookie-consent')");
-    expect(layout).toContain("localStorage.getItem('cookieAccepted')");
-  });
-
-  it('keeps advertising signals denied, since the site does not run ads', () => {
-    for (const key of ['ad_storage', 'ad_user_data', 'ad_personalization']) {
-      expect(layout).toContain(`${key}:'denied'`);
-    }
+  it('does not offer a reject button that would do nothing', () => {
+    // A control that claims to switch analytics off while gtag.js loads
+    // regardless is worse than no control at all.
+    expect(banner).not.toContain('Allow analytics');
+    expect(banner).not.toContain('Continue without');
   });
 });


### PR DESCRIPTION
Neither of the two consent designs produced usable numbers. GA reported a couple of hundred visitors a day against ~7k at the Cloudflare edge, and Consent Mode could not close the gap because behavioural modelling needs 1,000 daily consented users on 7 of the previous 28 days.

Analytics loads for everyone again. Banner is now a notice rather than a choice, so it doesn't show a reject button that wouldn't do anything.