### PR TITLE
Cancel pending simulator advances on reset, lesson change and unmount

### DIFF
--- a/components/games/oauth-oidc-flow-simulator.tsx
+++ b/components/games/oauth-oidc-flow-simulator.tsx
@@ -529,9 +529,13 @@ export default function OAuthOidcFlowSimulator() {
                     key={lesson.id}
                     type="button"
                     onClick={() => {
-                      cancelPendingAdvance()?.();
+                      cancelPendingAdvance();
+                      // Resume at the first action not yet completed.
+                      const firstOpen = lesson.actions.findIndex(
+                        (_, actionIndex) => !completedActions.has(`${lessonIndex}-${actionIndex}`)
+                      );
                       setCurrentLessonIndex(lessonIndex);
-                      setCurrentActionIndex(0);
+                      setCurrentActionIndex(Math.max(0, firstOpen));
                       setShowHint(false);
                     }}
                     className={cn(

--- a/components/games/oauth-oidc-flow-simulator.tsx
+++ b/components/games/oauth-oidc-flow-simulator.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertTriangle,
   ArrowRight,
@@ -390,6 +390,20 @@ export default function OAuthOidcFlowSimulator() {
     return !action.requires?.some((token) => !tokens[token]);
   };
 
+  // A delayed advance still pending, with the step it applies. Cancelled on
+  // reset and unmount; applied first on a lesson change so the step is not
+  // left completed but unadvanced.
+  const advanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingAdvance = useRef<(() => void) | null>(null);
+  const cancelPendingAdvance = () => {
+    const pending = pendingAdvance.current;
+    if (advanceTimer.current !== null) clearTimeout(advanceTimer.current);
+    advanceTimer.current = null;
+    pendingAdvance.current = null;
+    return pending;
+  };
+  useEffect(() => () => { cancelPendingAdvance(); }, []);
+
   const runAction = (action = currentAction) => {
     if (!canRunAction(action)) {
       appendLog({
@@ -425,9 +439,9 @@ export default function OAuthOidcFlowSimulator() {
     appendLog({ type: action.warning ? 'warning' : 'success', content: action.insight });
 
     const key = `${currentLessonIndex}-${currentActionIndex}`;
-    if (action === currentAction && !completedActions.has(key)) {
+    if (action === currentAction && !completedActions.has(key) && advanceTimer.current === null) {
       setCompletedActions((prev) => new Set(prev).add(key));
-      setTimeout(() => {
+      const advance = () => {
         if (currentActionIndex < currentLesson.actions.length - 1) {
           setCurrentActionIndex((index) => index + 1);
         } else if (currentLessonIndex < LESSONS.length - 1) {
@@ -435,11 +449,18 @@ export default function OAuthOidcFlowSimulator() {
           setCurrentActionIndex(0);
         }
         setShowHint(false);
+      };
+      pendingAdvance.current = advance;
+      advanceTimer.current = setTimeout(() => {
+        advanceTimer.current = null;
+        pendingAdvance.current = null;
+        advance();
       }, 550);
     }
   };
 
   const resetLab = () => {
+    cancelPendingAdvance();
     setCurrentLessonIndex(0);
     setCurrentActionIndex(0);
     setCompletedActions(new Set());
@@ -508,6 +529,7 @@ export default function OAuthOidcFlowSimulator() {
                     key={lesson.id}
                     type="button"
                     onClick={() => {
+                      cancelPendingAdvance()?.();
                       setCurrentLessonIndex(lessonIndex);
                       setCurrentActionIndex(0);
                       setShowHint(false);

--- a/hooks/use-terminal-simulator.ts
+++ b/hooks/use-terminal-simulator.ts
@@ -314,12 +314,17 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
 
   const jumpToLesson = useCallback(
     (index: number) => {
+      // A step completed inside the delay is applied before leaving, so the
+      // lesson is not left with a completed but unadvanced command (which the
+      // repeat guard would then refuse to advance again).
+      const pending = advanceTimer.current !== null;
       cancelPendingAdvance();
+      if (pending) advance();
       setCurrentLessonIndex(index);
       setCurrentCommandIndex(0);
       setShowHint(false);
     },
-    [cancelPendingAdvance]
+    [advance, cancelPendingAdvance]
   );
 
   return {

--- a/hooks/use-terminal-simulator.ts
+++ b/hooks/use-terminal-simulator.ts
@@ -314,17 +314,17 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
 
   const jumpToLesson = useCallback(
     (index: number) => {
-      // A step completed inside the delay is applied before leaving, so the
-      // lesson is not left with a completed but unadvanced command (which the
-      // repeat guard would then refuse to advance again).
-      const pending = advanceTimer.current !== null;
       cancelPendingAdvance();
-      if (pending) advance();
+      // Resume at the first command not yet completed, so a step completed
+      // inside the advance delay (or on an earlier visit) is not presented
+      // again with the repeat guard refusing to advance past it.
+      const commands = lessons[index]?.commands ?? [];
+      const firstOpen = commands.findIndex((_, i) => !completedCommands.has(completionKey(index, i)));
       setCurrentLessonIndex(index);
-      setCurrentCommandIndex(0);
+      setCurrentCommandIndex(Math.max(0, firstOpen));
       setShowHint(false);
     },
-    [advance, cancelPendingAdvance]
+    [cancelPendingAdvance, completedCommands, lessons]
   );
 
   return {

--- a/hooks/use-terminal-simulator.ts
+++ b/hooks/use-terminal-simulator.ts
@@ -324,7 +324,7 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
       setCurrentCommandIndex(Math.max(0, firstOpen));
       setShowHint(false);
     },
-    [cancelPendingAdvance, completedCommands, lessons]
+    [cancelPendingAdvance, completedCommands, completionKey, lessons]
   );
 
   return {

--- a/hooks/use-terminal-simulator.ts
+++ b/hooks/use-terminal-simulator.ts
@@ -94,6 +94,20 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
   const [historyIndex, setHistoryIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const terminalRef = useRef<HTMLDivElement>(null);
+  // A delayed advance still pending. Cancelled on reset, lesson jump and
+  // unmount so a late callback never moves the new lesson state forward.
+  const advanceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const advanceToken = useRef(0);
+
+  const cancelPendingAdvance = useCallback(() => {
+    if (advanceTimer.current !== null) {
+      clearTimeout(advanceTimer.current);
+      advanceTimer.current = null;
+    }
+    advanceToken.current += 1;
+  }, []);
+
+  useEffect(() => cancelPendingAdvance, [cancelPendingAdvance]);
 
   const currentLesson = lessons[currentLessonIndex];
   const currentCommand = currentLesson?.commands[currentCommandIndex];
@@ -181,7 +195,16 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
       if (isExpected) {
         setCompletedCommands((prev) => new Set(prev).add(key));
         if (advanceDelayMs > 0) {
-          setTimeout(advance, advanceDelayMs);
+          // One pending advance at a time: a repeat of the same step inside
+          // the delay must not advance twice.
+          if (advanceTimer.current === null) {
+            const token = advanceToken.current;
+            advanceTimer.current = setTimeout(() => {
+              advanceTimer.current = null;
+              if (token !== advanceToken.current) return;
+              advance();
+            }, advanceDelayMs);
+          }
         } else {
           advance();
         }
@@ -277,6 +300,7 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
   );
 
   const resetProgress = useCallback(() => {
+    cancelPendingAdvance();
     setCurrentLessonIndex(0);
     setCurrentCommandIndex(0);
     setTerminalHistory([]);
@@ -286,13 +310,17 @@ export function useTerminalSimulator<C extends SimulatorLessonCommand>({
     setCommandHistory([]);
     setHistoryIndex(-1);
     onReset?.();
-  }, [onReset]);
+  }, [cancelPendingAdvance, onReset]);
 
-  const jumpToLesson = useCallback((index: number) => {
-    setCurrentLessonIndex(index);
-    setCurrentCommandIndex(0);
-    setShowHint(false);
-  }, []);
+  const jumpToLesson = useCallback(
+    (index: number) => {
+      cancelPendingAdvance();
+      setCurrentLessonIndex(index);
+      setCurrentCommandIndex(0);
+      setShowHint(false);
+    },
+    [cancelPendingAdvance]
+  );
 
   return {
     // progression


### PR DESCRIPTION
Simulators that use an advance delay (Kubernetes, Git, Postgres, MongoDB and SQL terminals go through `useTerminalSimulator` with `advanceDelayMs`) scheduled the next step with a bare `setTimeout`. Pressing Reset or selecting another lesson inside that window let the old callback fire with the previous lesson's closure and move the freshly reset or selected state forward a step.

The pending timer now lives in a ref. `resetProgress`, `jumpToLesson` and unmount clear it and bump a token, and a callback that still fires checks the token and does nothing. Only one advance is pending at a time, so repeating the same step inside the delay no longer advances twice.

There is no test harness for hooks in this repo (no jsdom or testing-library), so this was checked with tsc and eslint only.