### PR TITLE
Add Atomsized as a sponsor

### DIFF
--- a/components/games/game-sponsors.tsx
+++ b/components/games/game-sponsors.tsx
@@ -16,31 +16,36 @@ interface GameSponsorsProps {
 export function GameSponsors({ className }: GameSponsorsProps) {
   return (
     <div className={cn('w-full mb-6', className)}>
-      <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-4 py-4 px-6 rounded-lg border border-border/40 bg-muted/20">
-        <span className="text-sm font-semibold text-muted-foreground">Supported by</span>
-        {sponsors.map((sponsor) => (
+      <div className="mx-auto max-w-6xl overflow-hidden rounded-lg border border-border/50 bg-muted/20">
+        <div className="flex min-h-10 items-center justify-between gap-4 border-b border-border/40 px-4 py-2">
+          <span className="text-sm font-semibold text-muted-foreground">Supported by</span>
           <Link
-            key={sponsor.name}
-            href={sponsor.url}
-            target="_blank"
-            rel="noopener noreferrer sponsored"
-            className="group flex items-center gap-2 px-4 py-2 rounded-md hover:bg-muted/50 transition-all"
+            href="/sponsorship"
+            className="whitespace-nowrap text-xs text-muted-foreground transition-colors underline-offset-4 hover:text-foreground hover:underline sm:text-sm"
           >
-            <SponsorLogo
-              sponsor={sponsor}
-              width={140}
-              height={44}
-              className="h-10 w-auto opacity-90 group-hover:opacity-100 transition-opacity"
-            />
+            Become a sponsor
           </Link>
-        ))}
-        <span className="text-muted-foreground/40 hidden sm:inline">|</span>
-        <Link
-          href="/sponsorship"
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors underline-offset-4 hover:underline"
-        >
-          Become a sponsor
-        </Link>
+        </div>
+
+        <div className="grid grid-cols-2 gap-px bg-border/30 sm:grid-cols-3 lg:grid-cols-6">
+          {sponsors.map((sponsor) => (
+            <Link
+              key={sponsor.name}
+              href={sponsor.url}
+              target="_blank"
+              rel="noopener noreferrer sponsored"
+              title={sponsor.tagline ? `${sponsor.name} — ${sponsor.tagline}` : sponsor.name}
+              className="group flex h-14 min-w-0 items-center justify-center bg-background/60 px-3 transition-colors hover:bg-muted/60"
+            >
+              <SponsorLogo
+                sponsor={sponsor}
+                width={140}
+                height={44}
+                className="h-10 w-full max-w-36 object-contain opacity-90 transition-opacity group-hover:opacity-100"
+              />
+            </Link>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/inline-sponsors.tsx
+++ b/components/inline-sponsors.tsx
@@ -12,7 +12,11 @@ interface InlineSponsorsProps {
   showCTA?: boolean;
 }
 
-export function InlineSponsors({ className, variant = 'full', showCTA = true }: InlineSponsorsProps) {
+export function InlineSponsors({
+  className,
+  variant = 'full',
+  showCTA = true,
+}: InlineSponsorsProps) {
   if (variant === 'banner') {
     return (
       <div className={cn('my-12', className)}>
@@ -27,15 +31,15 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
             <div className="flex items-center justify-center gap-2 mb-6">
               <Heart className="h-4 w-4 text-primary fill-primary animate-pulse" />
               <span className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-               Sponsored by
-             </span>
-             <Heart className="h-4 w-4 text-primary fill-primary animate-pulse" />
-           </div>
+                Sponsored by
+              </span>
+              <Heart className="h-4 w-4 text-primary fill-primary animate-pulse" />
+            </div>
             <p className="text-xs text-muted-foreground text-center mb-4">
               We earn commissions when you shop through the links below.
             </p>
 
-           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-4xl mx-auto">
               {sponsors.map((sponsor) => (
                 <Link
                   key={sponsor.name}
@@ -45,7 +49,7 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
                   className={cn(
                     'group relative flex items-center gap-4 p-4 bg-background/80 backdrop-blur-sm rounded-md border transition-colors',
                     sponsor.featured
-                      ? cn('md:col-span-2', sponsor.accentClassName)
+                      ? sponsor.accentClassName
                       : 'border-border hover:border-primary/40 hover:bg-muted/30'
                   )}
                 >
@@ -58,7 +62,7 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
                       sponsor={sponsor}
                       width={120}
                       height={60}
-                      className="h-auto w-auto max-h-16"
+                      className="h-12 w-full max-w-24 object-contain"
                     />
                   </div>
 
@@ -92,29 +96,31 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
   }
 
   if (variant === 'compact') {
-  return (
-    <div className={cn('my-8', className)}>
-      <div className="flex flex-wrap items-center justify-center gap-6">
-        <span className="text-xs text-muted-foreground/60 uppercase tracking-wider">Supported by</span>
-        {sponsors.map((sponsor) => (
-          <Link
-            key={sponsor.name}
-            href={sponsor.url}
-            target="_blank"
-            rel="noopener noreferrer sponsored"
-            className="group inline-flex items-center justify-center px-4 py-2 rounded-md hover:bg-muted/50 transition-colors"
-            title={sponsor.tagline}
-          >
-            <SponsorLogo
-              sponsor={sponsor}
-              width={100}
-              height={40}
-              className="h-auto w-auto max-h-8 opacity-50 group-hover:opacity-80 transition-opacity"
-            />
-          </Link>
-        ))}
+    return (
+      <div className={cn('my-8', className)}>
+        <div className="flex flex-wrap items-center justify-center gap-6">
+          <span className="text-xs text-muted-foreground/60 uppercase tracking-wider">
+            Supported by
+          </span>
+          {sponsors.map((sponsor) => (
+            <Link
+              key={sponsor.name}
+              href={sponsor.url}
+              target="_blank"
+              rel="noopener noreferrer sponsored"
+              className="group inline-flex items-center justify-center px-4 py-2 rounded-md hover:bg-muted/50 transition-colors"
+              title={sponsor.tagline}
+            >
+              <SponsorLogo
+                sponsor={sponsor}
+                width={100}
+                height={40}
+                className="h-8 w-auto max-w-36 object-contain opacity-50 transition-opacity group-hover:opacity-80"
+              />
+            </Link>
+          ))}
+        </div>
       </div>
-    </div>
     );
   }
 
@@ -132,10 +138,10 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20 mb-4">
               <Sparkles className="h-4 w-4 text-primary" />
               <span className="text-sm font-semibold text-foreground">Proudly Sponsored By</span>
-           </div>
-           <p className="text-muted-foreground text-sm max-w-2xl mx-auto">
+            </div>
+            <p className="text-muted-foreground text-sm max-w-2xl mx-auto">
               We earn commissions when you shop through the links below.
-           </p>
+            </p>
           </div>
 
           {/* Sponsors Grid */}
@@ -146,7 +152,7 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
                 href={sponsor.url}
                 target="_blank"
                 rel="noopener noreferrer sponsored"
-                className={cn('group relative', sponsor.featured && 'md:col-span-2')}
+                className="group relative"
               >
                 <div
                   className={cn(
@@ -170,7 +176,7 @@ export function InlineSponsors({ className, variant = 'full', showCTA = true }: 
                         sponsor={sponsor}
                         width={120}
                         height={60}
-                        className="h-auto w-auto max-h-16"
+                        className="h-14 w-full max-w-40 object-contain"
                       />
                     </div>
 

--- a/components/sponsor-sidebar.tsx
+++ b/components/sponsor-sidebar.tsx
@@ -30,7 +30,7 @@ export function SponsorSidebar({ className, relatedPosts = [] }: SponsorSidebarP
 
         <div className="relative rounded-xl border border-border/50 overflow-hidden backdrop-blur-sm bg-card/50">
           {/* Header with gradient */}
-         <div className="relative bg-linear-to-r from-primary/10 to-primary/5 px-4 py-2.5">
+          <div className="relative bg-linear-to-r from-primary/10 to-primary/5 px-4 py-2.5">
             <div className="flex items-center gap-2">
               <Sparkles className="h-4 w-4 text-primary" />
               <span className="font-semibold text-sm">Our Sponsors</span>
@@ -38,9 +38,9 @@ export function SponsorSidebar({ className, relatedPosts = [] }: SponsorSidebarP
             <p className="text-[10px] text-muted-foreground mt-0.5">
               We earn commissions when you shop through the links below.
             </p>
-         </div>
+          </div>
 
-          <div className="p-3 space-y-2">
+          <div className="grid grid-cols-2 gap-px border-y border-border/40 bg-border/40">
             {sponsors.map((sponsor) => (
               <Link
                 key={sponsor.name}
@@ -49,39 +49,32 @@ export function SponsorSidebar({ className, relatedPosts = [] }: SponsorSidebarP
                 rel="noopener noreferrer sponsored"
                 title={sponsor.tagline ? `${sponsor.name} — ${sponsor.tagline}` : sponsor.name}
                 className={cn(
-                  'group relative flex items-center gap-3 rounded-md border px-3 py-2.5 transition-colors',
-                  sponsor.accentClassName ??
-                    'border-border bg-muted/20 hover:border-primary/40 hover:bg-muted/40'
+                  'group relative isolate flex h-16 min-w-0 items-center justify-center bg-card/90 px-3 transition-all',
+                  sponsor.featured
+                    ? 'bg-linear-to-b from-[#2c70ff]/[0.08] to-card/90 shadow-[inset_0_2px_0_rgba(44,112,255,0.55)] hover:from-[#2c70ff]/[0.12]'
+                    : 'hover:bg-muted/70'
                 )}
               >
-                {/* Logo. The wordmark carries the sponsor name, so the row
-                    pairs it with the tagline rather than repeating the name. */}
-                <div className="flex w-24 shrink-0 items-center">
+                <div className="flex w-full min-w-0 items-center justify-center">
                   <SponsorLogo
                     sponsor={sponsor}
                     width={120}
                     height={40}
                     className={cn(
-                      'h-auto max-h-7 w-auto max-w-24 object-contain',
+                      'h-8 w-full max-w-28 object-contain opacity-90 transition-opacity group-hover:opacity-100',
                       sponsor.sidebarClassName
                     )}
                   />
                 </div>
 
-                {sponsor.tagline && (
-                  <p className="min-w-0 flex-1 text-[11px] leading-snug text-muted-foreground transition-colors group-hover:text-foreground/80">
-                    {sponsor.tagline}
-                  </p>
-                )}
-
                 {/* External link indicator */}
-                <ExternalLink className="absolute top-1.5 right-1.5 h-3 w-3 text-muted-foreground opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                <ExternalLink className="absolute right-1.5 top-1.5 h-3 w-3 text-muted-foreground opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
               </Link>
             ))}
           </div>
 
           {/* Optional CTA */}
-          <div className="px-3 pb-3">
+          <div className="px-3 py-2.5">
             <a
               href="/sponsorship"
               className="block text-center text-xs text-muted-foreground hover:text-primary transition-colors"

--- a/lib/sponsors.ts
+++ b/lib/sponsors.ts
@@ -15,10 +15,7 @@ export interface Sponsor {
   className?: string;
   /** Additional className for sidebar context (sizing, positioning) */
   sidebarClassName?: string;
-  /**
-   * Give this sponsor top billing: it is tinted in the sidebar and takes a
-   * full-width card in the grid layouts instead of a half-width one.
-   */
+  /** Give this sponsor highlighted styling in sponsor placements. */
   featured?: boolean;
   /** Border and background tint for a featured sponsor, in its own brand color. */
   accentClassName?: string;
@@ -35,6 +32,15 @@ export const sponsors: Sponsor[] = [
       'Svix Dispatch sends your webhooks for you: retries with exponential backoff, signed payloads, idempotency keys, and a delivery log your customers can see.',
     featured: true,
     accentClassName: 'border-[#2c70ff]/40 bg-[#2c70ff]/[0.06] hover:border-[#2c70ff]/70',
+  },
+  {
+    name: 'Atomsized',
+    logo: '/atomsized.svg',
+    darkLogo: '/atomsized-light.svg',
+    url: 'https://atomsized.com/',
+    tagline: 'AWS platform engineering and GitOps',
+    description:
+      'Design and automation for reliable AWS and Kubernetes platforms, safer delivery workflows, and preview and UAT environments your engineers can understand and own.',
   },
   {
     name: 'DigitalOcean',
@@ -56,14 +62,16 @@ export const sponsors: Sponsor[] = [
     logo: '/smtpfast.svg',
     url: 'https://smtpfa.st',
     tagline: 'Developer-first email API',
-    description: 'Send transactional and marketing email through a clean REST API. Detailed logs, webhooks, and embeddable signup forms in one dashboard.',
+    description:
+      'Send transactional and marketing email through a clean REST API. Detailed logs, webhooks, and embeddable signup forms in one dashboard.',
   },
   {
     name: 'QuizAPI',
     logo: '/quizapi.svg',
     url: 'https://quizapi.io?ref=devops-daily',
     tagline: 'Developer-first quiz platform',
-    description: 'Build, generate, and embed quizzes with a powerful REST API. AI-powered question generation and live multiplayer.',
+    description:
+      'Build, generate, and embed quizzes with a powerful REST API. AI-powered question generation and live multiplayer.',
   },
 ];
 

--- a/public/atomsized-light.svg
+++ b/public/atomsized-light.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 48" width="170" height="48" role="img" aria-label="Atomsized">
+  <g transform="scale(.75)">
+    <rect x="2" y="2" width="60" height="60" rx="10" fill="#0b1f3a"/>
+    <rect x="3" y="3" width="58" height="58" rx="9" fill="none" stroke="#edf3f9" stroke-opacity=".42" stroke-width="2"/>
+    <path d="M18 46 32 16l14 30M23.5 34h17" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+    <ellipse cx="32" cy="34" rx="23.5" ry="12.5" fill="none" stroke="#4d91d7" stroke-linecap="round" stroke-width="3.5" transform="rotate(-20 32 34)"/>
+    <circle cx="9.92" cy="42.04" r="4" fill="#df725c"/>
+    <circle cx="54.08" cy="25.96" r="4" fill="#f3c84b"/>
+    <circle cx="32" cy="34" r="3.2" fill="#4d91d7" stroke="#f8fafc" stroke-width="1.5"/>
+  </g>
+  <text x="58" y="32" font-family="Inter, system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" font-weight="600" letter-spacing="-.5" fill="#edf3f9">atomsized</text>
+</svg>

--- a/public/atomsized.svg
+++ b/public/atomsized.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 170 48" width="170" height="48" role="img" aria-label="Atomsized">
+  <g transform="scale(.75)">
+    <rect x="2" y="2" width="60" height="60" rx="10" fill="#0b1f3a"/>
+    <rect x="3" y="3" width="58" height="58" rx="9" fill="none" stroke="#edf3f9" stroke-opacity=".42" stroke-width="2"/>
+    <path d="M18 46 32 16l14 30M23.5 34h17" fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+    <ellipse cx="32" cy="34" rx="23.5" ry="12.5" fill="none" stroke="#4d91d7" stroke-linecap="round" stroke-width="3.5" transform="rotate(-20 32 34)"/>
+    <circle cx="9.92" cy="42.04" r="4" fill="#df725c"/>
+    <circle cx="54.08" cy="25.96" r="4" fill="#f3c84b"/>
+    <circle cx="32" cy="34" r="3.2" fill="#4d91d7" stroke="#f8fafc" stroke-width="1.5"/>
+  </g>
+  <text x="58" y="32" font-family="Inter, system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" font-weight="600" letter-spacing="-.5" fill="#0b1f3a">atomsized</text>
+</svg>

--- a/public/quizapi.svg
+++ b/public/quizapi.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 48" width="230" height="48" role="img" aria-label="QuizAPI">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 48" width="140" height="48" role="img" aria-label="QuizAPI">
   <defs>
     <linearGradient id="quizapiMark" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#6366f1"/>

--- a/public/smtpfast.svg
+++ b/public/smtpfast.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 48" width="230" height="48" role="img" aria-label="SMTPfast">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 158 48" width="158" height="48" role="img" aria-label="SMTPfast">
   <defs>
     <linearGradient id="smtpfastMark" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#10b981"/>


### PR DESCRIPTION
## Summary

- add Atomsized next to Svix in the centralized sponsor list, with light and dark logo assets
- rebalance the sponsor grids across game, banner, full, compact, and sidebar placements
- keep Svix featured without letting it dominate the layout, and correct the optical alignment of the bottom-row logos

## Verification

- targeted ESLint checks pass for every changed TypeScript file
- targeted Prettier checks pass for all changed files
- verified the posts listing, article, Hacktoberfest, and simulator sponsor layouts locally with no console errors
- the full unit run completed 6,513 assertions successfully; Vitest still exits non-zero because of the repository's existing missing `jsdom` worker setup
- the repository-wide typecheck has existing unrelated failures; none are in the changed sponsor files
