### PR TITLE
Fix digest week numbering and IndexNow URL mapping

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -69,23 +69,20 @@ jobs:
       - name: Map changed paths to URLs
         if: github.event_name == 'push' && steps.diff.outputs.count != '0'
         run: |
-          # Path -> URL mapping mirrors Next.js route structure.
-          awk '
-            /^content\/posts\//           { sub(/^content\/posts\//, "/posts/"); sub(/\.md$/, ""); print; next }
-            /^content\/news\//            { sub(/^content\/news\//, "/news/"); sub(/\.md$/, ""); print; next }
-            /^content\/newsletters\//     { sub(/^content\/newsletters\//, "/newsletters/"); sub(/\.md$/, ""); print; next }
-            /^content\/guides\/[^/]+\//   { sub(/^content\/guides\//, "/guides/"); sub(/\/.*$/, ""); print; next }
-            /^content\/comparisons\//     { sub(/^content\/comparisons\//, "/comparisons/"); sub(/\.md$/, ""); print; next }
-            /^content\/exercises\//       { sub(/^content\/exercises\//, "/exercises/"); sub(/\.json$/, ""); print; next }
-            /^content\/quizzes\//         { sub(/^content\/quizzes\//, "/quizzes/"); sub(/\.json$/, ""); print; next }
-            /^content\/flashcards\//      { sub(/^content\/flashcards\//, "/flashcards/"); sub(/\.json$/, ""); print; next }
-            /^content\/checklists\//      { sub(/^content\/checklists\//, "/checklists/"); sub(/\.json$/, ""); print; next }
-            /^content\/interview-questions\// { sub(/^content\/interview-questions\//, "/interview-questions/"); sub(/\.json$/, ""); print; next }
-            /^content\/advent-of-devops\// { sub(/^content\/advent-of-devops\//, "/advent-of-devops/"); sub(/\.md$/, ""); print; next }
-          ' changed.txt | sort -u > urls.txt
+          # Path -> URL mapping lives in scripts/content-path-to-url.ts so it
+          # is unit tested against the real route shapes (news slugs, guide
+          # parts, json-backed content, interview question tiers).
+          bun scripts/content-path-to-url.ts < changed.txt | sort -u > urls.txt
 
           echo "URLs to submit:"
           cat urls.txt
+
+      - name: Dry-run the IndexNow payload
+        if: github.event_name == 'push' && steps.diff.outputs.count != '0'
+        run: |
+          if [ -s urls.txt ]; then
+            cat urls.txt | bun scripts/submit-indexnow.ts --stdin --dry-run
+          fi
 
       - name: Submit changed URLs to IndexNow
         if: github.event_name == 'push' && steps.diff.outputs.count != '0'

--- a/scripts/__tests__/content-path-to-url.test.ts
+++ b/scripts/__tests__/content-path-to-url.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { contentPathToUrl, contentPathsToUrls } from '../content-path-to-url';
+
+const files: Record<string, string> = {
+  'content/interview-questions/otel-context-propagation.json': JSON.stringify({
+    slug: 'otel-context-propagation',
+    tier: 'senior',
+  }),
+  'content/interview-questions/broken.json': '{ not json',
+};
+const readFile = (path: string) => files[path] ?? null;
+
+describe('contentPathToUrl', () => {
+  it('maps posts, newsletters and advent days by file name', () => {
+    expect(contentPathToUrl('content/posts/my-post.md')).toBe('/posts/my-post');
+    expect(contentPathToUrl('content/newsletters/2026-week-16.md')).toBe('/newsletters/2026-week-16');
+    expect(contentPathToUrl('content/advent-of-devops/day-17.md')).toBe('/advent-of-devops/day-17');
+  });
+
+  it('maps a news digest to its year-week slug', () => {
+    expect(contentPathToUrl('content/news/2026/week-36.md')).toBe('/news/2026-week-36');
+    expect(contentPathToUrl('content/news/2026/week-07.md')).toBe('/news/2026-week-7');
+  });
+
+  it('maps guide index and part files to their own routes', () => {
+    expect(contentPathToUrl('content/guides/introduction-to-ansible/index.md')).toBe(
+      '/guides/introduction-to-ansible'
+    );
+    expect(contentPathToUrl('content/guides/introduction-to-ansible/02-inventory.md')).toBe(
+      '/guides/introduction-to-ansible/02-inventory'
+    );
+  });
+
+  it('strips the json extension from json-backed content', () => {
+    expect(contentPathToUrl('content/comparisons/ansible-vs-chef.json')).toBe('/comparisons/ansible-vs-chef');
+    expect(contentPathToUrl('content/exercises/terraform-aws-vpc.json')).toBe('/exercises/terraform-aws-vpc');
+    expect(contentPathToUrl('content/quizzes/a-quiz.json')).toBe('/quizzes/a-quiz');
+    expect(contentPathToUrl('content/flashcards/terraform-basics.json')).toBe('/flashcards/terraform-basics');
+    expect(contentPathToUrl('content/checklists/kubernetes-security.json')).toBe('/checklists/kubernetes-security');
+  });
+
+  it('reads the tier of an interview question from the file', () => {
+    expect(
+      contentPathToUrl('content/interview-questions/otel-context-propagation.json', { readFile })
+    ).toBe('/interview-questions/senior/otel-context-propagation');
+    expect(contentPathToUrl('content/interview-questions/broken.json', { readFile })).toBeNull();
+    expect(contentPathToUrl('content/interview-questions/missing.json', { readFile })).toBeNull();
+  });
+
+  it('ignores files that have no page of their own', () => {
+    expect(contentPathToUrl('content/categories/cloud.md')).toBeNull();
+    expect(contentPathToUrl('content/interview-questions/index.ts')).toBeNull();
+    expect(contentPathToUrl('scripts/devops-daily/data/sources.yaml')).toBeNull();
+    expect(contentPathToUrl('content/posts/nested/x.md')).toBeNull();
+  });
+
+  it('deduplicates and drops unmapped paths in bulk', () => {
+    expect(
+      contentPathsToUrls([
+        'content/posts/a.md',
+        'content/categories/cloud.md',
+        'content/posts/a.md',
+        'content/news/2026/week-1.md',
+      ])
+    ).toEqual(['/posts/a', '/news/2026-week-1']);
+  });
+});

--- a/scripts/__tests__/digest-date.test.ts
+++ b/scripts/__tests__/digest-date.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getIsoWeekAndYear, getCurrentWeek, getCurrentYear } from '../devops-daily/utils/date';
+
+describe('digest week numbering', () => {
+  it('uses the ISO week-based year at the turn of the year', () => {
+    // Monday 29 Dec 2025 is ISO week 1 of 2026, which is what `date +%V/%G`
+    // in the workflow reports. The old calendar-year lookup wrote 2025/week-1.
+    expect(getIsoWeekAndYear(new Date(2025, 11, 29))).toEqual({ week: 1, year: 2026 });
+    expect(getIsoWeekAndYear(new Date(2026, 0, 1))).toEqual({ week: 1, year: 2026 });
+  });
+
+  it('keeps a week 53 inside its own year', () => {
+    // 2026 has an ISO week 53 (28 Dec 2026 to 3 Jan 2027).
+    expect(getIsoWeekAndYear(new Date(2026, 11, 28))).toEqual({ week: 53, year: 2026 });
+    expect(getIsoWeekAndYear(new Date(2027, 0, 2))).toEqual({ week: 53, year: 2026 });
+  });
+
+  it('agrees with the single-value helpers for the same instant', () => {
+    const d = new Date(2026, 8, 7);
+    expect(getCurrentWeek(d)).toBe(37);
+    expect(getCurrentYear(d)).toBe(2026);
+  });
+});

--- a/scripts/content-path-to-url.ts
+++ b/scripts/content-path-to-url.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Map changed content file paths to the site routes they render at.
+ *
+ * Usage:
+ *   bun scripts/content-path-to-url.ts < changed.txt   # one path per line
+ *
+ * Paths that do not render to a page of their own (sources.yaml, category
+ * metadata, unknown folders) produce no output. The mapping mirrors the
+ * generateStaticParams of each route under app/.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface MapOptions {
+  /** Read a content file; used for routes whose params live inside the file. */
+  readFile?: (path: string) => string | null;
+}
+
+function defaultReadFile(path: string): string | null {
+  try {
+    return existsSync(path) ? readFileSync(path, 'utf8') : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Route for one content path, or null when the file has no page of its own. */
+export function contentPathToUrl(filePath: string, options: MapOptions = {}): string | null {
+  const p = filePath.trim().replace(/^\.\//, '');
+  const read = options.readFile ?? defaultReadFile;
+  let m: RegExpMatchArray | null;
+
+  if ((m = p.match(/^content\/posts\/([^/]+)\.md$/))) return `/posts/${m[1]}`;
+
+  // content/news/2026/week-36.md renders at /news/2026-week-36 (lib/news.ts)
+  if ((m = p.match(/^content\/news\/(\d{4})\/week-(\d+)\.md$/))) {
+    return `/news/${m[1]}-week-${parseInt(m[2], 10)}`;
+  }
+
+  if ((m = p.match(/^content\/newsletters\/([^/]+)\.md$/))) return `/newsletters/${m[1]}`;
+
+  // Guides are folders: index.md is the guide page, every other .md a part.
+  if ((m = p.match(/^content\/guides\/([^/]+)\/index\.md$/))) return `/guides/${m[1]}`;
+  if ((m = p.match(/^content\/guides\/([^/]+)\/([^/]+)\.md$/))) return `/guides/${m[1]}/${m[2]}`;
+
+  if ((m = p.match(/^content\/comparisons\/([^/]+)\.json$/))) return `/comparisons/${m[1]}`;
+  if ((m = p.match(/^content\/exercises\/([^/]+)\.json$/))) return `/exercises/${m[1]}`;
+  if ((m = p.match(/^content\/quizzes\/([^/]+)\.json$/))) return `/quizzes/${m[1]}`;
+  if ((m = p.match(/^content\/flashcards\/([^/]+)\.json$/))) return `/flashcards/${m[1]}`;
+  if ((m = p.match(/^content\/checklists\/([^/]+)\.json$/))) return `/checklists/${m[1]}`;
+
+  // Interview questions render at /interview-questions/<tier>/<slug>; the
+  // tier is only known from the file body.
+  if ((m = p.match(/^content\/interview-questions\/([^/]+)\.json$/))) {
+    const raw = read(p);
+    if (!raw) return null;
+    try {
+      const data = JSON.parse(raw) as { tier?: string; slug?: string };
+      if (typeof data.tier !== 'string') return null;
+      return `/interview-questions/${data.tier}/${data.slug || m[1]}`;
+    } catch {
+      return null;
+    }
+  }
+
+  if ((m = p.match(/^content\/advent-of-devops\/([^/]+)\.md$/))) return `/advent-of-devops/${m[1]}`;
+
+  return null;
+}
+
+/** Map many paths, dropping unmapped ones and duplicates, keeping input order. */
+export function contentPathsToUrls(paths: string[], options: MapOptions = {}): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const path of paths) {
+    const url = contentPathToUrl(path, options);
+    if (url && !seen.has(url)) {
+      seen.add(url);
+      out.push(url);
+    }
+  }
+  return out;
+}
+
+const isMain =
+  typeof process.argv[1] === 'string' &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const lines = readFileSync(0, 'utf8').split('\n').filter((line) => line.trim() !== '');
+  for (const url of contentPathsToUrls(lines)) console.log(url);
+}

--- a/scripts/devops-daily/index.ts
+++ b/scripts/devops-daily/index.ts
@@ -9,7 +9,7 @@ import { crawlWebSources } from './crawler/web.js';
 import { normalizeItems } from './utils/normalize.js';
 import { deduplicate } from './utils/dedupe.js';
 import { applyLimits } from './utils/limit.js';
-import { isWithinLastDays, getCurrentWeek, getCurrentYear } from './utils/date.js';
+import { isWithinLastDays, getIsoWeekAndYear } from './utils/date.js';
 import { classifyItems } from './ai/classify.js';
 import { summarizeItems } from './ai/summarize.js';
 import { assembleDigest } from './pipeline/assemble.js';
@@ -25,6 +25,8 @@ async function main() {
   if (skipAI) {
     console.log('ℹ️  Running with --skip-ai flag (using keyword-based classification)\n');
   }
+  // --force allows replacing a digest file that already exists
+  const force = process.argv.includes('--force');
 
   try {
     // 1. Load sources
@@ -89,8 +91,7 @@ async function main() {
 
     // 10. Assemble digest
     console.log('📝 Assembling digest...');
-    const week = getCurrentWeek();
-    const year = getCurrentYear();
+    const { week, year } = getIsoWeekAndYear();
     const digest = assembleDigest(allItems, week, year);
     printStats(digest);
 
@@ -109,6 +110,16 @@ async function main() {
     const newsDir = path.join(process.cwd(), 'content', 'news', year.toString());
     await fs.mkdir(newsDir, { recursive: true });
     const filePath = path.join(newsDir, `week-${week}.md`);
+    const exists = await fs
+      .access(filePath)
+      .then(() => true)
+      .catch(() => false);
+    if (exists && !force) {
+      console.error(
+        `❌ ${filePath} already exists. Re-run with --force to replace that issue.`
+      );
+      process.exit(1);
+    }
     await fs.writeFile(filePath, markdown, 'utf-8');
     console.log(`  ✓ Written to: ${filePath}\n`);
 

--- a/scripts/devops-daily/pipeline/assemble.ts
+++ b/scripts/devops-daily/pipeline/assemble.ts
@@ -1,5 +1,5 @@
 import { NewsItem, Digest, DigestMetadata } from '../crawler/types.js';
-import { getCurrentWeek, getCurrentYear, formatISODate } from '../utils/date.js';
+import { getIsoWeekAndYear, formatISODate } from '../utils/date.js';
 import { generateTitle, generateSummary } from './template.js';
 
 /**
@@ -46,8 +46,9 @@ export function assembleDigest(
   week?: number,
   year?: number
 ): Digest {
-  const w = week || getCurrentWeek();
-  const y = year || getCurrentYear();
+  const now = getIsoWeekAndYear();
+  const w = week || now.week;
+  const y = year || now.year;
 
   const metadata: DigestMetadata = {
     title: generateTitle(w, y),

--- a/scripts/devops-daily/utils/date.ts
+++ b/scripts/devops-daily/utils/date.ts
@@ -1,17 +1,26 @@
-import { format, getWeek, getYear, isAfter, isBefore, subDays } from 'date-fns';
+import { format, getISOWeek, getISOWeekYear, isAfter, isBefore, subDays } from 'date-fns';
 
 /**
- * Get the current week number
+ * ISO week number and week-based year for a date, taken from the same
+ * instant so a year-end run never pairs week 1 with the old year. Matches
+ * the `date +%V` / `date +%G` pair the digest workflow uses.
  */
-export function getCurrentWeek(): number {
-  return getWeek(new Date(), { weekStartsOn: 1 });
+export function getIsoWeekAndYear(date: Date = new Date()): { week: number; year: number } {
+  return { week: getISOWeek(date), year: getISOWeekYear(date) };
 }
 
 /**
- * Get the current year
+ * Get the current ISO week number
  */
-export function getCurrentYear(): number {
-  return getYear(new Date());
+export function getCurrentWeek(date: Date = new Date()): number {
+  return getIsoWeekAndYear(date).week;
+}
+
+/**
+ * Get the current ISO week-based year
+ */
+export function getCurrentYear(date: Date = new Date()): number {
+  return getIsoWeekAndYear(date).year;
 }
 
 /**
@@ -54,7 +63,8 @@ export function formatDisplayDate(date: Date | string): string {
  * Generate a branch name for the news digest
  */
 export function generateBranchName(year?: number, week?: number): string {
-  const y = year || getCurrentYear();
-  const w = week || getCurrentWeek();
+  const now = getIsoWeekAndYear();
+  const y = year || now.year;
+  const w = week || now.week;
   return `news-${y}-w${w}`;
 }


### PR DESCRIPTION
The weekly digest script paired date-fns getWeek with the calendar year, so the run on 29 Dec 2025 wrote `content/news/2025/week-1.md` while the workflow labelled the PR week 1 of 2026 (that file is still in the repo). Week and year now come from `getISOWeek` and `getISOWeekYear` on one timestamp, which matches the workflow's `date +%V` / `date +%G`. The script also refuses to overwrite a digest file that already exists unless `--force` is passed; the scheduled workflow runs on a fresh checkout so it is not affected.

The IndexNow workflow mapped changed content paths with awk rules that produced `/news/2026/week-36` instead of `/news/2026-week-36`, reduced guide paths to an empty string, and left `.json` on comparison URLs. The mapping now lives in `scripts/content-path-to-url.ts`, which follows the routes under `app/` (news slugs, guide index and part pages, json-backed content, interview question tiers read from the file) and has unit tests. The workflow prints a dry-run IndexNow payload before the real submission.

One assumption carried over from the old mapping: exercise, quiz, flashcard and checklist ids are taken from the file name, which is how the current content is laid out.