### PR TITLE
Preview environment simulator: remove em dashes, fix the drift drill commit

### DIFF
--- a/app/games/preview-environment-simulator/page.tsx
+++ b/app/games/preview-environment-simulator/page.tsx
@@ -110,7 +110,7 @@ export default function PreviewEnvironmentSimulatorPage() {
       fallbackDescription="See how a pull request becomes a temporary copy of your app, then review it and watch every resource disappear."
       educational={<PreviewEnvironmentEducational />}
       seoLearningPoints={seoLearningPoints}
-      shareText="I built a pull-request preview from Git intent to review evidence—and proved the cleanup path works."
+      shareText="I built a pull-request preview from Git intent to review evidence, and proved the cleanup path works."
     >
       <PreviewEnvironmentSimulator />
     </SimulatorShell>

--- a/components/games/preview-environment-simulator.tsx
+++ b/components/games/preview-environment-simulator.tsx
@@ -2017,8 +2017,8 @@ function EnvironmentScene({
             <div className="flex-1">
               <strong className="block text-sm">
                 {state.reviewDecision === 'approve'
-                  ? 'Preview approved — the PR can move forward.'
-                  : 'Changes requested — the preview stays isolated.'}
+                  ? 'Preview approved. The PR can move forward.'
+                  : 'Changes requested. The preview stays isolated.'}
               </strong>
               <span className="text-xs text-muted-foreground">
                 Close the PR to watch Argo CD remove the environment automatically.

--- a/lib/games.ts
+++ b/lib/games.ts
@@ -38,7 +38,7 @@ const games: Game[] = [
     title: 'Preview Environment Simulator',
     seoTitle: 'Preview Environment Simulator: From Pull Request to Teardown',
     description:
-      'See how a pull request becomes a temporary copy of your app—complete with a private URL, safe test data, review checks, and automatic cleanup.',
+      'See how a pull request becomes a temporary copy of your app, complete with a private URL, safe test data, review checks, and automatic cleanup.',
     iconName: 'Workflow',
     badgeText: 'New',
     color: 'from-blue-500 to-cyan-600',

--- a/lib/games/preview-environment-engine.ts
+++ b/lib/games/preview-environment-engine.ts
@@ -288,7 +288,7 @@ export const PREVIEW_FAILURES: Record<PreviewFailureId, PreviewFailure> = {
     summary:
       'Health checks pass, but the worker runs an older image than the commit recorded on the PR.',
     stage: 'verify',
-    signal: 'Expected worker@sha-8f3c2a1; observed worker@sha-72ba640.',
+    signal: 'Expected worker@sha-72ba640, the commit on the pull request; observed worker@sha-5d1e9c0 from the previous build.',
     remediationOptions: [
       {
         id: 'approve-healthy',


### PR DESCRIPTION
Replaces the four em dashes in the simulator copy with plain punctuation, and makes the revision drift drill (PR 182) quote that pull request's own commit instead of PR 184's.