### PR TITLE
Newsletter archive: featured latest issue and highlight cards

### DIFF
--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getAllNewsletters } from '@/lib/newsletters';
-import { Calendar, ArrowRight, Mail } from 'lucide-react';
+import { ArrowRight, Mail, Newspaper, Sparkles } from 'lucide-react';
 import { PageHero } from '@/components/page-hero';
 import { NewsletterForm } from '@/components/footer/newsletter-form';
 
@@ -12,8 +12,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/newsletters' },
   openGraph: {
     title: 'Newsletter Archive - DevOps Daily',
-    description:
-      'Browse past issues of the DevOps Daily newsletter.',
+    description: 'Browse past issues of the DevOps Daily newsletter.',
     type: 'website',
     url: '/newsletters',
     images: [
@@ -27,8 +26,17 @@ export const metadata: Metadata = {
   },
 };
 
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
 export default async function NewslettersPage() {
   const newsletters = await getAllNewsletters();
+  const [latest, ...rest] = newsletters;
 
   return (
     <div className="min-h-screen">
@@ -37,19 +45,10 @@ export default async function NewslettersPage() {
         title="Newsletter Archive"
         description="Every week we send a roundup of new content, tools, and learning resources. Browse past issues or subscribe to get the next one in your inbox."
         breadcrumbs={[{ label: 'Newsletter Archive' }]}
+        stats={[{ label: 'issues', value: newsletters.length }]}
       />
 
-      {/* Subscribe section */}
-      <section className="container mx-auto px-4 -mt-4 mb-8 max-w-md">
-        <NewsletterForm
-          source="newsletters_archive"
-          headline="Subscribe to the Newsletter"
-          description="Get next Monday's issue in your inbox."
-        />
-      </section>
-
-      {/* Newsletter List */}
-      <section className="py-8 container mx-auto px-4 mb-16 max-w-3xl">
+      <section className="container mx-auto px-4 py-8 mb-16 max-w-5xl">
         {newsletters.length === 0 ? (
           <div className="text-center py-12">
             <p className="text-muted-foreground">
@@ -57,35 +56,101 @@ export default async function NewslettersPage() {
             </p>
           </div>
         ) : (
-          <div className="space-y-4">
-            {newsletters.map((newsletter) => (
-              <Link
-                key={newsletter.slug}
-                href={`/newsletters/${newsletter.slug}`}
-                className="block group"
-              >
-                <div className="flex items-center gap-4 p-5 rounded-xl border border-border hover:border-primary/40 hover:shadow-md transition-all duration-200">
-                  <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center">
-                    <Calendar className="w-5 h-5 text-primary" />
+          <div className="space-y-10">
+            {/* Latest issue + subscribe, side by side */}
+            <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr] items-stretch">
+              <Link href={`/newsletters/${latest.slug}`} className="block group">
+                <article className="h-full rounded-2xl border border-primary/25 bg-primary/[0.04] p-6 sm:p-8 transition-all duration-200 hover:border-primary/50 hover:shadow-lg">
+                  <div className="flex items-center gap-2 mb-4">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/15 px-3 py-1 text-xs font-semibold text-primary">
+                      <Sparkles className="w-3.5 h-3.5" />
+                      Latest issue
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      <time dateTime={latest.date}>{formatDate(latest.date)}</time>
+                    </span>
                   </div>
-                  <div className="flex-grow min-w-0">
-                    <h3 className="font-semibold group-hover:text-primary transition-colors truncate">
-                      {newsletter.title}
-                    </h3>
-                    <p className="text-sm text-muted-foreground">
-                      <time dateTime={newsletter.date}>
-                        {new Date(newsletter.date).toLocaleDateString('en-US', {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric',
-                        })}
-                      </time>
+                  <h2 className="text-2xl font-bold mb-3 group-hover:text-primary transition-colors">
+                    Week {latest.week}, {latest.year}
+                  </h2>
+                  {latest.intro && (
+                    <p className="text-muted-foreground leading-relaxed mb-5 line-clamp-3">
+                      {latest.intro}
                     </p>
-                  </div>
-                  <ArrowRight className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors flex-shrink-0" />
-                </div>
+                  )}
+                  {latest.highlights.length > 0 && (
+                    <ul className="space-y-2 mb-6">
+                      {latest.highlights.map((h) => (
+                        <li key={h} className="flex items-start gap-2 text-sm">
+                          <Newspaper className="w-4 h-4 mt-0.5 text-primary/70 flex-shrink-0" />
+                          <span className="line-clamp-1">{h}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-primary">
+                    Read the issue
+                    <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
+                  </span>
+                </article>
               </Link>
-            ))}
+
+              <div className="lg:self-center">
+                <NewsletterForm
+                  source="newsletters_archive"
+                  headline="Subscribe to the Newsletter"
+                  description="One email every Monday. The week's posts, a simulator worth playing, and nothing else."
+                />
+              </div>
+            </div>
+
+            {/* Past issues */}
+            {rest.length > 0 && (
+              <div>
+                <h2 className="text-lg font-semibold mb-4 text-muted-foreground">Past issues</h2>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {rest.map((newsletter) => (
+                    <Link
+                      key={newsletter.slug}
+                      href={`/newsletters/${newsletter.slug}`}
+                      className="block group"
+                    >
+                      <article className="h-full rounded-xl border border-border p-5 transition-all duration-200 hover:border-primary/40 hover:shadow-md">
+                        <div className="flex items-center justify-between gap-3 mb-2">
+                          <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                            Week {newsletter.week}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            <time dateTime={newsletter.date}>{formatDate(newsletter.date)}</time>
+                          </span>
+                        </div>
+                        {newsletter.intro && (
+                          <p className="text-sm text-muted-foreground leading-relaxed mb-3 line-clamp-2">
+                            {newsletter.intro}
+                          </p>
+                        )}
+                        {newsletter.highlights.length > 0 && (
+                          <ul className="space-y-1 mb-3">
+                            {newsletter.highlights.slice(0, 3).map((h) => (
+                              <li
+                                key={h}
+                                className="text-sm text-foreground/80 line-clamp-1 before:content-['•'] before:text-primary/60 before:mr-2"
+                              >
+                                {h}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                        <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors">
+                          Read issue
+                          <ArrowRight className="w-3.5 h-3.5" />
+                        </span>
+                      </article>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/lib/newsletters.ts
+++ b/lib/newsletters.ts
@@ -20,6 +20,10 @@ export interface Newsletter {
   week: number;
   year: number;
   content: string;
+  /** The issue's greeting paragraph, extracted for archive cards. */
+  intro: string;
+  /** First few post titles in the issue, for archive cards. */
+  highlights: string[];
 }
 
 export interface NewsletterMeta {
@@ -29,6 +33,8 @@ export interface NewsletterMeta {
   date: string;
   week: number;
   year: number;
+  intro: string;
+  highlights: string[];
 }
 
 const loadNewsletters = createCachedLoader(async () => {
@@ -40,6 +46,17 @@ const loadNewsletters = createCachedLoader(async () => {
 
         const rendered = await remark().use(remarkHtml).process(content);
 
+        // Greeting: first non-empty, non-heading, non-image line of the body.
+        const intro =
+          content
+            .split('\n')
+            .map((line) => line.trim())
+            .find((line) => line && !line.startsWith('#') && !line.startsWith('![')) ?? '';
+        // Post titles: the "### [Title](url)" entries, first few.
+        const highlights = [...content.matchAll(/^### \[([^\]]+)\]/gm)]
+          .map((m) => m[1])
+          .slice(0, 4);
+
         return {
           slug,
           title: data.title || `Newsletter ${slug}`,
@@ -48,6 +65,8 @@ const loadNewsletters = createCachedLoader(async () => {
           week: data.week || 0,
           year: data.year || 0,
           content: String(rendered),
+          intro,
+          highlights,
         };
       } catch (error) {
         throw new Error(`Failed to parse newsletter file ${file}: ${formatUnknownError(error)}`);


### PR DESCRIPTION
Replaces the flat title+date list with: a featured latest-issue card (greeting excerpt, first post titles, read CTA) beside the subscribe form, and a two-column grid of past issues each showing week badge, date, greeting snippet and top three post titles. The loader now extracts intro and highlights from each issue's markdown.