### PR TITLE
Slim interview payloads, split the markdown display component, cache guide reads, explicit flashcard icons

### DIFF
--- a/app/flashcards/[id]/page.tsx
+++ b/app/flashcards/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ArrowLeft, BookOpen, Clock, Layers } from 'lucide-react'
 import Link from 'next/link'
-import * as Icons from 'lucide-react'
+import { FlashcardIcon } from '@/components/flashcard-icon'
 import { PageHero } from '@/components/page-hero'
 import { truncateMetaDescription } from '@/lib/meta-description'
 import { detailPageMetadata } from '@/lib/metadata-utils'
@@ -59,7 +59,6 @@ export default async function FlashcardPage({ params }: FlashcardPageProps) {
     notFound()
   }
 
-  const IconComponent = Icons[flashcardSet.icon as keyof typeof Icons] || BookOpen
   const difficultyColors = {
     beginner: 'bg-green-500',
     intermediate: 'bg-yellow-500',
@@ -88,7 +87,7 @@ export default async function FlashcardPage({ params }: FlashcardPageProps) {
                 background: `linear-gradient(135deg, ${flashcardSet.theme.gradientFrom}, ${flashcardSet.theme.gradientTo})`,
               }}
             >
-              <IconComponent className="w-8 h-8" />
+              <FlashcardIcon name={flashcardSet.icon} className="w-8 h-8" />
             </div>
             <div className="flex-1">
               <div className="flex items-center gap-2 mb-2">

--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -16,7 +16,7 @@ import {
   Trophy,
 } from 'lucide-react'
 import Link from 'next/link'
-import * as Icons from 'lucide-react'
+import { FlashcardIcon } from '@/components/flashcard-icon'
 
 export const metadata: Metadata = {
   title: 'DevOps Flashcards',
@@ -75,7 +75,6 @@ export default async function FlashcardsPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto">
             {flashcardSets.map((set) => {
-              const IconComponent = Icons[set.icon as keyof typeof Icons] || BookOpen
               const difficultyColors = {
                 beginner: 'bg-green-500',
                 intermediate: 'bg-yellow-500',
@@ -95,7 +94,7 @@ export default async function FlashcardsPage() {
                           background: `linear-gradient(135deg, ${set.theme.gradientFrom}, ${set.theme.gradientTo})`,
                         }}
                       >
-                        <IconComponent className="w-6 h-6" />
+                        <FlashcardIcon name={set.icon} className="w-6 h-6" />
                       </div>
                       <Badge
                         variant="secondary"

--- a/app/guides/[slug]/[part]/page.tsx
+++ b/app/guides/[slug]/[part]/page.tsx
@@ -1,7 +1,7 @@
 import { GuideContent } from '@/components/guide-content';
 import { GuideSidebar } from '@/components/guide-sidebar';
 import { SponsorSidebar } from '@/components/sponsor-sidebar';
-import { getGuideBySlug, getAllGuides, getGuidePart, getRelatedGuides, toGuideNav } from '@/lib/guides';
+import { getGuideBySlug, getAllGuides, getRelatedGuides, toGuideNav } from '@/lib/guides';
 import { notFound } from 'next/navigation';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { BreadcrumbSchema, TechArticleSchema } from '@/components/schema-markup';
@@ -96,13 +96,11 @@ export default async function GuidePartPage({
     notFound();
   }
 
-  const partContent = await getGuidePart(slug, partSlug);
+  const currentPart = guide.parts.find((p) => p.slug === partSlug);
 
-  if (!partContent) {
+  if (!currentPart) {
     notFound();
   }
-
-  const currentPart = guide.parts.find((p) => p.slug === partSlug);
 
   // Find the current part's index and determine previous and next parts
   const currentPartIndex = guide.parts.findIndex((p) => p.slug === partSlug);
@@ -180,7 +178,7 @@ export default async function GuidePartPage({
                 )}
 
                 <div className="dark:prose-invert max-w-none">
-                  <GuideContent content={partContent} />
+                  <GuideContent content={currentPart.content} />
                 </div>
 
                 {/* Navigation buttons */}

--- a/app/interview-questions/[tier]/page.tsx
+++ b/app/interview-questions/[tier]/page.tsx
@@ -5,7 +5,7 @@ import { QuestionBrowser } from '@/components/interview-questions/question-brows
 import { PageHero } from '@/components/page-hero';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import { Briefcase } from 'lucide-react';
-import type { ExperienceTier } from '@/lib/interview-utils';
+import { toQuestionSummary, type ExperienceTier } from '@/lib/interview-utils';
 
 const validTiers: ExperienceTier[] = ['junior', 'mid', 'senior'];
 
@@ -105,7 +105,10 @@ export default async function TierPage({ params }: PageProps) {
       />
 
       <div className="container mx-auto px-4 max-w-4xl py-10">
-        <QuestionBrowser questions={questions} lockedTier={tier as ExperienceTier} />
+        <QuestionBrowser
+          questions={questions.map(toQuestionSummary)}
+          lockedTier={tier as ExperienceTier}
+        />
       </div>
     </>
   );

--- a/app/interview-questions/page.tsx
+++ b/app/interview-questions/page.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/content/interview-questions';
 import { PageHero } from '@/components/page-hero';
 import { QuestionBrowser } from '@/components/interview-questions/question-browser';
-import type { ExperienceTier } from '@/lib/interview-utils';
+import { toQuestionSummary, type ExperienceTier } from '@/lib/interview-utils';
 
 export const metadata: Metadata = {
   title: 'DevOps Interview Questions | The DevOps Daily',
@@ -177,7 +177,7 @@ export default function InterviewQuestionsPage() {
               </Link>
             </div>
           </div>
-          <QuestionBrowser questions={interviewQuestions} />
+          <QuestionBrowser questions={interviewQuestions.map(toQuestionSummary)} />
         </section>
 
         {/* Browse by topic */}

--- a/app/interview-questions/topic/[topic]/page.tsx
+++ b/app/interview-questions/topic/[topic]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { QuestionBrowser } from '@/components/interview-questions/question-browser';
 import { PageHero } from '@/components/page-hero';
 import { BreadcrumbSchema } from '@/components/schema-markup';
+import { toQuestionSummary } from '@/lib/interview-utils';
 
 interface PageProps {
   params: Promise<{ topic: string }>;
@@ -84,7 +85,7 @@ export default async function TopicPage({ params }: PageProps) {
       />
 
       <div className="container mx-auto px-4 max-w-4xl py-10">
-        <QuestionBrowser questions={questions} lockedTopicSlug={topic.slug} />
+        <QuestionBrowser questions={questions.map(toQuestionSummary)} lockedTopicSlug={topic.slug} />
       </div>
     </>
   );

--- a/app/newsletters/[slug]/page.tsx
+++ b/app/newsletters/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { getAllNewsletters, getNewsletterBySlug } from '@/lib/newsletters';
 import { BreadcrumbSchema } from '@/components/schema-markup';
 import { CarbonAds } from '@/components/carbon-ads';
-import { MarkdownHtml } from '@/components/markdown-content';
+import { MarkdownHtml } from '@/components/markdown-html';
 import { Mail, ArrowLeft, Calendar } from 'lucide-react';
 import type { Metadata } from 'next';
 import { NewsletterForm } from '@/components/footer/newsletter-form';

--- a/components/advent-post-content.tsx
+++ b/components/advent-post-content.tsx
@@ -1,7 +1,8 @@
 import { parseMarkdown } from '@/lib/markdown';
 import { CodeBlockWrapper } from '@/components/code-block-wrapper';
 import { HeadingWrapper } from '@/components/heading-with-anchor';
-import { MarkdownContent, MarkdownHtml } from '@/components/markdown-content';
+import { MarkdownContent } from '@/components/markdown-content';
+import { MarkdownHtml } from '@/components/markdown-html';
 import { SolutionReveal } from '@/components/advent-solution-reveal';
 
 interface AdventPostContentProps {

--- a/components/flashcard-icon.tsx
+++ b/components/flashcard-icon.tsx
@@ -1,0 +1,64 @@
+import {
+  Activity,
+  BookOpen,
+  Boxes,
+  Cloud,
+  Container,
+  Database,
+  Flame,
+  FolderTree,
+  Gauge,
+  GitBranch,
+  GitFork,
+  GitMerge,
+  Globe,
+  Layers,
+  Network,
+  Package,
+  Server,
+  ShieldCheck,
+  Siren,
+  Snowflake,
+  Tags,
+  Target,
+  Terminal,
+  Vault,
+  Workflow,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react';
+
+// Icons referenced by the `icon` field in content/flashcards/*.json.
+// Add a name here when a new set uses one; unknown names fall back to BookOpen.
+const flashcardIcons: Record<string, LucideIcon> = {
+  Activity,
+  Boxes,
+  Cloud,
+  Container,
+  Database,
+  Flame,
+  FolderTree,
+  Gauge,
+  GitBranch,
+  GitFork,
+  GitMerge,
+  Globe,
+  Layers,
+  Network,
+  Package,
+  Server,
+  ShieldCheck,
+  Siren,
+  Snowflake,
+  Tags,
+  Target,
+  Terminal,
+  Vault,
+  Workflow,
+  Zap,
+};
+
+export function FlashcardIcon({ name, className }: { name: string; className?: string }) {
+  const Icon = flashcardIcons[name] ?? BookOpen;
+  return <Icon className={className} />;
+}

--- a/components/interview-questions/question-browser.tsx
+++ b/components/interview-questions/question-browser.tsx
@@ -8,13 +8,13 @@ import { tagToSlug } from '@/lib/tag-utils';
 import {
   getDifficultyColor,
   getInterviewProgress,
-  type InterviewQuestion,
+  type InterviewQuestionSummary,
   type ExperienceTier,
   type Difficulty,
 } from '@/lib/interview-utils';
 
 interface QuestionBrowserProps {
-  questions: InterviewQuestion[];
+  questions: InterviewQuestionSummary[];
   /** Fixed tier (tier landing pages) — hides the tier filter. */
   lockedTier?: ExperienceTier;
   /** Fixed topic slug (topic landing pages) — hides the topic filter. */

--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -1,31 +1,11 @@
-import type { Ref } from 'react';
 import { parseMarkdown } from '@/lib/markdown';
-import { cn } from '@/lib/utils';
+import { MarkdownHtml } from '@/components/markdown-html';
 import { CodeBlockWrapper } from '@/components/code-block-wrapper';
 import { ChartBlockWrapper } from '@/components/post-chart-blocks';
 import { TerminalBlockWrapper, TabsBlockWrapper } from '@/components/post-interactive-blocks';
 import { DiagramBlockWrapper } from '@/components/post-diagram-blocks';
 import { GithubEmbedWrapper } from '@/components/post-github-embed';
 import { HeadingWrapper } from '@/components/heading-with-anchor';
-
-const PROSE_CLASS =
-  'prose prose-lg dark:prose-invert max-w-none prose-headings:scroll-mt-24 prose-pre:bg-muted prose-pre:text-muted-foreground prose-code:text-primary prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:font-mono prose-code:text-sm prose-blockquote:border-l-primary prose-blockquote:bg-muted/10 prose-img:rounded-lg prose-img:shadow-lg prose-a:text-primary hover:prose-a:text-primary/80 prose-a:transition-colors prose-strong:text-foreground prose-ul:list-disc prose-ol:list-decimal prose-table:rounded-lg prose-table:shadow prose-th:bg-muted prose-td:border-border';
-
-interface MarkdownHtmlProps {
-  html: string;
-  className?: string;
-  htmlRef?: Ref<HTMLDivElement>;
-}
-
-export function MarkdownHtml({ html, className, htmlRef }: MarkdownHtmlProps) {
-  return (
-    <div
-      ref={htmlRef}
-      className={cn(PROSE_CLASS, className)}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
 
 interface MarkdownContentProps {
   content: string;

--- a/components/markdown-html.tsx
+++ b/components/markdown-html.tsx
@@ -1,0 +1,22 @@
+import type { Ref } from 'react';
+import { cn } from '@/lib/utils';
+
+export const PROSE_CLASS =
+  'prose prose-lg dark:prose-invert max-w-none prose-headings:scroll-mt-24 prose-pre:bg-muted prose-pre:text-muted-foreground prose-code:text-primary prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:font-mono prose-code:text-sm prose-blockquote:border-l-primary prose-blockquote:bg-muted/10 prose-img:rounded-lg prose-img:shadow-lg prose-a:text-primary hover:prose-a:text-primary/80 prose-a:transition-colors prose-strong:text-foreground prose-ul:list-disc prose-ol:list-decimal prose-table:rounded-lg prose-table:shadow prose-th:bg-muted prose-td:border-border';
+
+interface MarkdownHtmlProps {
+  html: string;
+  className?: string;
+  htmlRef?: Ref<HTMLDivElement>;
+}
+
+/** Renders already-parsed markdown HTML. Safe to import from client components. */
+export function MarkdownHtml({ html, className, htmlRef }: MarkdownHtmlProps) {
+  return (
+    <div
+      ref={htmlRef}
+      className={cn(PROSE_CLASS, className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/components/news-digest-content.tsx
+++ b/components/news-digest-content.tsx
@@ -2,7 +2,7 @@
 
 import { CodeBlockWrapper } from '@/components/code-block-wrapper';
 import { HeadingWrapper } from '@/components/heading-with-anchor';
-import { MarkdownHtml } from '@/components/markdown-content';
+import { MarkdownHtml } from '@/components/markdown-html';
 import { useEffect, useRef } from 'react';
 
 interface NewsDigestContentProps {

--- a/lib/guides.ts
+++ b/lib/guides.ts
@@ -1,7 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { getGuideImagePath } from './image-utils';
-import { createCachedLoader, isFileNotFound, readMarkdownFile } from './content-loader';
+import {
+  CONTENT_CACHE_DURATION,
+  createCachedLoader,
+  isFileNotFound,
+  readMarkdownFile,
+} from './content-loader';
 import { rankRelatedByScore } from './related-content';
 
 const GUIDES_DIR = path.join(process.cwd(), 'content', 'guides');
@@ -84,7 +89,7 @@ export async function getAllGuides(): Promise<Guide[]> {
   return loadGuides();
 }
 
-export async function getGuideBySlug(slug: string): Promise<Guide | null> {
+async function loadGuide(slug: string): Promise<Guide | null> {
   const guideDir = path.join(GUIDES_DIR, slug);
   try {
     const guide = await readMarkdownFile<Guide, Partial<Guide>>(
@@ -137,19 +142,22 @@ export async function getGuideBySlug(slug: string): Promise<Guide | null> {
   }
 }
 
-export async function getGuidePart(guideSlug: string, partSlug: string): Promise<string | null> {
-  const guideDir = path.join(GUIDES_DIR, guideSlug);
-  try {
-    return await readMarkdownFile<string>(
-      path.join(guideDir, `${partSlug}.md`),
-      (_, content) => content
-    );
-  } catch (error) {
-    if (isFileNotFound(error)) {
-      return null;
-    }
-    throw error;
+// Per-slug promise cache so metadata + page renders (and getAllGuides) share one read.
+const guideCache = new Map<string, { promise: Promise<Guide | null>; loadedAt: number }>();
+
+export function getGuideBySlug(slug: string): Promise<Guide | null> {
+  const now = Date.now();
+  const cached = guideCache.get(slug);
+  if (cached && now - cached.loadedAt < CONTENT_CACHE_DURATION) {
+    return cached.promise;
   }
+
+  const promise = loadGuide(slug).catch((error) => {
+    guideCache.delete(slug);
+    throw error;
+  });
+  guideCache.set(slug, { promise, loadedAt: now });
+  return promise;
 }
 
 export async function getGuidesByCategory(categorySlug: string) {

--- a/lib/interview-utils.ts
+++ b/lib/interview-utils.ts
@@ -33,6 +33,32 @@ export interface InterviewQuestion {
   }>;
 }
 
+/** The fields the browsing pages need. Answers and examples stay on detail/practice routes. */
+export type InterviewQuestionSummary = Pick<
+  InterviewQuestion,
+  'id' | 'slug' | 'title' | 'question' | 'category' | 'difficulty' | 'tier' | 'tags'
+>;
+
+export const toQuestionSummary = ({
+  id,
+  slug,
+  title,
+  question,
+  category,
+  difficulty,
+  tier,
+  tags,
+}: InterviewQuestion): InterviewQuestionSummary => ({
+  id,
+  slug,
+  title,
+  question,
+  category,
+  difficulty,
+  tier,
+  tags,
+});
+
 export interface InterviewQuestionProgress {
   [questionId: string]: {
     reviewed: boolean;


### PR DESCRIPTION
The interview index, tier and topic pages now pass only the eight fields QuestionBrowser reads (id, slug, title, question, category, difficulty, tier, tags). Measured on the index page with JSON.stringify of the props: 413,076 bytes before and 43,081 after; gzip 135,850 bytes before and 10,548 after. Practice and detail routes keep the full question data.

MarkdownHtml moves to components/markdown-html.tsx, which has no parser imports, so the client news digest no longer pulls marked and highlight.js into its module graph. server-only is not a dependency here, so lib/markdown.ts is unchanged.

getGuideBySlug now caches one promise per slug (honouring CONTENT_CACHE_DURATION like getAllGuides), and the guide part page renders the cached part content instead of reading the file a second time. The flashcard pages use an explicit map of the 25 lucide icons named in content/flashcards, with BookOpen as the fallback, instead of importing the whole namespace.

tsc adds no new errors against main (four pre-existing flashcard IconComponent errors go away); eslint on the changed files matches main; the markdown, data-integrity, tags, SEO and news vitest files pass.