### PR TITLE
Match tag pages to tag counts and slim the guide sidebar payload

### DIFF
--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -1,7 +1,7 @@
 import { GuideContent } from '@/components/guide-content';
 import { GuideSidebar } from '@/components/guide-sidebar';
 import { SponsorSidebar } from '@/components/sponsor-sidebar';
-import { getGuideBySlug, getAllGuides, getGuidePart, getRelatedGuides } from '@/lib/guides';
+import { getGuideBySlug, getAllGuides, getGuidePart, getRelatedGuides, toGuideNav } from '@/lib/guides';
 import { notFound } from 'next/navigation';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema, TechArticleSchema } from '@/components/schema-markup';
@@ -161,7 +161,7 @@ export default async function GuidePartPage({
             <div className="flex flex-col gap-8 lg:flex-row">
               {/* Guide Navigation Sidebar */}
               <aside className="shrink-0 lg:w-80">
-                <GuideSidebar guide={guide} activePart={partSlug} />
+                <GuideSidebar guide={toGuideNav(guide)} activePart={partSlug} />
               </aside>
 
               {/* Article Content */}

--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { GuideContent } from '@/components/guide-content';
 import { GuideSidebar } from '@/components/guide-sidebar';
 import { InlineSponsors } from '@/components/inline-sponsors';
-import { getGuideBySlug, getAllGuides, getRelatedGuides } from '@/lib/guides';
+import { getGuideBySlug, getAllGuides, getRelatedGuides, toGuideNav } from '@/lib/guides';
 import { notFound } from 'next/navigation';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema, TechArticleSchema } from '@/components/schema-markup';
@@ -108,7 +108,7 @@ export default async function GuidePage({ params }: { params: Promise<{ slug: st
 
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
           <aside className="order-last lg:col-span-3 lg:order-first">
-            <GuideSidebar guide={guide} />
+            <GuideSidebar guide={toGuideNav(guide)} />
           </aside>
           <div className="lg:col-span-9">
             <article className="prose dark:prose-invert max-w-none">

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -24,6 +24,21 @@ export function toGuideSummary(guide: Guide): GuideSummary {
   return { ...rest, parts: parts.map(({ content: _c, ...part }) => part) };
 }
 
+/** Just what the client-side guide sidebar needs: titles and slugs, no bodies. */
+export type GuideNav = {
+  title: string;
+  slug: string;
+  parts: Array<{ title: string; slug: string }>;
+};
+
+export function toGuideNav(guide: Guide): GuideNav {
+  return {
+    title: guide.title,
+    slug: guide.slug,
+    parts: guide.parts.map(({ title, slug }) => ({ title, slug })),
+  };
+}
+
 export type Guide = {
   title: string;
   /**

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -10,55 +10,45 @@ export type Tag = {
   count: number;
 };
 
+/**
+ * Count tags across content items by their slug, so `Docker Compose` and
+ * `docker-compose` share one entry. Each item counts at most once per slug,
+ * and the first spelling seen becomes the display name.
+ */
+export function countTags(tagLists: Array<string[] | undefined>): Tag[] {
+  const tagMap = new Map<string, { name: string; count: number }>();
+
+  for (const tags of tagLists) {
+    if (!tags) continue;
+    const seen = new Set<string>();
+    for (const tag of tags) {
+      const slug = tagToSlug(tag);
+      if (!slug || seen.has(slug)) continue;
+      seen.add(slug);
+      const existing = tagMap.get(slug);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        tagMap.set(slug, { name: tag, count: 1 });
+      }
+    }
+  }
+
+  return Array.from(tagMap.entries())
+    .map(([slug, { name, count }]) => ({ name, slug, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** True when any of the item's tags normalizes to the given slug. */
+export function hasTagSlug(tags: string[] | undefined, tagSlug: string): boolean {
+  return !!tags && tags.some((tag) => tagToSlug(tag) === tagSlug);
+}
+
 export async function getAllTags(): Promise<Tag[]> {
   const posts = (await getAllPosts()) as Post[];
   const guides = (await getAllGuides()) as Guide[];
 
-  // Collect all tags from posts and guides
-  // Use slug as key to handle both case-insensitive duplicates and slug conflicts
-  const tagMap = new Map<string, { name: string; count: number }>();
-
-  const processTag = (tag: string) => {
-    const slug = tagToSlug(tag);
-    const existing = tagMap.get(slug);
-
-    if (existing) {
-      // Increment count, keep the first occurrence's casing
-      tagMap.set(slug, {
-        name: existing.name,
-        count: existing.count + 1,
-      });
-    } else {
-      // First occurrence - use this tag's casing
-      tagMap.set(slug, {
-        name: tag,
-        count: 1,
-      });
-    }
-  };
-
-  // Process post tags
-  posts.forEach((post) => {
-    if (post.tags) {
-      post.tags.forEach(processTag);
-    }
-  });
-
-  // Process guide tags
-  guides.forEach((guide) => {
-    if (guide.tags) {
-      guide.tags.forEach(processTag);
-    }
-  });
-
-  // Convert to array and sort by count (descending)
-  const tags = Array.from(tagMap.entries()).map(([slug, { name, count }]) => ({
-    name,
-    slug,
-    count,
-  }));
-
-  return tags.sort((a, b) => b.count - a.count);
+  return countTags([...posts.map((post) => post.tags), ...guides.map((guide) => guide.tags)]);
 }
 
 // A tag used by fewer than this many items doesn't get its own page. A two- or
@@ -87,21 +77,11 @@ export async function getTagBySlug(slug: string): Promise<string | null> {
 }
 
 export async function getPostsByTagSlug(tagSlug: string): Promise<Post[]> {
-  const actualTag = await getTagBySlug(tagSlug);
-  if (!actualTag) return [];
-
   const posts = await getAllPosts();
-  return posts.filter(
-    (post) => post.tags && post.tags.some((tag) => tag.toLowerCase() === actualTag.toLowerCase())
-  );
+  return posts.filter((post) => hasTagSlug(post.tags, tagSlug));
 }
 
 export async function getGuidesByTagSlug(tagSlug: string): Promise<Guide[]> {
-  const actualTag = await getTagBySlug(tagSlug);
-  if (!actualTag) return [];
-
   const guides = await getAllGuides();
-  return guides.filter(
-    (guide) => guide.tags && guide.tags.some((tag) => tag.toLowerCase() === actualTag.toLowerCase())
-  );
+  return guides.filter((guide) => hasTagSlug(guide.tags, tagSlug));
 }

--- a/tests/tags.test.ts
+++ b/tests/tags.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { countTags, hasTagSlug, getAllTags, getPostsByTagSlug, getGuidesByTagSlug } from '@/lib/tags';
+
+describe('countTags', () => {
+  it('merges spellings that share a slug and keeps the first spelling as the name', () => {
+    const tags = countTags([['Docker Compose'], ['docker-compose'], ['Next.js'], ['nextjs']]);
+    expect(tags).toEqual([
+      { name: 'Docker Compose', slug: 'docker-compose', count: 2 },
+      { name: 'Next.js', slug: 'nextjs', count: 2 },
+    ]);
+  });
+
+  it('counts an item once per slug even when it repeats the tag', () => {
+    const tags = countTags([['Kubernetes', 'kubernetes', 'k8s']]);
+    expect(tags).toEqual([
+      { name: 'Kubernetes', slug: 'kubernetes', count: 1 },
+      { name: 'k8s', slug: 'k8s', count: 1 },
+    ]);
+  });
+
+  it('skips missing tag lists and tags that slug to nothing', () => {
+    expect(countTags([undefined, ['!!!'], ['a']])).toEqual([{ name: 'a', slug: 'a', count: 1 }]);
+  });
+});
+
+describe('hasTagSlug', () => {
+  it('matches any spelling that normalizes to the slug', () => {
+    expect(hasTagSlug(['Docker Compose'], 'docker-compose')).toBe(true);
+    expect(hasTagSlug(['docker-compose'], 'docker-compose')).toBe(true);
+    expect(hasTagSlug(['Docker'], 'docker-compose')).toBe(false);
+    expect(hasTagSlug(undefined, 'docker')).toBe(false);
+  });
+});
+
+describe('tag pages over the real content', () => {
+  it('lists exactly as many items on a tag page as the tag count says', async () => {
+    const tags = await getAllTags();
+    for (const tag of tags.slice(0, 40)) {
+      const [posts, guides] = await Promise.all([getPostsByTagSlug(tag.slug), getGuidesByTagSlug(tag.slug)]);
+      expect(posts.length + guides.length, tag.slug).toBe(tag.count);
+    }
+  });
+});


### PR DESCRIPTION
Tag counts in `lib/tags.ts` were merged by slug, while the tag pages filtered posts and guides by the exact display name. A slug shared by two spellings (`Docker Compose` and `docker-compose`, `Next.js` and `nextjs`) got a page whose count included both but whose list only showed one. Both paths now compare `tagToSlug(tag) === tagSlug`, and an item counts once per slug even if it repeats a tag. A new test checks that the top tag pages list exactly as many items as their count.

`GuideSidebar` is a client component and received the full guide object, including every chapter body, on every chapter page. The pages now pass `toGuideNav(guide)`, which is only the title, slug and the part titles and slugs.