### PR TITLE
Exclude footer bar, cookie banner and sponsor CTA from search snippets

### DIFF
--- a/components/cookie-banner.tsx
+++ b/components/cookie-banner.tsx
@@ -34,6 +34,7 @@ export function CookieBanner() {
 
   return (
     <div
+      data-nosnippet
       className={`
         fixed bottom-4 left-4 right-4 md:right-auto md:left-4 md:max-w-sm z-50 
         bg-linear-to-br from-card/95 to-background/95 backdrop-blur-lg 

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -53,7 +53,7 @@ export function Footer() {
         </div>
 
         {/* Footer bottom — terminal-style bar */}
-        <div className="mt-12 pt-6 border-t border-border/50">
+        <div className="mt-12 pt-6 border-t border-border/50" data-nosnippet>
           <div className="flex flex-col md:flex-row items-center justify-between gap-3 text-xs font-mono text-muted-foreground">
             <p className="tabular-nums">
               <span className="text-green-500/70">$</span> echo &quot;

--- a/components/inline-sponsors.tsx
+++ b/components/inline-sponsors.tsx
@@ -19,7 +19,7 @@ export function InlineSponsors({
 }: InlineSponsorsProps) {
   if (variant === 'banner') {
     return (
-      <div className={cn('my-12', className)}>
+      <div className={cn('my-12', className)} data-nosnippet>
         <div className="relative rounded-2xl border border-border/50 overflow-hidden bg-linear-to-br from-primary/5 via-background to-primary/5">
           {/* Decorative elements */}
           <div className="absolute inset-0 opacity-30">


### PR DESCRIPTION
Brand-name searches were getting snippets quoted from the footer terminal, the cookie notice and the sponsor CTA, because those are the passages that mention the site name. Adds data-nosnippet to the three boilerplate blocks so Google draws snippets from the article instead. No visual change.