### PR TITLE
Add predict mode to the binary simulator

### DIFF
--- a/components/games/binary-byte-simulator.tsx
+++ b/components/games/binary-byte-simulator.tsx
@@ -2,6 +2,17 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import {
+  type BitDiff,
+  type PredictMode,
+  breakdown,
+  diagnose,
+  expectedAnswer,
+  explainDiff,
+  parseGuess,
+  randomRound,
+} from '@/lib/binary-predict';
+
 /**
  * Binary Byte Simulator.
  *
@@ -159,11 +170,51 @@ export default function BinaryByteSimulator() {
   const [challengeIdx, setChallengeIdx] = useState(0);
   const [showChallenge, setShowChallenge] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
+  // Predict mode: the board is shown, the computed value is not, and the
+  // learner reads it off the bits. `verdict` is null until they submit.
+  const [predicting, setPredicting] = useState(false);
+  const [guess, setGuess] = useState('');
+  const [verdict, setVerdict] = useState<{ correct: boolean; diffs: BitDiff[] } | null>(null);
   const tileRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const guessRef = useRef<HTMLInputElement | null>(null);
 
   const width = WIDTH[mode];
   const challenge = CHALLENGES[mode][challengeIdx];
   const solved = showChallenge && bits === challenge.target;
+
+  // Subnet masks are read as a dotted quad and constrained to contiguous ones,
+  // which is a different exercise, so predicting is offered on the other two.
+  const canPredict = mode === 'byte' || mode === 'perms';
+  const predictMode = mode as PredictMode;
+
+  const startRound = useCallback(() => {
+    const next = randomRound(mode as PredictMode);
+    setPredicting(true);
+    setGuess('');
+    setVerdict(null);
+    setCounting(false);
+    setShowChallenge(false);
+    setChanged(new Set());
+    setBits(next);
+    // Focus lands on the input so the round can be answered from the keyboard.
+    requestAnimationFrame(() => guessRef.current?.focus());
+  }, [mode]);
+
+  const exitPredict = useCallback(() => {
+    setPredicting(false);
+    setGuess('');
+    setVerdict(null);
+  }, []);
+
+  const checkGuess = useCallback(() => {
+    const parsed = parseGuess(predictMode, guess);
+    if (parsed === null) {
+      setVerdict(null);
+      return;
+    }
+    const diffs = diagnose(predictMode, bits, parsed);
+    setVerdict({ correct: diffs.length === 0, diffs });
+  }, [bits, guess, predictMode]);
 
   // Switching mode resets the board to that mode's width.
   const switchMode = useCallback((next: Mode) => {
@@ -173,6 +224,9 @@ export default function BinaryByteSimulator() {
     setCounting(false);
     setChallengeIdx(0);
     setShowChallenge(false);
+    setPredicting(false);
+    setGuess('');
+    setVerdict(null);
   }, []);
 
   // Apply a new bit string and flash whichever tiles actually moved, which is
@@ -189,6 +243,9 @@ export default function BinaryByteSimulator() {
       }
       setChanged(moved);
       setBits(next);
+      // Flipping a tile changes the answer, so a previous verdict no longer
+      // describes what is on the board.
+      setVerdict(null);
     },
     [bits]
   );
@@ -326,20 +383,25 @@ export default function BinaryByteSimulator() {
         {mode === 'byte' && (
           <>
             <div className="bs-big">
-              <span className="bs-bigval">{value}</span>
+              <span className={`bs-bigval${predicting ? ' bs-hidden' : ''}`}>
+                {predicting ? '?' : value}
+              </span>
               <span className="bs-biglabel">decimal</span>
             </div>
             <div className="bs-side">
-              <button className="bs-chip" onClick={() => copy(`0x${value.toString(16).toUpperCase().padStart(2, '0')}`, 'hex')}>
-                <span className="bs-chipk">hex</span>
-                <span className="bs-chipv">0x{value.toString(16).toUpperCase().padStart(2, '0')}</span>
-                <span className="bs-copy">{copied === 'hex' ? 'copied' : 'copy'}</span>
-              </button>
+              {!predicting && (
+                <button className="bs-chip" onClick={() => copy(`0x${value.toString(16).toUpperCase().padStart(2, '0')}`, 'hex')}>
+                  <span className="bs-chipk">hex</span>
+                  <span className="bs-chipv">0x{value.toString(16).toUpperCase().padStart(2, '0')}</span>
+                  <span className="bs-copy">{copied === 'hex' ? 'copied' : 'copy'}</span>
+                </button>
+              )}
               <button className="bs-chip" onClick={() => copy(bits, 'bin')}>
                 <span className="bs-chipk">binary</span>
                 <span className="bs-chipv">{bits}</span>
                 <span className="bs-copy">{copied === 'bin' ? 'copied' : 'copy'}</span>
               </button>
+              {!predicting && (
               <div className="bs-chip bs-static">
                 <span className="bs-chipk">as maths</span>
                 <span className="bs-chipv bs-sum">
@@ -352,6 +414,7 @@ export default function BinaryByteSimulator() {
                         .join(' + ')}
                 </span>
               </div>
+              )}
             </div>
           </>
         )}
@@ -359,15 +422,19 @@ export default function BinaryByteSimulator() {
         {mode === 'perms' && (
           <>
             <div className="bs-big">
-              <span className="bs-bigval">{permOctal(bits)}</span>
+              <span className={`bs-bigval${predicting ? ' bs-hidden' : ''}`}>
+                {predicting ? '???' : permOctal(bits)}
+              </span>
               <span className="bs-biglabel">octal</span>
             </div>
             <div className="bs-side">
-              <button className="bs-chip" onClick={() => copy(`chmod ${permOctal(bits)} file.sh`, 'chmod')}>
-                <span className="bs-chipk">command</span>
-                <span className="bs-chipv">chmod {permOctal(bits)} file.sh</span>
-                <span className="bs-copy">{copied === 'chmod' ? 'copied' : 'copy'}</span>
-              </button>
+              {!predicting && (
+                <button className="bs-chip" onClick={() => copy(`chmod ${permOctal(bits)} file.sh`, 'chmod')}>
+                  <span className="bs-chipk">command</span>
+                  <span className="bs-chipv">chmod {permOctal(bits)} file.sh</span>
+                  <span className="bs-copy">{copied === 'chmod' ? 'copied' : 'copy'}</span>
+                </button>
+              )}
               <div className="bs-chip bs-static">
                 <span className="bs-chipk">ls -l</span>
                 <span className="bs-chipv">-{permSymbolic(bits)}</span>
@@ -489,7 +556,10 @@ export default function BinaryByteSimulator() {
         </button>
         <button
           className={`bs-btn${counting ? ' bs-on' : ''}`}
-          onClick={() => setCounting((c) => !c)}
+          onClick={() => {
+            if (!counting && predicting) exitPredict();
+            setCounting((c) => !c);
+          }}
         >
           {counting ? 'Stop' : 'Count up'}
         </button>
@@ -516,6 +586,131 @@ export default function BinaryByteSimulator() {
         the whole of binary arithmetic.
       </p>
 
+      {/* ---------- predict ---------- */}
+      {canPredict && (
+        <div
+          className={`bs-predict${
+            verdict ? (verdict.correct ? ' bs-solved' : ' bs-wrong') : ''
+          }`}
+        >
+          <div className="bs-chtop">
+            <div>
+              <span className="bs-chlabel">Predict</span>
+              <span className="bs-chprompt">
+                {predicting
+                  ? mode === 'perms'
+                    ? 'Read the chmod value off the tiles'
+                    : 'Read the decimal value off the tiles'
+                  : 'Hide the value and work it out from the bits'}
+              </span>
+            </div>
+            <div className="bs-chactions">
+              {!predicting ? (
+                <button className="bs-btn bs-primary" onClick={startRound}>
+                  Start
+                </button>
+              ) : (
+                <>
+                  <button className="bs-btn" onClick={startRound}>
+                    New round &rsaquo;
+                  </button>
+                  <button className="bs-btn" onClick={exitPredict}>
+                    Exit
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {predicting && (
+            <div className="bs-chbody">
+              <form
+                className="bs-guessrow"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  checkGuess();
+                }}
+              >
+                <label className="bs-guesslabel" htmlFor="bs-guess">
+                  {mode === 'perms' ? 'chmod' : 'decimal'}
+                </label>
+                <input
+                  id="bs-guess"
+                  ref={guessRef}
+                  className="bs-guess"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  maxLength={3}
+                  placeholder={mode === 'perms' ? '755' : '0-255'}
+                  value={guess}
+                  onChange={(e) => {
+                    setGuess(e.target.value);
+                    setVerdict(null);
+                  }}
+                  aria-describedby="bs-verdict"
+                />
+                <button className="bs-btn bs-primary" type="submit" disabled={!guess.trim()}>
+                  Check
+                </button>
+                <button
+                  className="bs-btn"
+                  type="button"
+                  onClick={() => {
+                    setGuess(expectedAnswer(predictMode, bits));
+                    setVerdict({ correct: true, diffs: [] });
+                  }}
+                >
+                  Reveal
+                </button>
+              </form>
+
+              <div id="bs-verdict" role="status" aria-live="polite">
+                {verdict === null ? (
+                  <p className="bs-chnote bs-chwait">
+                    {guess.trim() && parseGuess(predictMode, guess) === null
+                      ? mode === 'perms'
+                        ? 'Three digits, each 0 to 7. For example 755.'
+                        : 'A whole number from 0 to 255.'
+                      : 'The tiles are the only clue. Add up what is switched on.'}
+                  </p>
+                ) : verdict.correct ? (
+                  <div className="bs-chnote">
+                    <p>
+                      <b>Correct.</b> {expectedAnswer(predictMode, bits)} is what those tiles say.
+                    </p>
+                    <ul className="bs-sums">
+                      {breakdown(predictMode, bits).map((line) => (
+                        <li key={line}>{line}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : (
+                  <div className="bs-chnote">
+                    <p>
+                      <b>
+                        Not {guess.trim()}, and the gap is {verdict.diffs.length} bit
+                        {verdict.diffs.length > 1 ? 's' : ''}.
+                      </b>
+                    </p>
+                    <ul className="bs-diffs">
+                      {verdict.diffs.map((d) => (
+                        <li key={d.index} className={d.missed ? 'bs-miss' : 'bs-extra'}>
+                          {explainDiff(d)}
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="bs-chwait">
+                      Look at those tiles again, then try once more.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* ---------- challenge ---------- */}
       <div className={`bs-challenge${solved ? ' bs-solved' : ''}`}>
         <div className="bs-chtop">
@@ -528,8 +723,10 @@ export default function BinaryByteSimulator() {
               <button
                 className="bs-btn bs-primary"
                 onClick={() => {
-                  // Counting would keep changing the board under the learner.
+                  // Counting would keep changing the board under the learner,
+                  // and predict mode hides the value this challenge reveals.
                   setCounting(false);
+                  exitPredict();
                   setShowChallenge(true);
                 }}
               >
@@ -647,6 +844,20 @@ const CSS = `
 .bytesim .bs-hint { margin: 0 0 20px; font-size: 12.5px; line-height: 1.6; color: var(--bs-muted); max-width: 74ch; }
 .bytesim .bs-hint b { color: var(--bs-ink); }
 
+.bytesim .bs-predict { background: var(--bs-panel); border: 1px solid var(--bs-line); border-radius: 12px; padding: 14px 16px; margin-bottom: 12px; transition: border-color .25s, background .25s; }
+.bytesim .bs-predict.bs-solved { border-color: var(--bs-good); background: #46d8880f; }
+.bytesim .bs-predict.bs-wrong { border-color: #e0894a; background: #e0894a0f; }
+.bytesim .bs-bigval.bs-hidden { opacity: .35; letter-spacing: .05em; }
+.bytesim .bs-guessrow { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; }
+.bytesim .bs-guesslabel { font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: var(--bs-dim); }
+.bytesim .bs-guess { width: 6.5em; padding: 7px 10px; font: 600 16px/1.2 var(--bs-mono, ui-monospace, SFMono-Regular, Menlo, monospace); color: var(--bs-fg); background: var(--bs-bg); border: 1px solid var(--bs-line); border-radius: 8px; }
+.bytesim .bs-guess:focus-visible { outline: 2px solid var(--bs-accent); outline-offset: 1px; }
+.bytesim .bs-btn[disabled] { opacity: .45; cursor: not-allowed; }
+.bytesim .bs-sums, .bytesim .bs-diffs { margin: 6px 0 0; padding-left: 18px; display: grid; gap: 3px; }
+.bytesim .bs-sums li { font-family: var(--bs-mono, ui-monospace, SFMono-Regular, Menlo, monospace); font-size: 13px; color: var(--bs-dim); }
+.bytesim .bs-diffs li { font-size: 13px; }
+.bytesim .bs-diffs li.bs-miss { color: var(--bs-good); }
+.bytesim .bs-diffs li.bs-extra { color: #e0894a; }
 .bytesim .bs-challenge { background: var(--bs-panel); border: 1px solid var(--bs-line); border-radius: 12px; padding: 14px 16px; transition: border-color .25s, background .25s; }
 .bytesim .bs-challenge.bs-solved { border-color: var(--bs-good); background: #46d8880f; }
 .bytesim .bs-chtop { display: flex; align-items: center; justify-content: space-between; gap: 14px; flex-wrap: wrap; }

--- a/lib/binary-predict.ts
+++ b/lib/binary-predict.ts
@@ -1,0 +1,139 @@
+/**
+ * Predict-mode logic for the binary byte simulator.
+ *
+ * The idea came from a reader: hide the computed value for a round and ask the
+ * learner to read it off the bits instead. The teaching value is not in marking
+ * the answer right or wrong, it is in the diff. A guess of 7 against an actual
+ * 5 is not "wrong by 2", it is "you counted the write bit and it is off", and
+ * that names the single bit the learner has not understood.
+ *
+ * Kept free of React so it can be tested directly.
+ */
+
+export type PredictMode = 'byte' | 'perms';
+
+export const PREDICT_WIDTH: Record<PredictMode, number> = { byte: 8, perms: 9 };
+
+const PERM_LETTERS = ['r', 'w', 'x'] as const;
+const PERM_GROUPS = ['owner', 'group', 'other'] as const;
+const PERM_WORDS = ['read', 'write', 'execute'] as const;
+
+export interface BitDiff {
+  /** Index into the bit string, left to right. */
+  index: number;
+  /** Human name for the bit: "owner write", or "place value 32". */
+  label: string;
+  /** What the bit is worth: 4/2/1 within a permission triad, or its place value. */
+  value: number;
+  /** True when the bit is set but the guess does not account for it. */
+  missed: boolean;
+}
+
+function toBits(n: number, width: number): string {
+  return n.toString(2).padStart(width, '0');
+}
+
+/**
+ * Turn what the learner typed into a bit string, or null if it is not a
+ * well-formed answer for this mode. Returning null rather than throwing keeps
+ * the caller's "did you mean to submit that?" path simple.
+ */
+export function parseGuess(mode: PredictMode, raw: string): string | null {
+  const s = raw.trim();
+  if (mode === 'perms') {
+    // Three octal digits, one per group. "755", not "0755" and not "rwxr-xr-x".
+    if (!/^[0-7]{3}$/.test(s)) return null;
+    return s
+      .split('')
+      .map((d) => toBits(Number(d), 3))
+      .join('');
+  }
+  if (!/^\d{1,3}$/.test(s)) return null;
+  const n = Number(s);
+  if (n > 255) return null;
+  return toBits(n, 8);
+}
+
+/** What a single bit position is called and what it is worth. */
+export function bitInfo(mode: PredictMode, index: number): { label: string; value: number } {
+  if (mode === 'perms') {
+    const group = PERM_GROUPS[Math.floor(index / 3)];
+    const slot = index % 3;
+    return { label: `${group} ${PERM_WORDS[slot]}`, value: 2 ** (2 - slot) };
+  }
+  const value = 2 ** (PREDICT_WIDTH.byte - 1 - index);
+  return { label: `place value ${value}`, value };
+}
+
+/**
+ * Every bit where the guess disagrees with the board.
+ *
+ * Both sides are compared as bit strings rather than as numbers, so a wrong
+ * answer decomposes into named bits instead of an arithmetic difference.
+ */
+export function diagnose(mode: PredictMode, actual: string, guess: string): BitDiff[] {
+  const out: BitDiff[] = [];
+  for (let i = 0; i < actual.length && i < guess.length; i++) {
+    if (actual[i] === guess[i]) continue;
+    const { label, value } = bitInfo(mode, i);
+    out.push({ index: i, label, value, missed: actual[i] === '1' });
+  }
+  return out;
+}
+
+/** One sentence per wrong bit, naming it and saying which way the error went. */
+export function explainDiff(d: BitDiff): string {
+  return d.missed
+    ? `${d.label} is on and worth ${d.value}, but your answer leaves it out.`
+    : `${d.label} is off, but your answer counts its ${d.value}.`;
+}
+
+/** The arithmetic, shown after the answer so the sum is visible, not implied. */
+export function breakdown(mode: PredictMode, bits: string): string[] {
+  if (mode === 'perms') {
+    return [0, 1, 2].map((g) => {
+      const triad = bits.slice(g * 3, g * 3 + 3);
+      const symbolic = triad
+        .split('')
+        .map((b, i) => (b === '1' ? PERM_LETTERS[i] : '-'))
+        .join('');
+      const parts = triad
+        .split('')
+        .map((b, i) => (b === '1' ? 2 ** (2 - i) : 0))
+        .filter((v) => v > 0);
+      const total = parts.reduce((a, b) => a + b, 0);
+      const sum = parts.length ? parts.join(' + ') : '0';
+      return `${PERM_GROUPS[g]} ${symbolic} = ${sum} = ${total}`;
+    });
+  }
+  const parts = bits
+    .split('')
+    .map((b, i) => (b === '1' ? 2 ** (bits.length - 1 - i) : 0))
+    .filter((v) => v > 0);
+  const total = parts.reduce((a, b) => a + b, 0);
+  return [parts.length ? `${parts.join(' + ')} = ${total}` : '0'];
+}
+
+/** The answer the learner is being asked for, as they would type it. */
+export function expectedAnswer(mode: PredictMode, bits: string): string {
+  if (mode === 'perms') {
+    return [0, 1, 2].map((g) => parseInt(bits.slice(g * 3, g * 3 + 3), 2)).join('');
+  }
+  return String(parseInt(bits, 2));
+}
+
+/**
+ * A board worth reading. All-zero is excluded because "000" teaches nothing,
+ * and for permissions an all-ones board is the one value everyone already
+ * knows, so it is skipped too.
+ */
+export function randomRound(mode: PredictMode, rng: () => number = Math.random): string {
+  const width = PREDICT_WIDTH[mode];
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const bits = Array.from({ length: width }, () => (rng() < 0.5 ? '0' : '1')).join('');
+    if (!bits.includes('1')) continue;
+    if (mode === 'perms' && !bits.includes('0')) continue;
+    return bits;
+  }
+  return mode === 'perms' ? '111101101' : '00101010';
+}

--- a/tests/binary-predict.test.ts
+++ b/tests/binary-predict.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  breakdown,
+  bitInfo,
+  diagnose,
+  expectedAnswer,
+  explainDiff,
+  parseGuess,
+  randomRound,
+} from '@/lib/binary-predict';
+
+describe('parseGuess', () => {
+  it('turns three octal digits into nine bits', () => {
+    expect(parseGuess('perms', '755')).toBe('111101101');
+    expect(parseGuess('perms', '644')).toBe('110100100');
+    expect(parseGuess('perms', '000')).toBe('000000000');
+    expect(parseGuess('perms', '777')).toBe('111111111');
+  });
+
+  it('rejects permission answers that are not three octal digits', () => {
+    for (const bad of ['0755', '75', '7555', '8', '778', 'rwx', '', '  ', '-1']) {
+      expect(parseGuess('perms', bad)).toBeNull();
+    }
+  });
+
+  it('accepts a byte in range and rejects one outside it', () => {
+    expect(parseGuess('byte', '0')).toBe('00000000');
+    expect(parseGuess('byte', '42')).toBe('00101010');
+    expect(parseGuess('byte', '255')).toBe('11111111');
+    expect(parseGuess('byte', '256')).toBeNull();
+    expect(parseGuess('byte', '999')).toBeNull();
+    expect(parseGuess('byte', '1e2')).toBeNull();
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseGuess('perms', ' 755 ')).toBe('111101101');
+    expect(parseGuess('byte', ' 42 ')).toBe('00101010');
+  });
+});
+
+describe('bitInfo', () => {
+  it('names each permission bit by group and action', () => {
+    expect(bitInfo('perms', 0)).toEqual({ label: 'owner read', value: 4 });
+    expect(bitInfo('perms', 1)).toEqual({ label: 'owner write', value: 2 });
+    expect(bitInfo('perms', 2)).toEqual({ label: 'owner execute', value: 1 });
+    expect(bitInfo('perms', 3)).toEqual({ label: 'group read', value: 4 });
+    expect(bitInfo('perms', 8)).toEqual({ label: 'other execute', value: 1 });
+  });
+
+  it('names byte bits by place value, high bit first', () => {
+    expect(bitInfo('byte', 0)).toEqual({ label: 'place value 128', value: 128 });
+    expect(bitInfo('byte', 7)).toEqual({ label: 'place value 1', value: 1 });
+  });
+});
+
+describe('diagnose', () => {
+  it('returns nothing when the guess is right', () => {
+    expect(diagnose('perms', '111101101', '111101101')).toEqual([]);
+  });
+
+  /** The case from the suggestion: 7 where the answer is 5. */
+  it('names the single bit behind a 755 vs 775 mix-up', () => {
+    const actual = parseGuess('perms', '755')!;
+    const guess = parseGuess('perms', '775')!;
+    const diffs = diagnose('perms', actual, guess);
+
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].label).toBe('group write');
+    expect(diffs[0].value).toBe(2);
+    expect(diffs[0].missed).toBe(false); // the bit is off, the learner counted it
+    expect(explainDiff(diffs[0])).toBe(
+      'group write is off, but your answer counts its 2.'
+    );
+  });
+
+  it('reports a bit that is on but left out', () => {
+    const actual = parseGuess('perms', '755')!;
+    const guess = parseGuess('perms', '655')!; // owner execute dropped
+    const diffs = diagnose('perms', actual, guess);
+
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].label).toBe('owner execute');
+    expect(diffs[0].missed).toBe(true);
+    expect(explainDiff(diffs[0])).toBe(
+      'owner execute is on and worth 1, but your answer leaves it out.'
+    );
+  });
+
+  it('separates several wrong bits rather than reporting one total', () => {
+    const diffs = diagnose('perms', parseGuess('perms', '750')!, parseGuess('perms', '705')!);
+    // group loses r+x (4+1), other gains r+x
+    expect(diffs.map((d) => d.label)).toEqual([
+      'group read',
+      'group execute',
+      'other read',
+      'other execute',
+    ]);
+    expect(diffs.filter((d) => d.missed).map((d) => d.label)).toEqual([
+      'group read',
+      'group execute',
+    ]);
+  });
+
+  it('works the same way for a byte', () => {
+    const diffs = diagnose('byte', parseGuess('byte', '42')!, parseGuess('byte', '46')!);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].label).toBe('place value 4');
+    expect(diffs[0].missed).toBe(false);
+  });
+
+  /**
+   * Two answers can differ by the same amount for different reasons. Comparing
+   * numbers would call both "out by 4"; comparing bits names the actual bit.
+   */
+  it('distinguishes errors that share an arithmetic difference', () => {
+    const a = diagnose('byte', parseGuess('byte', '5')!, parseGuess('byte', '1')!);
+    const b = diagnose('byte', parseGuess('byte', '8')!, parseGuess('byte', '12')!);
+    expect(a[0].label).toBe('place value 4');
+    expect(a[0].missed).toBe(true);
+    expect(b[0].label).toBe('place value 4');
+    expect(b[0].missed).toBe(false);
+  });
+});
+
+describe('breakdown', () => {
+  it('shows the sum for each permission group', () => {
+    expect(breakdown('perms', parseGuess('perms', '755')!)).toEqual([
+      'owner rwx = 4 + 2 + 1 = 7',
+      'group r-x = 4 + 1 = 5',
+      'other r-x = 4 + 1 = 5',
+    ]);
+  });
+
+  it('handles a group with no permissions', () => {
+    expect(breakdown('perms', parseGuess('perms', '640')!)[2]).toBe('other --- = 0 = 0');
+  });
+
+  it('shows the addition for a byte', () => {
+    expect(breakdown('byte', parseGuess('byte', '42')!)).toEqual(['32 + 8 + 2 = 42']);
+    expect(breakdown('byte', parseGuess('byte', '0')!)).toEqual(['0']);
+  });
+});
+
+describe('expectedAnswer', () => {
+  it('round-trips through parseGuess', () => {
+    for (const answer of ['755', '644', '600', '777', '000', '421']) {
+      expect(expectedAnswer('perms', parseGuess('perms', answer)!)).toBe(answer);
+    }
+    for (const answer of ['0', '42', '128', '255']) {
+      expect(expectedAnswer('byte', parseGuess('byte', answer)!)).toBe(answer);
+    }
+  });
+});
+
+describe('randomRound', () => {
+  it('never produces an all-zero board', () => {
+    // rng always 1 would give all zeros without the guard
+    expect(randomRound('perms', () => 1)).toContain('1');
+    expect(randomRound('byte', () => 1)).toContain('1');
+  });
+
+  it('never produces 777, the one value nobody needs to work out', () => {
+    expect(randomRound('perms', () => 0)).not.toBe('111111111');
+  });
+
+  it('produces a board of the right width', () => {
+    let i = 0;
+    const rng = () => [0.1, 0.9, 0.2, 0.8, 0.3, 0.7, 0.4, 0.6, 0.45][i++ % 9];
+    expect(randomRound('perms', rng)).toHaveLength(9);
+    expect(randomRound('byte', rng)).toHaveLength(8);
+  });
+
+  it('produces boards that survive a full predict round trip', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      let i = seed;
+      const bits = randomRound('perms', () => ((i = (i * 9301 + 49297) % 233280) / 233280));
+      const answer = expectedAnswer('perms', bits);
+      expect(parseGuess('perms', answer)).toBe(bits);
+      expect(diagnose('perms', bits, parseGuess('perms', answer)!)).toEqual([]);
+    }
+  });
+});
+
+/**
+ * The logic above is only useful if the component actually hides the answer.
+ * These read the source and the rendered output, which is the cheap way to
+ * catch someone removing the mask without noticing.
+ */
+describe('predict mode wiring in the simulator', () => {
+  const src = readFileSync(
+    join(process.cwd(), 'components', 'games', 'binary-byte-simulator.tsx'),
+    'utf-8',
+  );
+
+  it('gates the big readout on predicting, in both modes', () => {
+    // byte
+    expect(src).toContain("{predicting ? '?' : value}");
+    // perms
+    expect(src).toContain("{predicting ? '???' : permOctal(bits)}");
+  });
+
+  it('hides every chip that would give the answer away', () => {
+    // chmod NNN, hex and the addition all restate the number being asked for.
+    for (const leak of ['chmod ${permOctal(bits)} file.sh', 'as maths', "'hex'"]) {
+      const at = src.indexOf(leak);
+      expect(at).toBeGreaterThan(-1);
+      // each is inside a `{!predicting && (` block opened above it
+      expect(src.lastIndexOf('{!predicting && (', at)).toBeGreaterThan(-1);
+    }
+  });
+
+  it('clears a stale verdict when the board changes', () => {
+    // Flipping a tile changes the answer, so an old verdict must not survive.
+    const applyBits = src.slice(src.indexOf('const applyBits'), src.indexOf('const toggleBit'));
+    expect(applyBits).toContain('setVerdict(null)');
+  });
+
+  it('does not offer predict mode for subnet masks', () => {
+    expect(src).toContain("const canPredict = mode === 'byte' || mode === 'perms';");
+  });
+});


### PR DESCRIPTION
Hides the value for a round and asks the learner to read it off the tiles, for both the byte and chmod modes.

The point is the wrong answer: guesses are compared bit by bit rather than as numbers, so 775 against 755 names the exact bit ('group write is off, but your answer counts its 2') instead of reporting an arithmetic difference.

Logic lives in lib/binary-predict.ts with 24 tests. Suggested by Agustin Barrientos in the community.