### PR TITLE
CI: restore the Next build cache and cancel superseded runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -26,6 +30,14 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '**/*.mjs', '**/*.cjs', '!**/node_modules/**', '!.next/**') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
build.yml now restores and saves .next/cache through actions/cache. The key is the runner OS plus the pnpm-lock.yaml hash plus a hash of the JS/TS sources, with a restore-keys prefix so a changed source tree still gets the newest cache for the same lockfile. The step runs before pnpm install so the source hash never walks node_modules.

Both build.yml and tests.yml get a concurrency group scoped to the pull request number (or the ref on main pushes) with cancel-in-progress, so a new push stops the run it replaces.

The steps that validate the build and tests are unchanged. Both files parse, and the step order is the same apart from the added cache step. Warm-build timing can only be measured once a couple of runs have populated the cache.