### PR TITLE
Charts: negative bars, reference lines, dashed series, tooltips, stricter parsing

### DIFF
--- a/.claude/commands/write-post.md
+++ b/.claude/commands/write-post.md
@@ -101,6 +101,13 @@ Four `type` values are supported:
 
 Common optional fields: `title`, `caption` (use it to cite sources and state assumptions), `unit` (`'$'`, `'%'`, `'ms'`, `'s'`, or a free-form suffix). Colors auto-assign from a theme-safe palette; set `color` per series only when you need specific brand colors (e.g. amber `#f59e0b` for the site accent).
 
+More options:
+
+- **`refs`** (bar and line): labeled reference lines for thresholds, e.g. `"refs": [{ "value": 200, "label": "SLO" }]`. On line charts they draw horizontally on the value axis; on bar charts, vertically. Optional `color` and `dash` per ref.
+- **`dash`** on a line series (e.g. `"dash": "6 5"`) distinguishes projected/experimental series from solid actuals; the legend shows the pattern.
+- Bar rows accept **negative values** (cost deltas, regressions); bars extend left of an automatic zero baseline.
+- Line/dot points carry hover tooltips with the exact value automatically.
+
 Example, a grouped bar comparison:
 
 ```chart

--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -8,6 +8,8 @@ import {
   type LineSeries,
   type DotSeries,
   type CdfSeries,
+  type ChartRef,
+  paddedDomain,
   parseChartSpec,
   formatValue,
   barValueColumnWidth,
@@ -43,8 +45,19 @@ function BarChart({ spec }: { spec: ChartSpec }) {
   const plotEnd = width - valuesW;
   const pad = 6;
   const height = rows.length * rowH + pad * 2;
-  const max = Math.max(...rows.map((r) => Math.max(r.value, r.tick ?? 0))) * 1.08;
-  const scale = (v: number) => (v / max) * (plotEnd - labelW);
+  // Sign-safe domain with a zero baseline, so negative deltas render as bars
+  // extending left instead of being clamped to a sliver.
+  const rawValues = rows.flatMap((r) => (r.tick != null ? [r.value, r.tick] : [r.value]));
+  const refValues = (spec.refs ?? []).map((r) => r.value);
+  const [domMin, domMax] = paddedDomain(
+    Math.min(0, ...rawValues, ...refValues),
+    Math.max(0, ...rawValues, ...refValues),
+    0.08
+  );
+  const xPos = (v: number) =>
+    labelW + ((v - domMin) / (domMax - domMin)) * (plotEnd - labelW);
+  const zeroX = xPos(0);
+  const hasNegative = rawValues.some((v) => v < 0);
 
   const seriesNames = [...new Set(rows.map((r) => r.series).filter(Boolean))] as string[];
   const colorFor = (row: BarRow) =>
@@ -57,6 +70,22 @@ function BarChart({ spec }: { spec: ChartSpec }) {
       role="img"
       aria-label={spec.title ?? 'Bar chart'}
     >
+      {hasNegative && (
+        <line x1={zeroX} y1={pad} x2={zeroX} y2={height - pad} className="stroke-border" strokeOpacity={0.9} />
+      )}
+      {(spec.refs ?? []).map((ref) => (
+        <g key={`ref-${ref.value}`}>
+          <line
+            x1={xPos(ref.value)} y1={pad} x2={xPos(ref.value)} y2={height - pad}
+            stroke={ref.color ?? '#f59e0b'} strokeDasharray={ref.dash ?? '4 5'} strokeWidth={1.5}
+          />
+          {ref.label && (
+            <text x={xPos(ref.value) + 5} y={pad + 10} fontSize={11} fill={ref.color ?? '#f59e0b'}>
+              {ref.label}
+            </text>
+          )}
+        </g>
+      ))}
       {rows.map((r, i) => {
         const cy = pad + i * rowH + rowH / 2;
         const labelLines = labels[i];
@@ -84,9 +113,9 @@ function BarChart({ spec }: { spec: ChartSpec }) {
               strokeOpacity={0.5}
             />
             <rect
-              x={labelW}
+              x={Math.min(zeroX, xPos(r.value))}
               y={cy - 7}
-              width={Math.max(2, scale(r.value))}
+              width={Math.max(2, Math.abs(xPos(r.value) - zeroX))}
               height={14}
               rx={4}
               fill={colorFor(r)}
@@ -94,9 +123,9 @@ function BarChart({ spec }: { spec: ChartSpec }) {
             />
             {r.tick != null && (
               <line
-                x1={labelW + scale(r.tick)}
+                x1={xPos(r.tick)}
                 y1={cy - 11}
-                x2={labelW + scale(r.tick)}
+                x2={xPos(r.tick)}
                 y2={cy + 11}
                 stroke="#f59e0b"
                 strokeWidth={2}
@@ -138,7 +167,8 @@ function LineChart({ spec }: { spec: ChartSpec }) {
   const padT = 12;
   const padB = 34;
   const points = Math.max(...series.map((s) => s.data.length));
-  const all = series.flatMap((s) => s.data);
+  const refs = spec.refs ?? [];
+  const all = [...series.flatMap((s) => s.data), ...(spec.log ? [] : refs.map((r) => r.value))];
 
   // Log axis (opt-in): spreads a squished low end next to a large spike. Falls
   // back to linear when any value is <= 0, since log10 is undefined there.
@@ -166,7 +196,9 @@ function LineChart({ spec }: { spec: ChartSpec }) {
   const padL = Math.min(108, Math.max(52, longestYLabel * 7 + 14));
   const x = (i: number) => padL + (i / Math.max(1, points - 1)) * (width - padL - padR);
   const y = (v: number) => padT + (1 - scaleY(v)) * (height - padT - padB);
-  const labels = spec.x ?? [...Array(points).keys()].map((i) => i + 1);
+  // Clamp author-provided x labels to the data length so extras never render
+  // beyond the plot.
+  const labels = (spec.x ?? [...Array(points).keys()].map((i) => i + 1)).slice(0, points);
   const labelStep = Math.ceil(labels.length / 8);
 
   return (
@@ -180,19 +212,48 @@ function LineChart({ spec }: { spec: ChartSpec }) {
         </g>
       ))}
       {labels.map((l, i) =>
-        i % labelStep === 0 ? (
-          <text key={`${l}-${i}`} x={x(i)} y={height - 12} fontSize={11.5} textAnchor="middle" className="fill-muted-foreground">
+        i % labelStep === 0 || i === labels.length - 1 ? (
+          <text
+            key={`${l}-${i}`}
+            x={x(i)}
+            y={height - 12}
+            fontSize={11.5}
+            textAnchor={i === 0 ? 'start' : i === labels.length - 1 ? 'end' : 'middle'}
+            className="fill-muted-foreground"
+          >
             {String(l)}
           </text>
         ) : null
       )}
+      {refs.map((ref) => (
+        <g key={`ref-${ref.value}`}>
+          <line
+            x1={padL} y1={y(ref.value)} x2={width - padR} y2={y(ref.value)}
+            stroke={ref.color ?? '#f59e0b'} strokeDasharray={ref.dash ?? '4 5'} strokeWidth={1.5}
+          />
+          {ref.label && (
+            <text x={width - padR} y={y(ref.value) - 6} fontSize={11} textAnchor="end" fill={ref.color ?? '#f59e0b'}>
+              {ref.label}
+            </text>
+          )}
+        </g>
+      ))}
       {series.map((s, si) => {
         const d = s.data.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(' ');
         return (
           <g key={s.name}>
-            <path d={d} fill="none" stroke={s.color ?? seriesColor(si)} strokeWidth={2.5} strokeLinejoin="round" />
+            <path
+              d={d}
+              fill="none"
+              stroke={s.color ?? seriesColor(si)}
+              strokeWidth={2.5}
+              strokeDasharray={s.dash}
+              strokeLinejoin="round"
+            />
             {s.data.map((v, i) => (
-              <circle key={i} cx={x(i)} cy={y(v)} r={3} fill={s.color ?? seriesColor(si)} />
+              <circle key={i} cx={x(i)} cy={y(v)} r={3} fill={s.color ?? seriesColor(si)}>
+                <title>{`${s.name}${labels[i] !== undefined ? ` · ${String(labels[i])}` : ''}: ${formatValue(v, spec.unit)}`}</title>
+              </circle>
             ))}
           </g>
         );
@@ -209,10 +270,12 @@ function DotPlot({ spec }: { spec: ChartSpec }) {
   const padX = 6;
   const height = series.length * rowH + labelH;
   const all = series.flatMap((s) => s.samples);
-  const min = Math.min(...all) * 0.94;
-  const max = Math.max(...all) * 1.04;
+  const [min, max] = paddedDomain(Math.min(...all), Math.max(...all), 0.05);
   const scale = (v: number) => padX + ((v - min) / (max - min)) * (width - padX * 2);
   const ticks = [...Array(6).keys()].map((t) => min + ((max - min) * t) / 5);
+  // Deterministic vertical stagger so overlapping samples read as density
+  // instead of a single dot; index-based, so the render is reproducible.
+  const jitter = (j: number) => ((j * 7) % 5) * 3.5 - 7;
 
   return (
     <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label={spec.title ?? 'Distribution plot'}>
@@ -240,7 +303,9 @@ function DotPlot({ spec }: { spec: ChartSpec }) {
               <text x={padX} y={si * rowH + 15} fontSize={13} className="fill-muted-foreground">{s.name}</text>
             )}
             {s.samples.map((v, j) => (
-              <circle key={j} cx={scale(v)} cy={cy + 8} r={4.5} fill={s.color ?? seriesColor(si)} fillOpacity={0.55} />
+              <circle key={j} cx={scale(v)} cy={cy + 8 + jitter(j)} r={4.5} fill={s.color ?? seriesColor(si)} fillOpacity={0.55}>
+                <title>{`${s.name}: ${formatValue(v, spec.unit)}`}</title>
+              </circle>
             ))}
             <line x1={mx} y1={cy - 7} x2={mx} y2={cy + 23} stroke="#f59e0b" strokeWidth={2.5} />
             <text x={mx + 8} y={cy} fontSize={12} fill="#f59e0b" fontWeight={600}>
@@ -262,8 +327,7 @@ function CdfChart({ spec }: { spec: ChartSpec }) {
   const padT = 12;
   const padB = 32;
   const all = series.flatMap((s) => s.samples);
-  const minV = Math.min(...all) * 0.96;
-  const maxV = Math.max(...all) * 1.02;
+  const [minV, maxV] = paddedDomain(Math.min(...all), Math.max(...all), 0.04);
   const x = (v: number) => padL + ((v - minV) / (maxV - minV)) * (width - padL - padR);
   const y = (pct: number) => padT + (1 - pct / 100) * (height - padT - padB);
   const xTicks = [...Array(5).keys()].map((t) => minV + ((maxV - minV) * (t + 1)) / 5);
@@ -304,7 +368,7 @@ function CdfChart({ spec }: { spec: ChartSpec }) {
         const sorted = [...s.samples].sort((a, b) => a - b);
         const d = sorted
           .map((v, i) => {
-            const pct = (i / (sorted.length - 1)) * 100;
+            const pct = sorted.length === 1 ? 100 : (i / (sorted.length - 1)) * 100;
             return `${i === 0 ? 'M' : 'L'}${x(v).toFixed(1)},${y(pct).toFixed(1)}`;
           })
           .join(' ');
@@ -324,14 +388,22 @@ function CdfChart({ spec }: { spec: ChartSpec }) {
 }
 
 function Legend({ spec }: { spec: ChartSpec }) {
-  let names: string[] = [];
+  // Colors must come from renderer indices (position in the series array),
+  // not from a name-filtered list, or unnamed series shift every color after
+  // them.
+  let items: Array<{ name: string; color: string; dash?: string }> = [];
   if (spec.type === 'bar') {
-    names = [...new Set((spec.rows ?? []).map((r) => r.series).filter(Boolean))] as string[];
+    const names = [...new Set((spec.rows ?? []).map((r) => r.series).filter(Boolean))] as string[];
+    items = names.map((name, i) => ({ name, color: seriesColor(i) }));
   } else if (spec.series) {
-    names = (spec.series as Array<{ name: string }>).map((s) => s.name).filter(Boolean);
+    const series = spec.series as Array<{ name?: string; color?: string; dash?: string }>;
+    items = series
+      .map((s, i) => ({ name: s.name ?? '', color: s.color ?? seriesColor(i), dash: s.dash }))
+      .filter((item) => item.name);
   }
-  const overrides = (spec.series as Array<{ name: string; color?: string }> | undefined) ?? [];
-  const items = names.map((name, i) => ({ name, color: overrides[i]?.color ?? seriesColor(i) }));
+  for (const ref of spec.refs ?? []) {
+    if (ref.label) items.push({ name: ref.label, color: ref.color ?? '#f59e0b', dash: ref.dash ?? '4 5' });
+  }
   if (spec.type !== 'line' && spec.tickLabel) items.push({ name: spec.tickLabel, color: '#f59e0b' });
   if (spec.type === 'dots') items.push({ name: 'median', color: '#f59e0b' });
   if (spec.type === 'cdf') items.push({ name: 'p95', color: '#f59e0b' });
@@ -341,7 +413,13 @@ function Legend({ spec }: { spec: ChartSpec }) {
     <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1.5 text-xs text-muted-foreground">
       {items.map((item) => (
         <span key={item.name} className="inline-flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-sm" style={{ background: item.color }} />
+          {item.dash ? (
+            <svg width={14} height={6} aria-hidden="true">
+              <line x1={0} y1={3} x2={14} y2={3} stroke={item.color} strokeWidth={2} strokeDasharray={item.dash} />
+            </svg>
+          ) : (
+            <span className="h-2 w-2 rounded-sm" style={{ background: item.color }} />
+          )}
           {item.name}
         </span>
       ))}

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -18,8 +18,20 @@ export interface BarRow {
 export interface LineSeries {
   name: string;
   data: number[];
+  /** Dash pattern to distinguish same-colored paths, e.g. "6 5" */
+  dash?: string;
   /** Optional color override; palette order applies when omitted */
   color?: string;
+}
+
+/** A labeled reference line (SLO threshold, capacity limit, incident marker). */
+export interface ChartRef {
+  value: number;
+  label?: string;
+  /** Optional color; defaults to the amber marker color */
+  color?: string;
+  /** Dash pattern; defaults to "4 5" */
+  dash?: string;
 }
 
 export interface DotSeries {
@@ -56,20 +68,58 @@ export interface ChartSpec {
   /** line: use a log10 y-axis (values must be > 0). Spreads out a squished
    *  low end next to a large spike. Opt-in; linear otherwise. */
   log?: boolean;
+  /** line: horizontal reference lines on the value axis (e.g. an SLO).
+   *  bar: vertical reference lines on the value axis (e.g. a budget). */
+  refs?: ChartRef[];
+}
+
+function finiteNumbers(arr: unknown): arr is number[] {
+  return Array.isArray(arr) && arr.length > 0 && arr.every((v) => Number.isFinite(v));
+}
+
+function validRefs(refs: unknown): boolean {
+  if (refs === undefined) return true;
+  return Array.isArray(refs) && refs.every((r) => r && Number.isFinite((r as ChartRef).value));
 }
 
 export function parseChartSpec(raw: string): ChartSpec | null {
   try {
     const spec = JSON.parse(raw) as ChartSpec;
     if (!spec || typeof spec !== 'object') return null;
-    if (spec.type === 'bar' && Array.isArray(spec.rows) && spec.rows.length > 0) return spec;
-    if (spec.type === 'line' && Array.isArray(spec.series) && spec.series.length > 0) return spec;
-    if (spec.type === 'dots' && Array.isArray(spec.series) && spec.series.length > 0) return spec;
-    if (spec.type === 'cdf' && Array.isArray(spec.series) && spec.series.length > 0) return spec;
+    if (!validRefs(spec.refs)) return null;
+    if (spec.type === 'bar') {
+      const rows = spec.rows;
+      if (!Array.isArray(rows) || rows.length === 0) return null;
+      const ok = rows.every(
+        (r) =>
+          r &&
+          typeof r.label === 'string' &&
+          Number.isFinite(r.value) &&
+          (r.tick === undefined || Number.isFinite(r.tick))
+      );
+      return ok ? spec : null;
+    }
+    if (spec.type === 'line') {
+      const series = spec.series as LineSeries[] | undefined;
+      if (!Array.isArray(series) || series.length === 0) return null;
+      return series.every((s) => s && finiteNumbers(s.data)) ? spec : null;
+    }
+    if (spec.type === 'dots' || spec.type === 'cdf') {
+      const series = spec.series as DotSeries[] | undefined;
+      if (!Array.isArray(series) || series.length === 0) return null;
+      return series.every((s) => s && finiteNumbers(s.samples)) ? spec : null;
+    }
     return null;
   } catch {
     return null;
   }
+}
+
+/** Pad a [min, max] domain by a fraction of its span; sign-safe (works for
+ *  negative and all-equal domains, unlike multiplying the endpoints). */
+export function paddedDomain(min: number, max: number, frac = 0.05): [number, number] {
+  const span = max - min || Math.abs(max) || 1;
+  return [min - span * frac, max + span * frac];
 }
 
 export function formatValue(v: number, unit?: string): string {

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { parseMarkdown } from '@/lib/markdown';
 import {
   parseChartSpec,
+  paddedDomain,
   formatValue,
   barValueColumnWidth,
   formatAxisValue,
@@ -125,5 +126,78 @@ describe('post chart embeds', () => {
   it('computes medians', () => {
     expect(median([3, 1, 2])).toBe(2);
     expect(median([4, 1, 2, 3])).toBe(2.5);
+  });
+});
+
+describe('stricter spec validation (2026-08 upgrade)', () => {
+  it('accepts negative values and refs', () => {
+    const spec = parseChartSpec(
+      JSON.stringify({
+        type: 'bar',
+        rows: [{ label: 'delta', value: -12 }],
+        refs: [{ value: 0, label: 'baseline' }],
+      })
+    );
+    expect(spec).not.toBeNull();
+  });
+
+  it('rejects rows with non-finite or missing values', () => {
+    expect(parseChartSpec(JSON.stringify({ type: 'bar', rows: [{ label: 'a' }] }))).toBeNull();
+    expect(
+      parseChartSpec(JSON.stringify({ type: 'bar', rows: [{ label: 'a', value: 'x' }] }))
+    ).toBeNull();
+  });
+
+  it('rejects line series with empty or malformed data', () => {
+    expect(
+      parseChartSpec(JSON.stringify({ type: 'line', series: [{ name: 's', data: [] }] }))
+    ).toBeNull();
+    expect(parseChartSpec(JSON.stringify({ type: 'line', series: [{ name: 's' }] }))).toBeNull();
+    expect(
+      parseChartSpec(JSON.stringify({ type: 'line', series: [{ name: 's', data: [1, null] }] }))
+    ).toBeNull();
+  });
+
+  it('rejects dots series with empty samples, accepts a single cdf sample', () => {
+    expect(
+      parseChartSpec(JSON.stringify({ type: 'dots', series: [{ name: 's', samples: [] }] }))
+    ).toBeNull();
+    expect(
+      parseChartSpec(JSON.stringify({ type: 'cdf', series: [{ name: 's', samples: [1] }] }))
+    ).not.toBeNull();
+  });
+
+  it('rejects refs without finite values', () => {
+    expect(
+      parseChartSpec(
+        JSON.stringify({
+          type: 'line',
+          series: [{ name: 's', data: [1, 2] }],
+          refs: [{ label: 'no value' }],
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('paddedDomain', () => {
+  it('pads a normal domain on both sides', () => {
+    const [lo, hi] = paddedDomain(10, 110, 0.05);
+    expect(lo).toBeLessThan(10);
+    expect(hi).toBeGreaterThan(110);
+  });
+
+  it('handles negative domains without clipping', () => {
+    const [lo, hi] = paddedDomain(-50, -10, 0.05);
+    expect(lo).toBeLessThan(-50);
+    expect(hi).toBeGreaterThan(-10);
+  });
+
+  it('handles degenerate all-equal and all-zero domains', () => {
+    for (const v of [5, 0]) {
+      const [lo, hi] = paddedDomain(v, v, 0.05);
+      expect(hi).toBeGreaterThan(lo);
+      expect(Number.isFinite(lo) && Number.isFinite(hi)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Fixes and features from a joint audit (see commit body). Bug fixes: negative bar values were clamped to a 2px sliver, dots/cdf domains broke on negative or all-equal samples, single-sample cdf produced NaN, legend colors misaligned when series lacked names, malformed nested chart JSON could render a blank hole instead of falling back. Features: refs (labeled SLO/threshold lines) on bar+line, dash on line series with legend dash swatches, deterministic dot jitter for overplotting, native tooltips on line and dot points, last x-label no longer clipped. Parser now validates nested shapes and finite numbers; verified all 47 existing chart fences still parse. 9 new tests; authoring docs updated in the write-post skill.