### PR TITLE
Note the 2026-07-28 protocol support in the MCP post and comparison

### DIFF
--- a/content/comparisons/smtpfast-vs-resend.json
+++ b/content/comparisons/smtpfast-vs-resend.json
@@ -181,7 +181,7 @@
       "name": "Hosted MCP server for AI agents",
       "category": "Ecosystem",
       "toolA": {
-        "value": "Yes, /api/mcp, 8 scoped tools, API-key auth",
+        "value": "Yes, /api/mcp, 8 scoped tools, API-key auth, speaks the 2026-07-28 spec",
         "rating": "good"
       },
       "toolB": {

--- a/content/posts/email-apis-with-hosted-mcp-servers.md
+++ b/content/posts/email-apis-with-hosted-mcp-servers.md
@@ -61,6 +61,8 @@ claude mcp add --transport http smtpfast https://smtpfa.st/api/mcp \
 
 The design bet is that a small, complete toolset beats a big one for agents: fewer tools means less for a model to misuse, and `list_suppressions` is there because the first thing a well-behaved agent should do before a send is check who it must not email.
 
+The server also speaks the current protocol revision, 2026-07-28: fully stateless per-request metadata, `server/discover`, and cacheable tool listings, with clients on the older 2025 revisions still supported.
+
 ### Resend
 
 [Resend's MCP server](https://resend.com/docs/mcp-server) is the most fully built out in the hosted club. The remote server lives at `https://mcp.resend.com/mcp` with two auth paths: OAuth for web clients (a browser approval flow, no key handling) and a Bearer API key for headless use. There is also an open source `resend-mcp` package if you prefer local, with stdio and HTTP transports.


### PR DESCRIPTION
One line each in the hosted-MCP post and the SMTPfast vs Resend comparison, matching smtpfast PR #523.