### PR TITLE
Harden the post renderer against bad specs and repeated headings

### DIFF
--- a/components/post-chart-blocks.tsx
+++ b/components/post-chart-blocks.tsx
@@ -15,6 +15,7 @@ import {
   barValueColumnWidth,
   formatAxisValue,
   niceAxisTicks,
+  logAxisTicks,
   wrapChartLabel,
   median,
   percentile,
@@ -168,21 +169,20 @@ function LineChart({ spec }: { spec: ChartSpec }) {
   const padB = 34;
   const points = Math.max(...series.map((s) => s.data.length));
   const refs = spec.refs ?? [];
-  const all = [...series.flatMap((s) => s.data), ...(spec.log ? [] : refs.map((r) => r.value))];
+  const data = series.flatMap((s) => s.data);
 
   // Log axis (opt-in): spreads a squished low end next to a large spike. Falls
-  // back to linear when any value is <= 0, since log10 is undefined there.
-  const canLog = spec.log && all.every((v) => v > 0);
+  // back to linear when the values cannot sit on a log scale (any <= 0, or
+  // decade bounds that leave the finite range).
+  const logAxis = spec.log ? logAxisTicks(data) : null;
+  const all = logAxis ? data : [...data, ...refs.map((r) => r.value)];
   let yTicks: number[];
   let scaleY: (v: number) => number;
-  if (canLog) {
-    const loB = 10 ** Math.floor(Math.log10(Math.min(...all)));
-    let hiB = 10 ** Math.ceil(Math.log10(Math.max(...all)));
-    if (hiB === loB) hiB *= 10;
+  if (logAxis) {
+    const { lo: loB, hi: hiB, ticks } = logAxis;
     const lg = (v: number) => Math.log10(Math.max(v, loB));
     scaleY = (v: number) => (lg(v) - lg(loB)) / (lg(hiB) - lg(loB));
-    yTicks = [];
-    for (let t = loB; t <= hiB + 1e-6; t *= 10) yTicks.push(t);
+    yTicks = ticks;
   } else {
     const dataMin = Math.min(0, Math.min(...all));
     const dataMax = Math.max(...all);

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -203,16 +203,18 @@ function headingSlug(plain: string): string {
 function reserveHeadingIds(content: string): void {
   reservedHeadingIds.clear();
   const textRenderer = new TextRenderer();
-  for (const token of marked.lexer(content)) {
-    if (token.type !== 'heading') continue;
-    let plain = token.text;
+  // walkTokens visits nested tokens too (blockquotes, list items, callouts).
+  marked.walkTokens(marked.lexer(content), (token) => {
+    if (token.type !== 'heading') return;
+    const heading = token as Tokens.Heading;
+    let plain = heading.text;
     try {
-      plain = new Parser().parseInline(token.tokens, textRenderer);
+      plain = new Parser().parseInline(heading.tokens, textRenderer);
     } catch {
       // fall back to the raw heading text
     }
-    reservedHeadingIds.add(`h${token.depth}-${headingSlug(plain)}`);
-  }
+    reservedHeadingIds.add(`h${heading.depth}-${headingSlug(plain)}`);
+  });
 }
 
 function uniqueHeadingId(base: string): string {

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,4 +1,4 @@
-import { marked, type Tokens, type TokenizerAndRendererExtension } from 'marked';
+import { marked, type Tokens, type TokenizerAndRendererExtension, Parser, TextRenderer } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import hljs, { type HLJSApi, type Language } from 'highlight.js';
@@ -183,12 +183,41 @@ const INTERACTIVE_FENCES: Record<string, { className: string; attr: string; vali
 };
 
 // Heading ids already used in the document being parsed; reset per parse so a
-// repeated heading gets a numbered suffix instead of a duplicate anchor.
+// repeated heading gets a numbered suffix instead of a duplicate anchor. The
+// base ids of every heading in the document are reserved up front, so a
+// suffix never takes the id a later heading ("Example 1" after two "Example")
+// would have had on its own; links to first occurrences stay stable.
 const usedHeadingIds = new Set<string>();
+const reservedHeadingIds = new Set<string>();
+
+function headingSlug(plain: string): string {
+  return plain
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function reserveHeadingIds(content: string): void {
+  reservedHeadingIds.clear();
+  const textRenderer = new TextRenderer();
+  for (const token of marked.lexer(content)) {
+    if (token.type !== 'heading') continue;
+    let plain = token.text;
+    try {
+      plain = new Parser().parseInline(token.tokens, textRenderer);
+    } catch {
+      // fall back to the raw heading text
+    }
+    reservedHeadingIds.add(`h${token.depth}-${headingSlug(plain)}`);
+  }
+}
 
 function uniqueHeadingId(base: string): string {
   let id = base;
-  for (let n = 1; usedHeadingIds.has(id); n++) id = `${base}-${n}`;
+  for (let n = 1; usedHeadingIds.has(id) || (id !== base && reservedHeadingIds.has(id)); n++) id = `${base}-${n}`;
   usedHeadingIds.add(id);
   return id;
 }
@@ -198,7 +227,9 @@ function uniqueHeadingId(base: string): string {
 marked.use({
   renderer: {
     code({ text, lang }: Tokens.Code) {
-      const fence = lang ? INTERACTIVE_FENCES[lang] : undefined;
+      // Own-property lookup: a fence language such as "constructor" must not
+      // resolve to something inherited from Object.prototype.
+      const fence = lang && Object.prototype.hasOwnProperty.call(INTERACTIVE_FENCES, lang) ? INTERACTIVE_FENCES[lang] : undefined;
       if (fence) {
         if (fence.valid(text)) {
           return `<div class="${fence.className} not-prose" ${fence.attr}="${escapeHtml(JSON.stringify(JSON.parse(text)))}"></div>`;
@@ -224,13 +255,7 @@ marked.use({
       const headingTag = `h${depth}`;
 
       // Create a simple slug from the text with heading level prefix to avoid duplicates
-      const baseSlug = plain
-        .toLowerCase()
-        .trim()
-        .replace(/[^\w\s-]/g, '') // Remove special characters
-        .replace(/\s+/g, '-') // Replace spaces with hyphens
-        .replace(/-+/g, '-') // Replace multiple hyphens with single
-        .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
+      const baseSlug = headingSlug(plain);
 
       // Heading level prefix plus a per-document suffix for repeats
       const slug = uniqueHeadingId(`h${depth}-${baseSlug}`);
@@ -380,6 +405,7 @@ export function sanitizeRenderedHtml(html: string): string {
 
 export function parseMarkdown(content: string): string {
   usedHeadingIds.clear();
+  reserveHeadingIds(content);
   const result = marked.parse(content);
   return typeof result === 'string' ? sanitizeRenderedHtml(result) : '';
 }

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -3,6 +3,9 @@ import { markedHighlight } from 'marked-highlight';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import hljs, { type HLJSApi, type Language } from 'highlight.js';
 import sanitizeHtml from 'sanitize-html';
+import { parseChartSpec } from './post-charts';
+import { parseTerminalSpec, parseTabsSpec } from './post-interactive';
+import { parseDiagramSpec } from './post-diagram';
 
 // Import specific languages for better support
 import javascript from 'highlight.js/lib/languages/javascript';
@@ -169,55 +172,40 @@ function parseRepoSlug(input: string): string | null {
   return null;
 }
 
+// Interactive fences become placeholder divs that the client wrappers hydrate.
+// The same parsers the wrappers use decide whether a fence is valid, so a spec
+// that would render as nothing on the client shows up as a code block instead.
+const INTERACTIVE_FENCES: Record<string, { className: string; attr: string; valid: (raw: string) => boolean }> = {
+  chart: { className: 'post-chart', attr: 'data-chart', valid: (raw) => parseChartSpec(raw) !== null },
+  terminal: { className: 'post-terminal', attr: 'data-terminal', valid: (raw) => parseTerminalSpec(raw) !== null },
+  tabs: { className: 'post-tabs', attr: 'data-tabs', valid: (raw) => parseTabsSpec(raw) !== null },
+  diagram: { className: 'post-diagram', attr: 'data-diagram', valid: (raw) => parseDiagramSpec(raw) !== null },
+};
+
+// Heading ids already used in the document being parsed; reset per parse so a
+// repeated heading gets a numbered suffix instead of a duplicate anchor.
+const usedHeadingIds = new Set<string>();
+
+function uniqueHeadingId(base: string): string {
+  let id = base;
+  for (let n = 1; usedHeadingIds.has(id); n++) id = `${base}-${n}`;
+  usedHeadingIds.add(id);
+  return id;
+}
+
 // Custom renderer: headings get anchor links, and ```chart fences become
 // placeholders that ChartBlockWrapper hydrates client-side.
 marked.use({
   renderer: {
     code({ text, lang }: Tokens.Code) {
-      if (lang === 'chart') {
-        try {
-          const spec = JSON.parse(text);
-          if (spec && typeof spec === 'object' && spec.type) {
-            return `<div class="post-chart not-prose" data-chart="${escapeHtml(JSON.stringify(spec))}"></div>`;
-          }
-        } catch {
-          // malformed spec: fall through to a visible code block so the
-          // mistake is obvious in the rendered post instead of a blank hole
+      const fence = lang ? INTERACTIVE_FENCES[lang] : undefined;
+      if (fence) {
+        if (fence.valid(text)) {
+          return `<div class="${fence.className} not-prose" ${fence.attr}="${escapeHtml(JSON.stringify(JSON.parse(text)))}"></div>`;
         }
-        return `<pre><code class="hljs language-chart">${escapeHtml(text)}</code></pre>`;
-      }
-      if (lang === 'terminal') {
-        try {
-          const spec = JSON.parse(text);
-          if (spec && typeof spec === 'object' && Array.isArray(spec.steps)) {
-            return `<div class="post-terminal not-prose" data-terminal="${escapeHtml(JSON.stringify(spec))}"></div>`;
-          }
-        } catch {
-          // fall through to a visible code block
-        }
-        return `<pre><code class="hljs language-terminal">${escapeHtml(text)}</code></pre>`;
-      }
-      if (lang === 'tabs') {
-        try {
-          const spec = JSON.parse(text);
-          if (spec && typeof spec === 'object' && Array.isArray(spec.tabs)) {
-            return `<div class="post-tabs not-prose" data-tabs="${escapeHtml(JSON.stringify(spec))}"></div>`;
-          }
-        } catch {
-          // fall through to a visible code block
-        }
-        return `<pre><code class="hljs language-tabs">${escapeHtml(text)}</code></pre>`;
-      }
-      if (lang === 'diagram') {
-        try {
-          const spec = JSON.parse(text);
-          if (spec && typeof spec === 'object' && typeof spec.type === 'string') {
-            return `<div class="post-diagram not-prose" data-diagram="${escapeHtml(JSON.stringify(spec))}"></div>`;
-          }
-        } catch {
-          // fall through to a visible code block
-        }
-        return `<pre><code class="hljs language-diagram">${escapeHtml(text)}</code></pre>`;
+        // malformed or incomplete spec: a visible code block makes the
+        // mistake obvious in the rendered post instead of a blank hole
+        return `<pre><code class="hljs language-${lang}">${escapeHtml(text)}</code></pre>`;
       }
       if (lang === 'github') {
         const slug = parseRepoSlug(text);
@@ -244,8 +232,8 @@ marked.use({
         .replace(/-+/g, '-') // Replace multiple hyphens with single
         .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
 
-      // Add heading level prefix to ensure uniqueness (h1-, h2-, h3-, etc.)
-      const slug = `h${depth}-${baseSlug}`;
+      // Heading level prefix plus a per-document suffix for repeats
+      const slug = uniqueHeadingId(`h${depth}-${baseSlug}`);
 
       return `<${headingTag} id="${slug}" class="group relative scroll-mt-24">
         <a href="#${slug}" class="no-underline text-inherit hover:text-inherit focus:outline-none focus:ring-0 focus:ring-offset-0">
@@ -391,6 +379,7 @@ export function sanitizeRenderedHtml(html: string): string {
 }
 
 export function parseMarkdown(content: string): string {
+  usedHeadingIds.clear();
   const result = marked.parse(content);
   return typeof result === 'string' ? sanitizeRenderedHtml(result) : '';
 }

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -164,6 +164,30 @@ export function niceAxisTicks(min: number, max: number, targetIntervals = 4): nu
   return Array.from({ length: count + 1 }, (_, i) => Number((first + i * step).toPrecision(12)));
 }
 
+export interface LogAxis {
+  lo: number;
+  hi: number;
+  ticks: number[];
+}
+
+/** Decade bounds and ticks for a log10 axis. Returns null when the values
+ *  cannot sit on one: any value <= 0, a decade bound that underflows to 0 or
+ *  overflows to Infinity, or more decades than fit on a chart. Callers fall
+ *  back to a linear axis in that case. */
+export function logAxisTicks(values: number[], maxDecades = 24): LogAxis | null {
+  if (values.length === 0 || !values.every((v) => Number.isFinite(v) && v > 0)) return null;
+  const e0 = Math.floor(Math.log10(Math.min(...values)));
+  let e1 = Math.ceil(Math.log10(Math.max(...values)));
+  if (e1 === e0) e1 += 1;
+  if (e1 - e0 > maxDecades) return null;
+  const lo = 10 ** e0;
+  const hi = 10 ** e1;
+  if (!(lo > 0) || !Number.isFinite(hi)) return null;
+  const ticks: number[] = [];
+  for (let e = e0; e <= e1; e++) ticks.push(10 ** e);
+  return { lo, hi, ticks };
+}
+
 /** Wrap a chart label at a word boundary and cap the second line so labels can
  * never spill into the plot area. */
 export function wrapChartLabel(label: string, maxChars = 28): string[] {

--- a/lib/post-charts.ts
+++ b/lib/post-charts.ts
@@ -160,6 +160,9 @@ export function niceAxisTicks(min: number, max: number, targetIntervals = 4): nu
   const first = Math.floor(min / step) * step;
   const last = Math.ceil(max / step) * step;
   const count = Math.round((last - first) / step);
+  // Values near the float limit overflow the rounded bounds; a two-tick axis
+  // keeps the chart drawable instead of asking for an infinite array.
+  if (![step, first, last, count].every(Number.isFinite) || count > 1000) return [min, max];
 
   return Array.from({ length: count + 1 }, (_, i) => Number((first + i * step).toPrecision(12)));
 }

--- a/tests/markdown-sanitize.test.ts
+++ b/tests/markdown-sanitize.test.ts
@@ -46,6 +46,12 @@ describe('parseMarkdown sanitization', () => {
     expect(ids).toEqual(['h2-example', 'h2-example-2', 'h2-example-1']);
   });
 
+  it('reserves headings nested in blockquotes and lists too', () => {
+    const html = parseMarkdown('## Example\n\n## Example\n\n> ## Example 1\n');
+    const ids = [...html.matchAll(/<h2[^>]*id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids).toEqual(['h2-example', 'h2-example-2', 'h2-example-1']);
+  });
+
   it('treats a fence language named after an Object.prototype member as a plain code block', () => {
     expect(() => parseMarkdown('```constructor\nfoo\n```\n')).not.toThrow();
     const html = parseMarkdown('```toString\nfoo\n```\n');

--- a/tests/markdown-sanitize.test.ts
+++ b/tests/markdown-sanitize.test.ts
@@ -40,6 +40,19 @@ describe('parseMarkdown sanitization', () => {
     expect(html).toContain('id="h2-the-img-srcx-onerroralert1-element"');
   });
 
+  it('gives repeated headings distinct ids and resets between documents', () => {
+    const html = parseMarkdown('### Example Output\n\none\n\n### Example Output\n\ntwo\n\n## Example Output');
+    expect(html).toContain('id="h3-example-output"');
+    expect(html).toContain('id="h3-example-output-1"');
+    expect(html).toContain('href="#h3-example-output-1"');
+    expect(html).toContain('data-heading-id="h3-example-output-1"');
+    expect(html).toContain('id="h2-example-output"');
+
+    const again = parseMarkdown('### Example Output');
+    expect(again).toContain('id="h3-example-output"');
+    expect(again).not.toContain('h3-example-output-1');
+  });
+
   it('adds rel=noopener to external links and leaves internal ones alone', () => {
     const html = parseMarkdown('[ext](https://example.com) [int](/posts/x)');
     expect(html).toMatch(/<a href="https:\/\/example.com"[^>]*rel="noopener noreferrer"/);

--- a/tests/markdown-sanitize.test.ts
+++ b/tests/markdown-sanitize.test.ts
@@ -40,6 +40,19 @@ describe('parseMarkdown sanitization', () => {
     expect(html).toContain('id="h2-the-img-srcx-onerroralert1-element"');
   });
 
+  it('never gives a duplicate heading the id a later heading has on its own', () => {
+    const html = parseMarkdown('## Example\n\n## Example\n\n## Example 1\n');
+    const ids = [...html.matchAll(/<h2[^>]*id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids).toEqual(['h2-example', 'h2-example-2', 'h2-example-1']);
+  });
+
+  it('treats a fence language named after an Object.prototype member as a plain code block', () => {
+    expect(() => parseMarkdown('```constructor\nfoo\n```\n')).not.toThrow();
+    const html = parseMarkdown('```toString\nfoo\n```\n');
+    expect(html).toContain('language-toString');
+    expect(html).not.toContain('data-terminal');
+  });
+
   it('gives repeated headings distinct ids and resets between documents', () => {
     const html = parseMarkdown('### Example Output\n\none\n\n### Example Output\n\ntwo\n\n## Example Output');
     expect(html).toContain('id="h3-example-output"');

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -11,6 +11,7 @@ import {
   wrapChartLabel,
   median,
   percentile,
+  niceAxisTicks,
 } from '@/lib/post-charts';
 
 const BAR_SPEC = {
@@ -243,6 +244,13 @@ describe('interactive fence validation', () => {
 });
 
 describe('logAxisTicks', () => {
+  it('linear ticks stay finite for values near the float limit', () => {
+    const ticks = niceAxisTicks(0, 1.7e308);
+    expect(ticks.every(Number.isFinite)).toBe(true);
+    expect(ticks.length).toBeGreaterThanOrEqual(2);
+    expect(ticks.length).toBeLessThan(1002);
+  });
+
   it('returns decade ticks spanning the data', () => {
     expect(logAxisTicks([3, 4000])).toEqual({ lo: 1, hi: 10000, ticks: [1, 10, 100, 1000, 10000] });
   });

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -11,7 +11,6 @@ import {
   wrapChartLabel,
   median,
   percentile,
-  niceAxisTicks,
 } from '@/lib/post-charts';
 
 const BAR_SPEC = {

--- a/tests/post-charts.test.ts
+++ b/tests/post-charts.test.ts
@@ -7,6 +7,7 @@ import {
   barValueColumnWidth,
   formatAxisValue,
   niceAxisTicks,
+  logAxisTicks,
   wrapChartLabel,
   median,
   percentile,
@@ -53,6 +54,14 @@ describe('post chart embeds', () => {
     expect(html).not.toContain('post-chart');
     expect(html).toContain('language-chart');
     expect(html).toContain('{ not json');
+  });
+
+  it('renders a chart spec the client parser rejects as a code block', () => {
+    // Valid JSON with the right shape but bad values: the client would return
+    // null and leave the placeholder blank.
+    const html = parseMarkdown('```chart\n{"type":"line","series":[{"name":"x","data":["a"]}]}\n```');
+    expect(html).not.toContain('post-chart');
+    expect(html).toContain('language-chart');
   });
 
   it('leaves other code fences untouched', () => {
@@ -199,5 +208,67 @@ describe('paddedDomain', () => {
       expect(hi).toBeGreaterThan(lo);
       expect(Number.isFinite(lo) && Number.isFinite(hi)).toBe(true);
     }
+  });
+});
+
+describe('interactive fence validation', () => {
+  it('renders a terminal step with a non-string cmd as a code block', () => {
+    const html = parseMarkdown('```terminal\n{"steps":[{"cmd":123}]}\n```');
+    expect(html).not.toContain('post-terminal');
+    expect(html).toContain('language-terminal');
+    expect(html).toContain('{"steps":[{"cmd":123}]}');
+  });
+
+  it('keeps a valid terminal spec as a placeholder', () => {
+    const html = parseMarkdown('```terminal\n{"steps":[{"cmd":"pwd","output":"/app"}]}\n```');
+    expect(html).toMatch(/<div class="post-terminal not-prose" data-terminal="[^"]+"><\/div>/);
+  });
+
+  it('renders tabs without a usable tab as a code block', () => {
+    const html = parseMarkdown('```tabs\n{"tabs":[{"label":"a"}]}\n```');
+    expect(html).not.toContain('post-tabs');
+    expect(html).toContain('language-tabs');
+  });
+
+  it('renders a diagram with an unknown type as a code block', () => {
+    const html = parseMarkdown('```diagram\n{"type":"pie","nodes":[{"label":"a"}]}\n```');
+    expect(html).not.toContain('post-diagram');
+    expect(html).toContain('language-diagram');
+  });
+
+  it('keeps a valid diagram spec as a placeholder', () => {
+    const html = parseMarkdown('```diagram\n{"type":"flow","nodes":[{"label":"a"},{"label":"b"}]}\n```');
+    expect(html).toMatch(/<div class="post-diagram not-prose" data-diagram="[^"]+"><\/div>/);
+  });
+});
+
+describe('logAxisTicks', () => {
+  it('returns decade ticks spanning the data', () => {
+    expect(logAxisTicks([3, 4000])).toEqual({ lo: 1, hi: 10000, ticks: [1, 10, 100, 1000, 10000] });
+  });
+
+  it('widens a single-decade range to one full decade', () => {
+    expect(logAxisTicks([5, 7])?.ticks).toEqual([1, 10]);
+  });
+
+  it('refuses values that are not strictly positive', () => {
+    expect(logAxisTicks([0, 10])).toBeNull();
+    expect(logAxisTicks([-1, 10])).toBeNull();
+    expect(logAxisTicks([])).toBeNull();
+  });
+
+  it('refuses a lower bound that underflows to zero', () => {
+    // 10 ** -324 is 0; multiplying it by ten forever never reaches the top.
+    expect(logAxisTicks([5e-324])).toBeNull();
+    expect(logAxisTicks([5e-324, 1])).toBeNull();
+  });
+
+  it('refuses an upper bound that overflows and a span too wide to draw', () => {
+    expect(logAxisTicks([1, 1.7e308])).toBeNull();
+    expect(logAxisTicks([1e-30, 1e30])).toBeNull();
+  });
+
+  it('accepts a wide but drawable range', () => {
+    expect(logAxisTicks([1e-3, 1e5])?.ticks).toHaveLength(9);
   });
 });


### PR DESCRIPTION
A line chart with `log: true` and a value whose lower decade rounds to zero (for example 5e-324) made the tick loop multiply zero by ten forever and froze the browser tab. Log axes now come from a bounded helper that requires positive finite bounds, caps the decade count, and falls back to a linear axis otherwise.

Interactive fences (chart, terminal, tabs, diagram) are now validated with the same parsers the client wrappers use before a placeholder is emitted. A spec that the client would reject renders as a visible code block instead of an empty div. A scan of all 201 fences in the current content shows none change rendering mode.

Repeated headings get a per-document numbered suffix (`h3-example-output`, `h3-example-output-1`) so copied anchor links point at the right section. Tests cover the log-axis edge cases, the fence validation and the heading ids.