### PR TITLE
Give cover title measurement more headroom for wider system fonts

### DIFF
--- a/scripts/og-utils.ts
+++ b/scripts/og-utils.ts
@@ -182,7 +182,7 @@ function estimatedTextWidth(text: string, fontSize: number, weight = 800): numbe
     else if (/[-_+\/=()\[\]{}]/.test(character)) em += 0.5;
     else em += 1;
   }
-  return em * fontSize * (weight >= 800 ? 1.035 : 1.015);
+  return em * fontSize * (weight >= 800 ? 1.06 : 1.03);
 }
 
 function splitLongToken(token: string, fontSize: number, maxWidth: number): string[] {


### PR DESCRIPTION
The cover title test failed on main because the runner's Arial substitute renders about 1% wider than the estimate assumes, so the longest title spilled 7px past the title area. Raises the estimate factors (bold 1.035 to 1.06, regular 1.015 to 1.03) so wrapping stays inside the box on wider fonts. Passes locally with Liberation Sans.