### PR TITLE
Update DigitalOcean AI links after the Gradient rebrand

### DIFF
--- a/content/posts/ci-log-triage-digitalocean-inference.md
+++ b/content/posts/ci-log-triage-digitalocean-inference.md
@@ -24,7 +24,7 @@ A CI job fails. You open the run, scroll past four hundred lines of dependency r
 
 You do this several times a week. It is not hard, it is just tedious, and it is exactly the shape of problem that cheap inference is good at: a lot of text, a small answer, no need for the model to be clever.
 
-So we built it. A GitHub Action that takes a failing job's log and posts what broke, why, and what to try first. It runs on [DigitalOcean's serverless inference](https://docs.digitalocean.com/products/gradient-ai-platform/), the code is [on GitHub](https://github.com/The-DevOps-Daily/ci-log-triage), and the whole thing is about 400 lines.
+So we built it. A GitHub Action that takes a failing job's log and posts what broke, why, and what to try first. It runs on [DigitalOcean's serverless inference](https://docs.digitalocean.com/products/ai-platform/), the code is [on GitHub](https://github.com/The-DevOps-Daily/ci-log-triage), and the whole thing is about 400 lines.
 
 The interesting part turned out not to be the model call. That was twenty lines. The interesting part was everything we did before it.
 

--- a/content/posts/dns-detective-digitalocean-inference.md
+++ b/content/posts/dns-detective-digitalocean-inference.md
@@ -22,7 +22,7 @@ tags:
 
 Ask an LLM "why does mail to my domain bounce?" and you get a plausible list of everything that has ever caused a bounce. Ask an engineer, and they do something different: they run `dig`, look at the answer, and let the evidence pick the next question. The difference is not knowledge; it is that the engineer is allowed to touch the network.
 
-So we gave the model the network. **DNS Detective** is a small agent, running on [DigitalOcean Serverless Inference](https://www.digitalocean.com/products/gradient), that diagnoses DNS, TLS and email-record problems by calling real probe tools in a loop: resolve records, shake hands with TLS endpoints, pull registration data, fetch URLs. It probes, reads, probes again, and delivers a diagnosis where every claim cites a lookup it actually ran. The whole thing is about 300 lines of Python, and this post walks the build plus three real diagnoses recorded as they happened.
+So we gave the model the network. **DNS Detective** is a small agent, running on [DigitalOcean Serverless Inference](https://www.digitalocean.com/products/inference-engine), that diagnoses DNS, TLS and email-record problems by calling real probe tools in a loop: resolve records, shake hands with TLS endpoints, pull registration data, fetch URLs. It probes, reads, probes again, and delivers a diagnosis where every claim cites a lookup it actually ran. The whole thing is about 300 lines of Python, and this post walks the build plus three real diagnoses recorded as they happened.
 
 ```github
 The-DevOps-Daily/dns-detective
@@ -38,7 +38,7 @@ The-DevOps-Daily/dns-detective
 ## Prerequisites
 
 - Python 3.10+, `pip install dnspython`
-- A [DigitalOcean Serverless Inference](https://www.digitalocean.com/products/gradient) API key
+- A [DigitalOcean Serverless Inference](https://www.digitalocean.com/products/inference-engine) API key
 - No infrastructure: the agent is one file, the probes run from wherever you run it
 
 ## The architecture is one loop


### PR DESCRIPTION
digitalocean.com/products/gradient now redirects to the generic products page; the live page is /products/inference-engine. Also moves the docs link to its new /products/ai-platform/ home.